### PR TITLE
Dominant sparks stop draining newly upgraded sparks now.

### DIFF
--- a/MODSRC/vazkii/botania/common/entity/EntitySpark.java
+++ b/MODSRC/vazkii/botania/common/entity/EntitySpark.java
@@ -272,7 +272,7 @@ public class EntitySpark extends Entity implements ISparkEntity {
 			Entity e = worldObj.getEntityByID(id);
 			if(e != null && e instanceof ISparkEntity) {
 				ISparkEntity spark = (ISparkEntity) e;
-				if(spark != this && !spark.areIncomingTransfersDone() && spark.getAttachedTile() != null && !spark.getAttachedTile().isFull() && spark.getUpgrade() != 4 && (getUpgrade() != 4 || getUpgrade() != 3 || getUpgrade() != 1 || !(spark.getAttachedTile() instanceof IManaPool))) {
+				if(spark != this && !spark.areIncomingTransfersDone() && spark.getAttachedTile() != null && !spark.getAttachedTile().isFull() && ((getUpgrade() == 0 && spark.getUpgrade() == 2) || (getUpgrade() == 3 && (spark.getUpgrade() == 0 || spark.getUpgrade() == 1))) && spark.getAttachedTile() instanceof IManaPool) {
 					entities.add((ISparkEntity) e);
 					added = true;
 				}


### PR DESCRIPTION
This is to fix a perceived exploit/oversight and is based on assumptions from the in-game descriptions as well as impressions about intended mod design. Basically, it is possible to create a mana transfer chain using dominant sparks that is extendable to arbitrary lengths. Basic sparks sending mana never fail the if statement and so never remove the dominant spark from their transfers list even when they are upgraded to dominant themselves. It should now only allow basic sparks to send to dominants, and recessive sparks to send to basic and dispersive. I know the basic->dominant transfers were the only ones that got put in the list, but it never hurts to be thorough.

Consider this an issue report with one possible way of fixing it attached.
