### PR TITLE
Fix Lexica Botania typos, changed some sentences

### DIFF
--- a/resources/assets/botania/lang/en_US.lang
+++ b/resources/assets/botania/lang/en_US.lang
@@ -283,27 +283,27 @@ botania.page.flowers5=Grinding Petals into Dye.
 botania.entry.apothecary=Petal Apothecary
 botania.page.apothecary0=In order for a botanist to create plantlife that can do it's bidding, one would need special means of infusing plants with mystical energy.<br>Luckilly, the &1Petal Apothecary&0 does just that.
 botania.page.apothecary1=The &1Petal Apothecary&0.
-botania.page.apothecary2=This block, when placed in the world and given some water (by use of a &1Water Bucket&0), will accept any &1Mystical Petals&0 thrown at it, releasing their energies.<br>Once one has set the correct petals in, throwing some &1Seeds&0 in will finalize the proccess.<br>Tossing in the full bucket will also fill the recepient with water.
+botania.page.apothecary2=This block, when placed in the world and given some water (by use of a &1Water Bucket&0), will accept any &1Mystical Petals&0 thrown at it, releasing their energies.<br>Once one has set the correct petals in, throwing some &1Seeds&0 in will finalize the proccess.<br>Tossing in the full bucket will also fill the recipient with water.
 botania.page.apothecary3=Quite a few plants can be made using this method, for more information, read on the &4Functional Flora&0 and &4Generation Flora&0 sections of this Lexicon.
 botania.page.apothecary4=Crafting the &1Petal Apothecary&0.
 
 # -- PURE DAISY
 botania.entry.pureDaisy=Pure Daisy
-botania.page.pureDaisy0=The &1Pure Daisy&0 is not only the most basic, but also the most important flower a botanist can have.<br>This flower will purify any adjacent &1Wood&0 and &1Stone&0 blocks, as seen in the next page, into their purified counterparts, &1Livingwood&0 and &1Livingrock&0, which can be used for crafting.  
+botania.page.pureDaisy0=The &1Pure Daisy&0 is not only the most basic, but also the most important flower a botanist can have.<br>This flower will purify any adjacent &1Wood&0 and &1Stone&0 blocks, as seen on the next page, into their purified counterparts, &1Livingwood&0 and &1Livingrock&0, which can be used for crafting.  
 botania.page.pureDaisy1=Just give it &4a minute&0 or so...
 botania.page.pureDaisy2=White is bright and pure
 
 # -- WAND OF THE FOREST
 botania.entry.wand=Wand of the Forest
-botania.page.wand0=The general multi use tool for a botanist is the &1Wand of the Forest&0.<br>This wand, made by, effectively, strapping a pair of &1Mystical Petals&0 of any color to a few &1Sticks&0 is required for a good amount of tasks.
-botania.page.wand1=The petals use determine the colors.
+botania.page.wand0=The general multi-use tool for a botanist is the &1Wand of the Forest&0.<br>This wand, made by, effectively, strapping a pair of &1Mystical Petals&0 of any color to a few &1Sticks&0, is required for a good amount of tasks.
+botania.page.wand1=The petals used determine the colors of the wand.
 
 # -- RUNIC ALTAR
 botania.entry.runeAltar=Runic Altar
 botania.page.runeAltar0=&1Runes&0 are extremely important components of complex magical devices or flora.<br>In order to create these, one would require a &1Runic Altar&0.<br>To utilize this &1Runic Altar&0, start by placing, via right click, the components to the rune you want to create.
-botania.page.runeAltar1=Proceed by linking a &1Mana Spreader&0 to the altar, and right click it with a &1Wand of the Forest&0.<br>It should be apparent when the altar has received enough &4Mana&0, when that happens, just drop a piece of &1Livingrock&0 on top of it and use the wand on it again to collect your rune.
+botania.page.runeAltar1=Proceed by linking a &1Mana Spreader&0 to the altar, and right click it with a &1Wand of the Forest&0.<br>It should be apparent when the altar has received enough &4Mana&0. When that happens, just drop a piece of &1Livingrock&0 on top of it and use the wand on it again to collect your rune.
 botania.page.runeAltar2=Crafting the &1Runic Altar&0.
-botania.page.runeAltar3=A total of 16 &1Runes&0 exist.<br>The most basic and elementary runes are named after the &4Four Elements&0. The interemediate runes are named after the &4Four Seasons&0, and the most advanced runes are named after the &4Seven Deadly Sins&0. A separate &1Rune of Mana&0 also exists.
+botania.page.runeAltar3=A total of 16 &1Runes&0 exist.<br>The most basic and elementary runes are named after the &4Four Elements&0. The intermediate runes are named after the &4Four Seasons&0, and the most advanced runes are named after the &4Seven Deadly Sins&0. A separate &1Rune of Mana&0 also exists.
 botania.page.runeAltar4=The &1Rune of Water&0.
 botania.page.runeAltar5=The &1Rune of Earth&0.
 botania.page.runeAltar6=The &1Rune of Air&0.
@@ -324,19 +324,19 @@ botania.page.runeAltar19=The &1Rune of Pride&0.
 # - MANA
 # -- INTRODUCTION TO MANA
 botania.entry.mIntro=An Introduction to Mana
-botania.page.mIntro0=&4Mana&0 is an ethereal substance, in layman's terms, it's a form of &4mystical energy&0. It's sensorial existance is inconstant, and it's color depends on the environment it's put on.<br>Mastering &4Mana&0 is one of the most important skills a botanist needs to master.
-botania.page.mIntro1=In order to create &4Mana&0, one would require a set of &4Generating Flowers&0 (read the respective section). This &4Mana&0 can be dispersed utilizing &1Mana Spreaders&0 and stored in &1Mana Pools&0. &4Mana&0 can be used for a myriad of different things, for starters, it can be used for &4Functional Flowers&0 (read the respective section).
+botania.page.mIntro0=&4Mana&0 is an ethereal substance. In layman's terms, it is a form of &4mystical energy&0. Its sensorial existance is inconstant, and its color depends on the environment its put in.<br>Mastering &4Mana&0 is one of the most important skills a botanist needs to master.
+botania.page.mIntro1=In order to create &4Mana&0, one would require a set of &4Generating Flowers&0 (read the respective section). This &4Mana&0 can be dispersed by utilizing &1Mana Spreaders&0 and stored in &1Mana Pools&0. &4Mana&0 can be used for a myriad of different things. For starters, it can be used for &4Functional Flowers&0 (read the respective section).
 botania.page.mIntro2=To get started with mastering the art of &4Mana&0, one would start by learning how to use &1Dayblooms&0, &1Mana Spreaders&0 and &1Mana Pools&0.<br>These form a basic infrastructure for mana, which can be used for all sorts of purposes. Have a read at the &4Functional Flora&0 and &4Magical Apparatus&0 sections of this Lexicon. 
 
 # -- MANA SPREADER
 botania.entry.spreader=Mana Spreader
-botania.page.spreader0=The &1Mana Spreader&0 is the most inportant component in manipulating &4Mana&0.<br>This is the block that allows &4Mana&0 to travel from point A to point B. When this block is placed on the ground, it'll face one of 6 basic directions. By shift-right clicking it with a &1Wand of the Forest&0, one can orient it to the opposite of where it was clicked. 
+botania.page.spreader0=The &1Mana Spreader&0 is the most important component in manipulating &4Mana&0.<br>This is the block that allows &4Mana&0 to travel from point A to point B. When this block is placed on the ground, it'll face one of 6 basic directions. By shift-right clicking it with a &1Wand of the Forest&0, one can orient it to the opposite of where it was clicked. 
 botania.page.spreader1=Holding a &1Wand of the Forest&0
 botania.page.spreader2=The &1Mana Spreader&0 has a small internal buffer of &4Mana&0, which will get filled by nearby &4Generating Flowers&0. This buffer can be viewed by looking at the &1Spreader&0 with a &1Wand of the Forest&0, as demonstrated in the last page.<br>Note that the block needs to be right clicked with a wand to get accurate and adequate values.  
-botania.page.spreader3=Holding a &1Wand of the Forest&0 displays a beam which shows where the spreader is pointing at. Hovering over it shows the target. The sparkle that's always shown is the point when &4mana loss&0 starts to happen.<br>If the target of the spreader is a block that can contain mana, and isn't full, the spreader will fire a &4Mana Burst&0, which will travel to the target, and pass the mana along to it.
-botania.page.spreader4=The spreader only fires one burst at once, it'll only fire another one when the last one hits the target.<br>Furthermore, the bursts also, after a small amount of time start suffering &4mana loss&0, this can be seen in the beam, as when this happens it becomes a lot thinner. There is also a small amount of &4mana loss&0 when a beam enters a spreader.
+botania.page.spreader3=Holding a &1Wand of the Forest&0 displays a beam which shows where the spreader is pointing at. Hovering over it shows the target. The sparkle that's always shown is the point when &4Mana loss&0 starts to happen.<br>If the target of the spreader is a block that can contain &4Mana&0, and isn't full, the spreader will fire a &4Mana Burst&0, which will travel to the target, and pass the &4Mana&0 along to it.
+botania.page.spreader4=The spreader only fires one burst at once, it'll only fire another one when the last one hits the target.<br>Furthermore, the bursts also start suffering &4mana loss&0 after a small amount of time. This can be seen in the beam, which becomes a lot thinner when this happens. There is also a small amount of &4mana loss&0 when a beam enters a spreader.
 botania.page.spreader5=Crafting the &1Mana Spreader&0
-botania.page.spreader6=In order to upgrade the potencial of the spreader, once can apply &1Mana Lenses&0. The very basic mana lens does absolutely nothing.<br>Lenses can be &4dyed&0 all the 16 colors of the spectrum, or combined with a &1Mana Pearl&0 to create a &1Rainbow Lens&0, these will change the color of the burst.
+botania.page.spreader6=In order to upgrade the potential of the spreader, one can apply &1Mana Lenses&0. The very basic mana lens does absolutely nothing.<br>Lenses can be &4dyed&0 all the 16 colors of the spectrum, or combined with a &1Mana Pearl&0 to create a &1Rainbow Lens&0. These will change the color of the burst.
 botania.page.spreader7=The basic lens, it doesn't do anything...
 botania.page.spreader8=&4Dying&0 lenses!
 botania.page.spreader9=&1Rainbow Lens&0 all the way
@@ -345,7 +345,7 @@ botania.page.spreader9=&1Rainbow Lens&0 all the way
 botania.entry.pool=Mana Pool
 botania.page.pool0=The &1Mana Pool&0 is, simply put, a storage of &4Mana&0.<br>Mana can be inserted into it by usage of a &1Mana Spreader&0, and any adjacent &1Mana Spreaders&0 will pull mana from it to increase their internal buffer automatically.<br>Any &4Functional Flowers&0 require a nearby &1Mana Pool&0 to draw power from.
 botania.page.pool1=Making the &1Mana Pool&0.
-botania.page.pool2=Tossing in some resources into the Mana Pool will cause them to get infused with &4Mana&0, turning them into more powerful forms.<br>A few examples are &1Iron Ingots or Mystical Petals&0.<br>&4Mana&0 reading for this block functions like the &1Mana Spreader&0. A &1Redstone Comparator&0 can also output a signal based on the contents.
+botania.page.pool2=Tossing in some resources into the Mana Pool will cause them to get infused with &4Mana&0, turning them into more powerful forms.<br>A few examples are &1Iron Ingots&0 or &1Mystical Petals&0.<br>&4Mana&0 reading for this block functions like the &1Mana Spreader&0. A &1Redstone Comparator&0 can also output a signal based on the contents.
 botania.page.pool3=Infusing &1Manasteel&0
 botania.page.pool4=Infusing &1Mana Pearls&0
 botania.page.pool5=Infusing &1Mana Diamonds&0
@@ -353,7 +353,7 @@ botania.page.pool6=Infusing &1Mana Petals&0
 
 # -- MANA DISTRIBUTOR
 botania.entry.distributor=Mana Distributor
-botania.page.distributor0=Any botanist will eventually reach a point where a single &1Mana Pool&0 setup is not enough.<br>The &1Mana Distributor&0 will fix all those issues. By placing it adjacently to a few &1Mana Pools&0 on it's sides, when it receives &4Mana&0 through &4Mana Bursts&0 it'll equally spread it to the adjacent pools. 
+botania.page.distributor0=Any botanist will eventually reach a point where a single &1Mana Pool&0 setup is not enough.<br>The &1Mana Distributor&0 will fix all those issues. By placing it adjacently to a few &1Mana Pools&0 on its sides, when it receives &4Mana&0 through &4Mana Bursts&0 it'll equally spread it to the adjacent pools. 
 botania.page.distributor1=Crafting the distributor
 
 # -- MANA VOID
@@ -378,7 +378,7 @@ botania.page.lensResistance1=Crafting the lens
 
 # -- MANA LENS: EFFICIENCY
 botania.entry.lensEfficiency=Mana Lens: Efficiency
-botania.page.lensEfficiency0=The &1Efficiency Lens&0 will decrease the amount of time it takes for the &4Mana Burst&0 to start losing it's &4Mana&0, but when that happens, it does so at a lot slower rate.
+botania.page.lensEfficiency0=The &1Efficiency Lens&0 will decrease the amount of time it takes for the &4Mana Burst&0 to start losing its &4Mana&0, but when that happens, it does so at a lot slower rate.
 botania.page.lensEfficiency1=Crafting the lens 
 
 # -- MANA LENS: BOUNCE
@@ -388,17 +388,17 @@ botania.page.lensBounce1=Crafting the lens
 
 # -- MANA LENS: GRAVITY
 botania.entry.lensGravity=Mana Lens: Gravity
-botania.page.lensGravity0=The &1Gravity Lens&0 makes the &4Mana Burst&0 be attracted by the world's gravitational pull, thus movimenting in an arc. For compensation, it also slightly increases the time before &4Mana&0 loss starts to happen.
+botania.page.lensGravity0=The &1Gravity Lens&0 makes the &4Mana Burst&0 be attracted by the world's gravitational pull, thus moving in an arc. As compensation, it also slightly increases the time before &4Mana&0 loss starts to happen.
 botania.page.lensGravity1=Crafting the lens 
 
 # -- MANA LENS: BORE
 botania.entry.lensBore=Mana Lens: Bore
-botania.page.lensBore0=The &1Bore Lens&0 charges the &4Mana Burst&0 with the ability to break any blocks it comes into contact, draining it's own mana to do so. 
+botania.page.lensBore0=The &1Bore Lens&0 charges the &4Mana Burst&0 with the ability to break any blocks it comes into contact with, draining its own mana to do so. 
 botania.page.lensBore1=Crafting the lens 
 
 # -- MANA LENS: DAMAGING
 botania.entry.lensDamaging=Mana Lens: Damaging
-botania.page.lensDamaging0=The &1Damaging Lens&0 charges the &4Mana Burst&0 with the power to damage any living beings it comes across, draining it's own mana to do so.
+botania.page.lensDamaging0=The &1Damaging Lens&0 charges the &4Mana Burst&0 with the power to damage any living beings it comes across, draining its own mana to do so.
 botania.page.lensDamaging1=Crafting the lens
 
 # -- MANA LENS: PHANTOM
@@ -408,12 +408,12 @@ botania.page.lensPhantom1=Crafting the lens
 
 # -- MANA LENS: MAGNETIZING
 botania.entry.lensMagnet=Mana Lens: Magnetizing
-botania.page.lensMagnet0=The &1Magnetizing Lens&0, as it's name states, allows the &4Mana Burst&0 to magnetize, or home in, on any nearby blocks that can receive &4Mana&0. Doing so slightly decreases the speed of the burst.
+botania.page.lensMagnet0=The &1Magnetizing Lens&0, as its name states, allows the &4Mana Burst&0 to magnetize, or home in, on any nearby blocks that can receive &4Mana&0. Doing so slightly decreases the speed of the burst.
 botania.page.lensMagnet1=Crafting the lens
 
 # -- MANA LENS: ENTROPIC
 botania.entry.lensExplosive=Mana Lens: Entropic
-botania.page.lensExplosive0=The &1Entropic Lens&0 imbues the &4Mana Burst&0 with entropy, causing it to release it's energy in the form of an explosion, case it collides against something that can't receive &4Mana&0.
+botania.page.lensExplosive0=The &1Entropic Lens&0 imbues the &4Mana Burst&0 with entropy, causing it to release its energy in the form of an explosion when it collides against something that can't receive &4Mana&0.
 botania.page.lensExplosive1=Crafting the lens
 
 # -- PORTABLE MANA TRANSPORT
@@ -429,7 +429,7 @@ botania.page.manaDetector1=Crafting the detector
 
 # -- COMPOSITE MANA LENSES
 botania.entry.compositeLens=Composite Mana Lenses
-botania.page.compositeLens0=Having a single &1Mana Lens&0 in a spreader just isn't enough sometimes. By combining two lenses with a &1Slimeball&0 in a crafting table, it's possible to unite them into one, and having the effects of both.<br>The first lens used determines the visuals(texture and color). It's to note that some combinations will not work, and that two lenses of the same type can't be stacked.
+botania.page.compositeLens0=Having a single &1Mana Lens&0 in a spreader just isn't enough sometimes. By combining two lenses with a &1Slimeball&0 in a crafting table, it's possible to unite them into one, and keep the effects of both.<br>The first lens used determines the visuals (texture and color). It's to note that some combinations will not work, and that two lenses of the same type can't be stacked.
 
 # - FUNCTIONAL FLOWERS
 # -- AN INTRODUCTION TO FUNCTION


### PR DESCRIPTION
Fully did "Basics" and "Mana Manipulation".

I saw that sometimes you spell Mana with a capital m and sometimes not, and sometimes it is displayed with a red font color and sometimes not.  I did not consolidate that.
