### PR TITLE
Fixed NullPointerException

### DIFF
--- a/MODSRC/vazkii/botania/common/entity/EntitySpark.java
+++ b/MODSRC/vazkii/botania/common/entity/EntitySpark.java
@@ -61,8 +61,9 @@ public class EntitySpark extends Entity implements ISparkEntity {
 		super.onUpdate();
 
 		ISparkAttachable tile = getAttachedTile();
-		if(tile == null && !worldObj.isRemote) {
-			setDead();
+		if(tile == null) {
+			if(!worldObj.isRemote)
+				setDead();
 			return;
 		}
 


### PR DESCRIPTION
Client was continuing past the null check and throwing a NPE when it got to tile.getCurrentMana(). This occurred when breaking pools with sparks on them. Haven't been able to duplicate the crash after running with this change for awhile.
