### PR TITLE
Removed particles when game settings is set to minimal

### DIFF
--- a/MODSRC/vazkii/botania/client/fx/FXSparkle.java
+++ b/MODSRC/vazkii/botania/client/fx/FXSparkle.java
@@ -25,9 +25,11 @@ import vazkii.botania.common.core.helper.ObfuscationHelper;
 
 public class FXSparkle extends EntityFX {
 
-	public static final ResourceLocation particles = new ResourceLocation(LibResources.MISC_PARTICLES);
+	public static final ResourceLocation particles = new ResourceLocation(
+			LibResources.MISC_PARTICLES);
 
-	public FXSparkle(World world, double x, double y, double z, float size, float red, float green, float blue, int m) {
+	public FXSparkle(World world, double x, double y, double z, float size,
+			float red, float green, float blue, int m) {
 		super(world, x, y, z, 0.0D, 0.0D, 0.0D);
 
 		particleRed = red;
@@ -46,10 +48,11 @@ public class FXSparkle extends EntityFX {
 	}
 
 	@Override
-	public void renderParticle(Tessellator tessellator, float f, float f1, float f2, float f3, float f4, float f5) {
-		if(Minecraft.getMinecraft().gameSettings.particleSetting ==2)
-            return;
-        tessellator.draw();
+	public void renderParticle(Tessellator tessellator, float f, float f1,
+			float f2, float f3, float f4, float f5) {
+		if (Minecraft.getMinecraft().gameSettings.particleSetting == 2)
+			return;
+		tessellator.draw();
 		GL11.glPushMatrix();
 
 		GL11.glDepthMask(false);
@@ -59,27 +62,34 @@ public class FXSparkle extends EntityFX {
 		Minecraft.getMinecraft().renderEngine.bindTexture(particles);
 
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.75F);
-		int part = particle + particleAge/multiplier;
+		int part = particle + particleAge / multiplier;
 
 		float var8 = part % 8 / 8.0F;
-		float var9 = var8 + 0.0624375F*2;
+		float var9 = var8 + 0.0624375F * 2;
 		float var10 = part / 8 / 8.0F;
-		float var11 = var10 + 0.0624375F*2;
+		float var11 = var10 + 0.0624375F * 2;
 		float var12 = 0.1F * particleScale;
-		if (shrink) var12 *= (particleMaxAge-particleAge+1)/(float)particleMaxAge;
-		float var13 = (float)(prevPosX + (posX - prevPosX) * f - interpPosX);
-		float var14 = (float)(prevPosY + (posY - prevPosY) * f - interpPosY);
-		float var15 = (float)(prevPosZ + (posZ - prevPosZ) * f - interpPosZ);
+		if (shrink)
+			var12 *= (particleMaxAge - particleAge + 1)
+					/ (float) particleMaxAge;
+		float var13 = (float) (prevPosX + (posX - prevPosX) * f - interpPosX);
+		float var14 = (float) (prevPosY + (posY - prevPosY) * f - interpPosY);
+		float var15 = (float) (prevPosZ + (posZ - prevPosZ) * f - interpPosZ);
 		float var16 = 1.0F;
 
 		tessellator.startDrawingQuads();
 		tessellator.setBrightness(0x0000f0);
 
-		tessellator.setColorRGBA_F(particleRed * var16, particleGreen * var16, particleBlue * var16, 1);
-		tessellator.addVertexWithUV(var13 - f1 * var12 - f4 * var12, var14 - f2 * var12, var15 - f3 * var12 - f5 * var12, var9, var11);
-		tessellator.addVertexWithUV(var13 - f1 * var12 + f4 * var12, var14 + f2 * var12, var15 - f3 * var12 + f5 * var12, var9, var10);
-		tessellator.addVertexWithUV(var13 + f1 * var12 + f4 * var12, var14 + f2 * var12, var15 + f3 * var12 + f5 * var12, var8, var10);
-		tessellator.addVertexWithUV(var13 + f1 * var12 - f4 * var12, var14 - f2 * var12, var15 + f3 * var12 - f5 * var12, var8, var11);
+		tessellator.setColorRGBA_F(particleRed * var16, particleGreen * var16,
+				particleBlue * var16, 1);
+		tessellator.addVertexWithUV(var13 - f1 * var12 - f4 * var12, var14 - f2
+				* var12, var15 - f3 * var12 - f5 * var12, var9, var11);
+		tessellator.addVertexWithUV(var13 - f1 * var12 + f4 * var12, var14 + f2
+				* var12, var15 - f3 * var12 + f5 * var12, var9, var10);
+		tessellator.addVertexWithUV(var13 + f1 * var12 + f4 * var12, var14 + f2
+				* var12, var15 + f3 * var12 + f5 * var12, var8, var10);
+		tessellator.addVertexWithUV(var13 + f1 * var12 - f4 * var12, var14 - f2
+				* var12, var15 + f3 * var12 - f5 * var12, var8, var11);
 
 		tessellator.draw();
 
@@ -87,7 +97,8 @@ public class FXSparkle extends EntityFX {
 		GL11.glDepthMask(true);
 
 		GL11.glPopMatrix();
-		Minecraft.getMinecraft().renderEngine.bindTexture(ObfuscationHelper.getParticleTexture());
+		Minecraft.getMinecraft().renderEngine.bindTexture(ObfuscationHelper
+				.getParticleTexture());
 		tessellator.startDrawingQuads();
 	}
 
@@ -103,7 +114,8 @@ public class FXSparkle extends EntityFX {
 		motionY -= 0.04D * particleGravity;
 
 		if (!noClip && !fake)
-			pushOutOfBlocks(posX, (boundingBox.minY + boundingBox.maxY) / 2.0D, posZ);
+			pushOutOfBlocks(posX, (boundingBox.minY + boundingBox.maxY) / 2.0D,
+					posZ);
 
 		posX += motionX;
 		posY += motionY;
@@ -120,7 +132,7 @@ public class FXSparkle extends EntityFX {
 			}
 		}
 
-		if(fake && particleAge > 1)
+		if (fake && particleAge > 1)
 			setDead();
 	}
 
@@ -137,12 +149,18 @@ public class FXSparkle extends EntityFX {
 		double var14 = par5 - var9;
 
 		if (!worldObj.isAirBlock(var7, var8, var9)) {
-			boolean var16 = !worldObj.isBlockNormalCubeDefault(var7 - 1, var8, var9, false);
-			boolean var17 = !worldObj.isBlockNormalCubeDefault(var7 + 1, var8, var9, false);
-			boolean var18 = !worldObj.isBlockNormalCubeDefault(var7, var8 - 1, var9, false);
-			boolean var19 = !worldObj.isBlockNormalCubeDefault(var7, var8 + 1, var9, false);
-			boolean var20 = !worldObj.isBlockNormalCubeDefault(var7, var8, var9 - 1, false);
-			boolean var21 = !worldObj.isBlockNormalCubeDefault(var7, var8, var9 + 1, false);
+			boolean var16 = !worldObj.isBlockNormalCubeDefault(var7 - 1, var8,
+					var9, false);
+			boolean var17 = !worldObj.isBlockNormalCubeDefault(var7 + 1, var8,
+					var9, false);
+			boolean var18 = !worldObj.isBlockNormalCubeDefault(var7, var8 - 1,
+					var9, false);
+			boolean var19 = !worldObj.isBlockNormalCubeDefault(var7, var8 + 1,
+					var9, false);
+			boolean var20 = !worldObj.isBlockNormalCubeDefault(var7, var8,
+					var9 - 1, false);
+			boolean var21 = !worldObj.isBlockNormalCubeDefault(var7, var8,
+					var9 + 1, false);
 			byte var22 = -1;
 			double var23 = 9999.0D;
 
@@ -181,36 +199,37 @@ public class FXSparkle extends EntityFX {
 
 			if (var22 == 0) {
 				motionX = -var25;
-				motionY=motionZ=var26;
+				motionY = motionZ = var26;
 			}
 
 			if (var22 == 1) {
 				motionX = var25;
-				motionY=motionZ=var26;
+				motionY = motionZ = var26;
 			}
 
 			if (var22 == 2) {
 				motionY = -var25;
-				motionX=motionZ=var26;
+				motionX = motionZ = var26;
 			}
 
 			if (var22 == 3) {
 				motionY = var25;
-				motionX=motionZ=var26;
+				motionX = motionZ = var26;
 			}
 
 			if (var22 == 4) {
 				motionZ = -var25;
-				motionY=motionX=var26;
+				motionY = motionX = var26;
 			}
 
 			if (var22 == 5) {
 				motionZ = var25;
-				motionY=motionX=var26;
+				motionY = motionX = var26;
 			}
 
 			return true;
-		} else return false;
+		} else
+			return false;
 	}
 
 	public boolean fake = false;

--- a/MODSRC/vazkii/botania/client/fx/FXWisp.java
+++ b/MODSRC/vazkii/botania/client/fx/FXWisp.java
@@ -26,9 +26,12 @@ import cpw.mods.fml.client.FMLClientHandler;
 
 public class FXWisp extends EntityFX {
 
-	public static final ResourceLocation particles = new ResourceLocation(LibResources.MISC_WISP_LARGE);
+	public static final ResourceLocation particles = new ResourceLocation(
+			LibResources.MISC_WISP_LARGE);
 
-	public FXWisp(World world, double d, double d1, double d2,  float size, float red, float green, float blue, boolean distanceLimit, float maxAgeMul) {
+	public FXWisp(World world, double d, double d1, double d2, float size,
+			float red, float green, float blue, boolean distanceLimit,
+			float maxAgeMul) {
 		super(world, d, d1, d2, 0.0D, 0.0D, 0.0D);
 		particleRed = red;
 		particleGreen = green;
@@ -37,19 +40,20 @@ public class FXWisp extends EntityFX {
 		motionX = motionY = motionZ = 0;
 		particleScale *= size;
 		moteParticleScale = particleScale;
-		particleMaxAge = (int)(28D / (Math.random() * 0.3D + 0.7D) * maxAgeMul);
+		particleMaxAge = (int) (28D / (Math.random() * 0.3D + 0.7D) * maxAgeMul);
 
 		moteHalfLife = particleMaxAge / 2;
 		noClip = true;
 		setSize(0.01F, 0.01F);
 		EntityLivingBase renderentity = FMLClientHandler.instance().getClient().renderViewEntity;
 
-		if(distanceLimit) {
+		if (distanceLimit) {
 			int visibleDistance = 50;
 			if (!FMLClientHandler.instance().getClient().gameSettings.fancyGraphics)
 				visibleDistance = 25;
 
-			if (renderentity == null || renderentity.getDistance(posX, posY, posZ) > visibleDistance)
+			if (renderentity == null
+					|| renderentity.getDistance(posX, posY, posZ) > visibleDistance)
 				particleMaxAge = 0;
 		}
 
@@ -59,11 +63,12 @@ public class FXWisp extends EntityFX {
 	}
 
 	@Override
-	public void renderParticle(Tessellator tessellator, float f, float f1, float f2, float f3, float f4, float f5) {
-        if(Minecraft.getMinecraft().gameSettings.particleSetting ==2)
-            return;
-        float agescale = 0;
-		agescale = (float)particleAge / (float) moteHalfLife;
+	public void renderParticle(Tessellator tessellator, float f, float f1,
+			float f2, float f3, float f4, float f5) {
+		if (Minecraft.getMinecraft().gameSettings.particleSetting == 2)
+			return;
+		float agescale = 0;
+		agescale = (float) particleAge / (float) moteHalfLife;
 		if (agescale > 1F)
 			agescale = 2 - agescale;
 
@@ -81,17 +86,22 @@ public class FXWisp extends EntityFX {
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 0.75F);
 
 		float f10 = 0.5F * particleScale;
-		float f11 = (float)(prevPosX + (posX - prevPosX) * f - interpPosX);
-		float f12 = (float)(prevPosY + (posY - prevPosY) * f - interpPosY);
-		float f13 = (float)(prevPosZ + (posZ - prevPosZ) * f - interpPosZ);
+		float f11 = (float) (prevPosX + (posX - prevPosX) * f - interpPosX);
+		float f12 = (float) (prevPosY + (posY - prevPosY) * f - interpPosY);
+		float f13 = (float) (prevPosZ + (posZ - prevPosZ) * f - interpPosZ);
 
 		tessellator.startDrawingQuads();
 		tessellator.setBrightness(240);
-		tessellator.setColorRGBA_F(particleRed, particleGreen, particleBlue, 0.5F);
-		tessellator.addVertexWithUV(f11 - f1 * f10 - f4 * f10, f12 - f2 * f10, f13 - f3 * f10 - f5 * f10, 0, 1);
-		tessellator.addVertexWithUV(f11 - f1 * f10 + f4 * f10, f12 + f2 * f10, f13 - f3 * f10 + f5 * f10, 1, 1);
-		tessellator.addVertexWithUV(f11 + f1 * f10 + f4 * f10, f12 + f2 * f10, f13 + f3 * f10 + f5 * f10, 1, 0);
-		tessellator.addVertexWithUV(f11 + f1 * f10 - f4 * f10, f12 - f2 * f10, f13 + f3 * f10 - f5 * f10, 0, 0);
+		tessellator.setColorRGBA_F(particleRed, particleGreen, particleBlue,
+				0.5F);
+		tessellator.addVertexWithUV(f11 - f1 * f10 - f4 * f10, f12 - f2 * f10,
+				f13 - f3 * f10 - f5 * f10, 0, 1);
+		tessellator.addVertexWithUV(f11 - f1 * f10 + f4 * f10, f12 + f2 * f10,
+				f13 - f3 * f10 + f5 * f10, 1, 1);
+		tessellator.addVertexWithUV(f11 + f1 * f10 + f4 * f10, f12 + f2 * f10,
+				f13 + f3 * f10 + f5 * f10, 1, 0);
+		tessellator.addVertexWithUV(f11 + f1 * f10 - f4 * f10, f12 - f2 * f10,
+				f13 + f3 * f10 - f5 * f10, 0, 0);
 
 		tessellator.draw();
 
@@ -99,7 +109,8 @@ public class FXWisp extends EntityFX {
 		GL11.glDepthMask(true);
 
 		GL11.glPopMatrix();
-		Minecraft.getMinecraft().renderEngine.bindTexture(ObfuscationHelper.getParticleTexture());
+		Minecraft.getMinecraft().renderEngine.bindTexture(ObfuscationHelper
+				.getParticleTexture());
 		tessellator.startDrawingQuads();
 	}
 


### PR DESCRIPTION
Turned of all particles when the in game setting is set minimal.

I know there is a config file to do this, but surly they shouldn't spawn when set to minimal.

This is helpful when I am playing on my laptop witch only get around 20 fps. I saw a 8 fps boost doing this. 
