### PR TITLE
Added a deobf task to the build script 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,4 +46,14 @@ processResources
     from(sourceSets.main.resources.srcDirs) {
         exclude 'mcmod.info'
     }
+	
+	task deobfJar(type: Jar) {
+		from(sourceSets.main.output)
+			classifier = 'deobf'	
+			
+	}
+	
+	artifacts {
+		archives deobfJar		
+	}   
 }


### PR DESCRIPTION
Made this so developers can add Botania to their workspace without having to clone it.

On a side note why do you use an ANT build script when gradle could do it just as easy?
