### PR TITLE
add BuildCraft API triggers for Botania

### DIFF
--- a/MODSRC/vazkii/botania/common/block/tile/TileRuneAltar.java
+++ b/MODSRC/vazkii/botania/common/block/tile/TileRuneAltar.java
@@ -139,6 +139,13 @@ public class TileRuneAltar extends TileSimpleInventory implements ISidedInventor
 			worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
 		}
 	}
+	
+	public boolean hasValidRecipe() {
+		for(RecipeRuneAltar recipe : BotaniaAPI.runeAltarRecipes)
+			if(recipe.matches(this)) return true;
+		
+		return false;
+	}
 
 	public void onWanded(EntityPlayer player, ItemStack wand) {
 		updateRecipe();

--- a/MODSRC/vazkii/botania/common/core/proxy/CommonProxy.java
+++ b/MODSRC/vazkii/botania/common/core/proxy/CommonProxy.java
@@ -47,7 +47,9 @@ import vazkii.botania.common.entity.ModEntities;
 import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.lexicon.LexiconData;
 import vazkii.botania.common.network.GuiHandler;
+import vazkii.botania.common.plugins.buildcraft.StatementAPIPlugin;
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.ModAPIManager;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLInterModComms;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
@@ -90,6 +92,10 @@ public class CommonProxy {
 		FMLCommonHandler.instance().bus().register(new CommonTickHandler());
 
 		FMLInterModComms.sendMessage("ProjectE", "interdictionblacklist", EntityManaBurst.class.getCanonicalName());
+		
+		if (ModAPIManager.INSTANCE.hasAPI("BuildCraftAPI|statements")) {
+			new StatementAPIPlugin();
+		}
 	}
 
 	public void postInit(FMLPostInitializationEvent event) {

--- a/MODSRC/vazkii/botania/common/entity/EntityManaBurst.java
+++ b/MODSRC/vazkii/botania/common/entity/EntityManaBurst.java
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
+import buildcraft.api.transport.IPipeTile;
+import cpw.mods.fml.common.Loader;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockBush;
 import net.minecraft.block.BlockLeaves;
@@ -547,6 +549,9 @@ public class EntityManaBurst extends EntityThrowable implements IManaBurst {
 			if(tile instanceof IManaCollisionGhost && ((IManaCollisionGhost) tile).isGhost() || block instanceof BlockBush || block instanceof BlockLeaves)
 				return;
 
+			if(tile instanceof IPipeTile) // BuildCeaft pipe compat
+				return;
+			
 			ChunkCoordinates coords = getBurstSourceChunkCoordinates();
 			if(tile != null && (tile.xCoord != coords.posX || tile.yCoord != coords.posY || tile.zCoord != coords.posZ))
 				collidedTile = tile;

--- a/MODSRC/vazkii/botania/common/plugins/buildcraft/StatementAPIPlugin.java
+++ b/MODSRC/vazkii/botania/common/plugins/buildcraft/StatementAPIPlugin.java
@@ -1,0 +1,67 @@
+package vazkii.botania.common.plugins.buildcraft;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import vazkii.botania.api.mana.IManaBlock;
+import vazkii.botania.api.mana.IManaReceiver;
+import vazkii.botania.common.block.tile.TileRuneAltar;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.ITriggerExternal;
+import buildcraft.api.statements.ITriggerInternal;
+import buildcraft.api.statements.ITriggerProvider;
+import buildcraft.api.statements.StatementManager;
+
+public class StatementAPIPlugin implements ITriggerProvider {
+	public static final ITriggerExternal triggerManaEmpty = new TriggerManaLevel(TriggerManaLevel.State.Empty);
+	public static final ITriggerExternal triggerManaContains = new TriggerManaLevel(TriggerManaLevel.State.Contains);
+	public static final ITriggerExternal triggerManaSpace = new TriggerManaLevel(TriggerManaLevel.State.Space);
+	public static final ITriggerExternal triggerManaFull = new TriggerManaLevel(TriggerManaLevel.State.Full);
+	public static final ITriggerInternal triggerManaDetector = new TriggerManaDetector();
+	
+	public static final ITriggerExternal triggerRuneAltarCanCraft = new TriggerRuneAltarCanCraft();
+
+	public StatementAPIPlugin() {
+		StatementManager.registerStatement(triggerManaEmpty);
+		StatementManager.registerStatement(triggerManaContains);
+		StatementManager.registerStatement(triggerManaSpace);
+		StatementManager.registerStatement(triggerManaFull);
+		StatementManager.registerStatement(triggerManaDetector);
+
+		StatementManager.registerStatement(triggerRuneAltarCanCraft);
+		
+		StatementManager.registerTriggerProvider(this);
+	}
+
+	@Override
+	public Collection<ITriggerInternal> getInternalTriggers(
+			IStatementContainer container) {
+		ArrayList<ITriggerInternal> list = new ArrayList<ITriggerInternal>();
+		list.add(triggerManaDetector);
+		return list;
+	}
+
+	@Override
+	public Collection<ITriggerExternal> getExternalTriggers(
+			ForgeDirection side, TileEntity tile) {
+		ArrayList<ITriggerExternal> list = new ArrayList<ITriggerExternal>();
+		
+		if (tile instanceof IManaBlock) {
+			list.add(triggerManaEmpty);
+			list.add(triggerManaContains);
+			
+			if (tile instanceof IManaReceiver) {
+				list.add(triggerManaSpace);
+				list.add(triggerManaFull);
+			}
+		}
+		
+		if (tile instanceof TileRuneAltar) {
+			list.add(triggerRuneAltarCanCraft);
+		}
+		
+		return list;
+	}
+}

--- a/MODSRC/vazkii/botania/common/plugins/buildcraft/StatementBase.java
+++ b/MODSRC/vazkii/botania/common/plugins/buildcraft/StatementBase.java
@@ -1,0 +1,35 @@
+package vazkii.botania.common.plugins.buildcraft;
+
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.util.IIcon;
+import buildcraft.api.statements.IStatement;
+import buildcraft.api.statements.IStatementParameter;
+
+public abstract class StatementBase implements IStatement {
+	protected IIcon icon;
+	
+	@Override
+	public IIcon getIcon() {
+		return icon;
+	}
+
+	@Override
+	public int maxParameters() {
+		return 0;
+	}
+
+	@Override
+	public int minParameters() {
+		return 0;
+	}
+
+	@Override
+	public IStatementParameter createParameter(int index) {
+		return null;
+	}
+
+	@Override
+	public IStatement rotateLeft() {
+		return this;
+	}
+}

--- a/MODSRC/vazkii/botania/common/plugins/buildcraft/TriggerManaDetector.java
+++ b/MODSRC/vazkii/botania/common/plugins/buildcraft/TriggerManaDetector.java
@@ -1,0 +1,47 @@
+package vazkii.botania.common.plugins.buildcraft;
+
+import vazkii.botania.api.internal.IManaBurst;
+import vazkii.botania.common.Botania;
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.util.StatCollector;
+import net.minecraft.world.World;
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import buildcraft.api.statements.ITriggerInternal;
+
+public class TriggerManaDetector extends StatementBase implements
+		ITriggerInternal {
+
+	@Override
+	public String getUniqueTag() {
+		return "botania:manaDetector";
+	}
+
+	@Override
+	public void registerIcons(IIconRegister iconRegister) {
+		icon = iconRegister.registerIcon("botania:triggers/manaDetector");
+	}
+
+	@Override
+	public String getDescription() {
+		return StatCollector.translateToLocal("botania.trigger.manaDetector");
+	}
+
+	@Override
+	public boolean isTriggerActive(IStatementContainer source,
+			IStatementParameter[] parameters) {
+		World world = source.getTile().getWorldObj();
+		int x = source.getTile().xCoord, y = source.getTile().yCoord, z = source.getTile().zCoord;
+		
+		boolean output = world.getEntitiesWithinAABB(IManaBurst.class, AxisAlignedBB.getBoundingBox(x, y, z, x + 1, y + 1, z + 1)).size() != 0;
+		
+		if (output) {
+			for(int i = 0; i < 4; i++)
+				Botania.proxy.sparkleFX(world, x + Math.random(), y + Math.random(), z + Math.random(), 1F, 0.2F, 0.2F, 0.7F + 0.5F * (float) Math.random(), 5);
+		}
+		
+		return output;
+	}
+
+}

--- a/MODSRC/vazkii/botania/common/plugins/buildcraft/TriggerManaLevel.java
+++ b/MODSRC/vazkii/botania/common/plugins/buildcraft/TriggerManaLevel.java
@@ -1,0 +1,63 @@
+package vazkii.botania.common.plugins.buildcraft;
+
+import vazkii.botania.api.mana.IManaBlock;
+import vazkii.botania.api.mana.IManaCollector;
+import vazkii.botania.api.mana.IManaReceiver;
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.IIcon;
+import net.minecraft.util.StatCollector;
+import net.minecraftforge.common.util.ForgeDirection;
+import buildcraft.api.statements.IStatement;
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import buildcraft.api.statements.ITriggerExternal;
+
+public class TriggerManaLevel extends StatementBase implements ITriggerExternal {
+	public enum State {
+		Empty, Contains, Space, Full
+	};
+
+	private State state;
+	
+	public TriggerManaLevel(State state) {
+		this.state = state;
+	}
+	
+	@Override
+	public String getUniqueTag() {
+		return "botania:mana" + state.name();
+	}
+
+	@Override
+	public void registerIcons(IIconRegister iconRegister) {
+		icon = iconRegister.registerIcon("botania:triggers/mana" + state.name() + ".png");
+	}
+
+	@Override
+	public String getDescription() {
+		return StatCollector.translateToLocal("botania.trigger.mana" + state.name());
+	}
+
+	@Override
+	public boolean isTriggerActive(TileEntity target, ForgeDirection side,
+			IStatementContainer source, IStatementParameter[] parameters) {
+		if (target instanceof IManaBlock) {
+			if (state == State.Empty) {
+				return ((IManaBlock) target).getCurrentMana() == 0;
+			} else if (state == State.Contains) {
+				return ((IManaBlock) target).getCurrentMana() > 0;
+			} else if (state == State.Space) {
+				if (target instanceof IManaReceiver) {
+					return !((IManaReceiver) target).isFull();
+				}
+			} else if (state == State.Full) {
+				if (target instanceof IManaReceiver) {
+					return ((IManaReceiver) target).isFull();
+				}
+			}
+		}
+		
+		return false;
+	}
+}

--- a/MODSRC/vazkii/botania/common/plugins/buildcraft/TriggerRuneAltarCanCraft.java
+++ b/MODSRC/vazkii/botania/common/plugins/buildcraft/TriggerRuneAltarCanCraft.java
@@ -1,0 +1,40 @@
+package vazkii.botania.common.plugins.buildcraft;
+
+import vazkii.botania.common.block.tile.TileRuneAltar;
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.StatCollector;
+import net.minecraftforge.common.util.ForgeDirection;
+import buildcraft.api.statements.IStatementContainer;
+import buildcraft.api.statements.IStatementParameter;
+import buildcraft.api.statements.ITriggerExternal;
+
+public class TriggerRuneAltarCanCraft extends StatementBase implements
+		ITriggerExternal {
+
+	@Override
+	public String getUniqueTag() {
+		return "botania:runeAltarCanCraft";
+	}
+
+	@Override
+	public void registerIcons(IIconRegister iconRegister) {
+		icon = iconRegister.registerIcon("botania:triggers/runeAltarCanCraft.png");
+	}
+
+	@Override
+	public String getDescription() {
+		return StatCollector.translateToLocal("botania.trigger.runeAltarCanCraft");
+	}
+
+	@Override
+	public boolean isTriggerActive(TileEntity target, ForgeDirection side,
+			IStatementContainer source, IStatementParameter[] parameters) {
+		if (target instanceof TileRuneAltar) {
+			return ((TileRuneAltar) target).hasValidRecipe();
+		} else {
+			return false;
+		}
+	}
+
+}

--- a/apis/buildcraft/api/core/BCLog.java
+++ b/apis/buildcraft/api/core/BCLog.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+import java.lang.reflect.Method;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public final class BCLog {
+
+	public static final Logger logger = LogManager.getLogger("BuildCraft");
+
+	/**
+	 * Deactivate constructor
+	 */
+	private BCLog() {
+	}
+
+	public static void initLog() {
+
+		logger.info("Starting BuildCraft " + getVersion());
+		logger.info("Copyright (c) SpaceToad, 2011-2014");
+		logger.info("http://www.mod-buildcraft.com");
+	}
+
+	public static void logErrorAPI(String mod, Throwable error, Class<?> classFile) {
+		StringBuilder msg = new StringBuilder(mod);
+		msg.append(" API error, please update your mods. Error: ").append(error);
+		StackTraceElement[] stackTrace = error.getStackTrace();
+		if (stackTrace.length > 0) {
+			msg.append(", ").append(stackTrace[0]);
+		}
+
+		logger.log(Level.ERROR, msg.toString());
+
+		if (classFile != null) {
+			msg = new StringBuilder(mod);
+			msg.append(" API error: ").append(classFile.getSimpleName()).append(" is loaded from ").append(classFile.getProtectionDomain().getCodeSource().getLocation());
+			logger.log(Level.ERROR, msg.toString());
+		}
+	}
+
+    public static String getVersion() {
+        try {
+            Class<?> clazz = Class.forName("buildcraft.core.Version");
+            Method method = clazz.getDeclaredMethod("getVersion");
+            return String.valueOf(method.invoke(null));
+        } catch (Exception e) {
+            return "UNKNOWN VERSION";
+        }
+    }
+}

--- a/apis/buildcraft/api/core/BlockIndex.java
+++ b/apis/buildcraft/api/core/BlockIndex.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.Entity;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+/**
+ * This class is a comparable container for block positions. TODO: should this be merged with position?
+ */
+public class BlockIndex implements Comparable<BlockIndex> {
+
+	public int x;
+	public int y;
+	public int z;
+
+	public BlockIndex() {
+
+	}
+
+	/**
+	 * Creates an index for a block located on x, y. z
+	 */
+	public BlockIndex(int x, int y, int z) {
+
+		this.x = x;
+		this.y = y;
+		this.z = z;
+	}
+
+	public BlockIndex(NBTTagCompound c) {
+		this.x = c.getInteger("i");
+		this.y = c.getInteger("j");
+		this.z = c.getInteger("k");
+	}
+
+	public BlockIndex(Entity entity) {
+		x = (int) Math.floor(entity.posX);
+		y = (int) Math.floor(entity.posY);
+		z = (int) Math.floor(entity.posZ);
+	}
+
+	public BlockIndex(TileEntity entity) {
+		this(entity.xCoord, entity.yCoord, entity.zCoord);
+	}
+
+	/**
+	 * Provides a deterministic and complete ordering of block positions.
+	 */
+	@Override
+	public int compareTo(BlockIndex o) {
+
+		if (o.x < x) {
+			return 1;
+		} else if (o.x > x) {
+			return -1;
+		} else if (o.z < z) {
+			return 1;
+		} else if (o.z > z) {
+			return -1;
+		} else if (o.y < y) {
+			return 1;
+		} else if (o.y > y) {
+			return -1;
+		} else {
+			return 0;
+		}
+	}
+
+	public void writeTo(NBTTagCompound c) {
+		c.setInteger("i", x);
+		c.setInteger("j", y);
+		c.setInteger("k", z);
+	}
+
+	public Block getBlock(World world) {
+		return world.getBlock(x, y, z);
+	}
+
+	@Override
+	public String toString() {
+		return "{" + x + ", " + y + ", " + z + "}";
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof BlockIndex) {
+			BlockIndex b = (BlockIndex) obj;
+
+			return b.x == x && b.y == y && b.z == z;
+		}
+
+		return super.equals(obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return (x * 37 + y) * 37 + z;
+	}
+
+	public boolean nextTo(BlockIndex blockIndex) {
+		return (Math.abs(blockIndex.x - x) <= 1 && blockIndex.y == y && blockIndex.z == z)
+				|| (blockIndex.x == x && Math.abs(blockIndex.y - y) <= 1 && blockIndex.z == z)
+				|| (blockIndex.x == x && blockIndex.y == y && Math.abs(blockIndex.z - z) <= 1);
+	}
+}

--- a/apis/buildcraft/api/core/BlockMetaPair.java
+++ b/apis/buildcraft/api/core/BlockMetaPair.java
@@ -1,0 +1,53 @@
+package buildcraft.api.core;
+
+import net.minecraft.block.Block;
+import net.minecraftforge.oredict.OreDictionary;
+
+public class BlockMetaPair implements Comparable<BlockMetaPair> {
+	private int id, meta;
+	
+	public BlockMetaPair(Block block, int meta) {
+		this.id = Block.getIdFromBlock(block);
+		this.meta = meta;
+	}
+	
+	public Block getBlock() {
+		return Block.getBlockById(id);
+	}
+	
+	public int meta() {
+		return meta;
+	}
+	
+	@Override
+	public int hashCode() {
+		return 17 * meta + id;
+	}
+	
+	@Override
+	public boolean equals(Object other) {
+		if (other == null || !(other instanceof BlockMetaPair)) {
+			return false;
+		}
+		
+		return ((BlockMetaPair) other).id == id && ((BlockMetaPair) other).meta == meta;
+	}
+	
+	@Override
+	public int compareTo(BlockMetaPair arg) {
+		if (arg.id != id) {
+			return (id - arg.id) * 16;
+		} else {
+			return meta - arg.meta;
+		}
+	}
+	
+	@Override
+	public String toString() {
+		if (this.getBlock() == null) {
+			return "invalid";
+		}
+		
+		return Block.blockRegistry.getNameForObject(this.getBlock()) + ":" + (this.meta == OreDictionary.WILDCARD_VALUE ? "*" : this.meta);
+	}
+}

--- a/apis/buildcraft/api/core/BuildCraftAPI.java
+++ b/apis/buildcraft/api/core/BuildCraftAPI.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import net.minecraft.block.Block;
+import net.minecraft.world.World;
+
+public final class BuildCraftAPI {
+
+	public static ICoreProxy proxy;
+
+	public static final Set<Block> softBlocks = new HashSet<Block>();
+
+	public static IWorldProperty isSoftProperty;
+	public static IWorldProperty isWoodProperty;
+	public static IWorldProperty isLeavesProperty;
+	public static IWorldProperty[] isOreProperty;
+	public static IWorldProperty isHarvestableProperty;
+	public static IWorldProperty isFarmlandProperty;
+	public static IWorldProperty isDirtProperty;
+	public static IWorldProperty isShoveled;
+	public static IWorldProperty isFluidSource;
+
+	/**
+	 * Deactivate constructor
+	 */
+	private BuildCraftAPI() {
+	}
+
+	public static boolean isSoftBlock(World world, int x, int y, int z) {
+		return isSoftProperty.get(world, x, y, z);
+	}
+}

--- a/apis/buildcraft/api/core/EnumColor.java
+++ b/apis/buildcraft/api/core/EnumColor.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+import java.util.Locale;
+import java.util.Random;
+
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.util.IIcon;
+import net.minecraft.util.StatCollector;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public enum EnumColor {
+
+	BLACK,
+	RED,
+	GREEN,
+	BROWN,
+	BLUE,
+	PURPLE,
+	CYAN,
+	LIGHT_GRAY,
+	GRAY,
+	PINK,
+	LIME,
+	YELLOW,
+	LIGHT_BLUE,
+	MAGENTA,
+	ORANGE,
+	WHITE;
+	public static final EnumColor[] VALUES = values();
+	public static final String[] DYES = {
+		"dyeBlack",
+		"dyeRed",
+		"dyeGreen",
+		"dyeBrown",
+		"dyeBlue",
+		"dyePurple",
+		"dyeCyan",
+		"dyeLightGray",
+		"dyeGray",
+		"dyePink",
+		"dyeLime",
+		"dyeYellow",
+		"dyeLightBlue",
+		"dyeMagenta",
+		"dyeOrange",
+		"dyeWhite"};
+	public static final String[] NAMES = {
+		"Black",
+		"Red",
+		"Green",
+		"Brown",
+		"Blue",
+		"Purple",
+		"Cyan",
+		"LightGray",
+		"Gray",
+		"Pink",
+		"Lime",
+		"Yellow",
+		"LightBlue",
+		"Magenta",
+		"Orange",
+		"White"};
+	public static final int[] DARK_HEX = {
+		0x2D2D2D,
+		0xA33835,
+		0x394C1E,
+		0x5C3A24,
+		0x3441A2,
+		0x843FBF,
+		0x36809E,
+		0x888888,
+		0x444444,
+		0xE585A0,
+		0x3FAA36,
+		0xCFC231,
+		0x7F9AD1,
+		0xFF64FF,
+		0xFF6A00,
+		0xFFFFFF};
+	public static final int[] LIGHT_HEX = {
+		0x181414,
+		0xBE2B27,
+		0x007F0E,
+		0x89502D,
+		0x253193,
+		0x7e34bf,
+		0x299799,
+		0xa0a7a7,
+		0x7A7A7A,
+		0xD97199,
+		0x39D52E,
+		0xFFD91C,
+		0x66AAFF,
+		0xD943C6,
+		0xEA7835,
+		0xe4e4e4};
+
+	@SideOnly(Side.CLIENT)
+	private static IIcon[] brushIcons;
+
+	public int getDarkHex() {
+		return DARK_HEX[ordinal()];
+	}
+
+	public int getLightHex() {
+		return LIGHT_HEX[ordinal()];
+	}
+
+	public static EnumColor fromId(int id) {
+		if (id < 0 || id >= VALUES.length) {
+			return WHITE;
+		}
+		return VALUES[id];
+	}
+
+	public static EnumColor fromDye(String dyeTag) {
+		for (int id = 0; id < DYES.length; id++) {
+			if (DYES[id].equals(dyeTag)) {
+				return VALUES[id];
+			}
+		}
+		return null;
+	}
+
+	public static EnumColor fromName(String name) {
+		for (int id = 0; id < NAMES.length; id++) {
+			if (NAMES[id].equals(name)) {
+				return VALUES[id];
+			}
+		}
+		return null;
+	}
+
+	public static EnumColor getRand() {
+		return VALUES[new Random().nextInt(VALUES.length)];
+	}
+
+	public EnumColor getNext() {
+		EnumColor next = VALUES[(ordinal() + 1) % VALUES.length];
+		return next;
+	}
+
+	public EnumColor getPrevious() {
+		EnumColor previous = VALUES[(ordinal() + VALUES.length - 1) % VALUES.length];
+		return previous;
+	}
+
+	public EnumColor inverse() {
+		return EnumColor.VALUES[15 - ordinal()];
+	}
+
+	public String getTag() {
+		return "color." + name().replace("_", ".").toLowerCase(Locale.ENGLISH);
+	}
+
+	public String getBasicTag() {
+		return name().replace("_", ".").toLowerCase(Locale.ENGLISH);
+	}
+
+	public String getName() {
+		return NAMES[ordinal()];
+	}
+
+	public String getLocalizedName() {
+		return StatCollector.translateToLocal(getTag());
+	}
+
+	public String getDye() {
+		return DYES[ordinal()];
+	}
+
+	@Override
+	public String toString() {
+		String s = name().replace("_", " ");
+		String[] words = s.split(" ");
+		StringBuilder b = new StringBuilder();
+		for (String word : words) {
+			b.append(word.charAt(0)).append(word.substring(1).toLowerCase(Locale.ENGLISH)).append(" ");
+		}
+		return b.toString().trim();
+	}
+
+	@SideOnly(Side.CLIENT)
+	public static void registerIcons(IIconRegister iconRegister) {
+		brushIcons = new IIcon[16];
+		for (EnumColor c : values()) {
+			brushIcons[c.ordinal()] = iconRegister.registerIcon("buildcraft:triggers/color_"
+					+ c.name().toLowerCase(Locale.ENGLISH));
+		}
+	}
+
+	@SideOnly(Side.CLIENT)
+	public IIcon getIcon() {
+		return brushIcons [ordinal()];
+	}
+}

--- a/apis/buildcraft/api/core/IAreaProvider.java
+++ b/apis/buildcraft/api/core/IAreaProvider.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+/**
+ * To be implemented by TileEntities able to provide a square area on the world, typically BuildCraft markers.
+ */
+public interface IAreaProvider {
+
+	int xMin();
+
+	int yMin();
+
+	int zMin();
+
+	int xMax();
+
+	int yMax();
+
+	int zMax();
+
+	/**
+	 * Remove from the world all objects used to define the area.
+	 */
+	void removeFromWorld();
+
+}

--- a/apis/buildcraft/api/core/IBox.java
+++ b/apis/buildcraft/api/core/IBox.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+public interface IBox extends IZone {
+
+	IBox expand(int amount);
+
+	IBox contract(int amount);
+
+	Position pMin();
+
+	Position pMax();
+
+	void createLaserData();
+
+}

--- a/apis/buildcraft/api/core/ICoreProxy.java
+++ b/apis/buildcraft/api/core/ICoreProxy.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+import java.lang.ref.WeakReference;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.WorldServer;
+
+public interface ICoreProxy {
+	WeakReference<EntityPlayer> getBuildCraftPlayer(WorldServer world);
+}

--- a/apis/buildcraft/api/core/IIconProvider.java
+++ b/apis/buildcraft/api/core/IIconProvider.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.util.IIcon;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public interface IIconProvider {
+
+	/**
+	 * @param iconIndex
+	 */
+	@SideOnly(Side.CLIENT)
+	IIcon getIcon(int iconIndex);
+
+	/**
+	 * A call for the provider to register its Icons. This may be called multiple times but should only be executed once per provider
+	 * @param iconRegister
+	 */
+	@SideOnly(Side.CLIENT)
+	void registerIcons(IIconRegister iconRegister);
+
+}

--- a/apis/buildcraft/api/core/IInvSlot.java
+++ b/apis/buildcraft/api/core/IInvSlot.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+import net.minecraft.item.ItemStack;
+
+public interface IInvSlot {
+    /**
+     * Returns the slot number of the underlying Inventory.
+     *
+     * @return the slot number
+     */
+    int getIndex();
+
+    boolean canPutStackInSlot(ItemStack stack);
+
+    boolean canTakeStackFromSlot(ItemStack stack);
+
+	ItemStack decreaseStackInSlot(int amount);
+
+    ItemStack getStackInSlot();
+
+    void setStackInSlot(ItemStack stack);
+}

--- a/apis/buildcraft/api/core/IWorldProperty.java
+++ b/apis/buildcraft/api/core/IWorldProperty.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+import net.minecraft.world.World;
+
+public interface IWorldProperty {
+
+	boolean get(World world, int x, int y, int z);
+
+	void clear();
+}

--- a/apis/buildcraft/api/core/IZone.java
+++ b/apis/buildcraft/api/core/IZone.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+import java.util.Random;
+
+public interface IZone {
+
+	double distanceTo(BlockIndex index);
+
+	boolean contains(double x, double y, double z);
+
+	BlockIndex getRandomBlockIndex(Random rand);
+
+}

--- a/apis/buildcraft/api/core/JavaTools.java
+++ b/apis/buildcraft/api/core/JavaTools.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class JavaTools {
+	public static double bounds(double value, double min, double max) {
+		return Math.max(min, Math.min(value, max));
+	}
+
+	public static <T> T[] concat(T[] first, T[] second) {
+		T[] result = Arrays.copyOf(first, first.length + second.length);
+		System.arraycopy(second, 0, result, first.length, second.length);
+		return result;
+	}
+
+	public static int[] concat(int[] first, int[] second) {
+		int[] result = Arrays.copyOf(first, first.length + second.length);
+		System.arraycopy(second, 0, result, first.length, second.length);
+		return result;
+	}
+
+	public static float[] concat(float[] first, float[] second) {
+		float[] result = Arrays.copyOf(first, first.length + second.length);
+		System.arraycopy(second, 0, result, first.length, second.length);
+		return result;
+	}
+
+	public <T> T[] concatenate (T[] a, T[] b) {
+	    int aLen = a.length;
+	    int bLen = b.length;
+
+	    @SuppressWarnings("unchecked")
+		T[] c = (T[]) Array.newInstance(a.getClass().getComponentType(), aLen + bLen);
+	    System.arraycopy(a, 0, c, 0, aLen);
+	    System.arraycopy(b, 0, c, aLen, bLen);
+
+	    return c;
+	}
+
+	public static List<Field> getAllFields(Class<?> clas) {
+	    List<Field> result = new ArrayList<Field>();
+
+	    Class<?> current = clas;
+
+	    while (current != null && current != Object.class) {
+	    	for (Field f : current.getDeclaredFields()) {
+	    		result.add(f);
+	    	}
+
+	        current = current.getSuperclass();
+	    }
+
+	    return result;
+	}
+
+	public static List<Method> getAllMethods(Class<?> clas) {
+	    List<Method> result = new ArrayList<Method>();
+
+	    Class<?> current = clas;
+
+	    while (current != null && current != Object.class) {
+	    	for (Method m : current.getDeclaredMethods()) {
+	    		result.add(m);
+	    	}
+
+	        current = current.getSuperclass();
+	    }
+
+	    return result;
+	}
+
+	public static String surroundWithQuotes(String stringToSurroundWithQuotes) {
+		return String.format("\"%s\"", stringToSurroundWithQuotes);
+	}
+
+	public static String stripSurroundingQuotes(String stringToStripQuotes) {
+		return stringToStripQuotes.replaceAll("^\"|\"$", "");
+	}
+}

--- a/apis/buildcraft/api/core/NetworkData.java
+++ b/apis/buildcraft/api/core/NetworkData.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface NetworkData {
+
+}

--- a/apis/buildcraft/api/core/Position.java
+++ b/apis/buildcraft/api/core/Position.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+public class Position {
+
+	@NetworkData
+	public double x, y, z;
+
+	@NetworkData
+	public ForgeDirection orientation;
+
+	public Position() {
+		x = 0;
+		y = 0;
+		z = 0;
+		orientation = ForgeDirection.UNKNOWN;
+	}
+
+	public Position(double ci, double cj, double ck) {
+		x = ci;
+		y = cj;
+		z = ck;
+		orientation = ForgeDirection.UNKNOWN;
+	}
+
+	public Position(double ci, double cj, double ck, ForgeDirection corientation) {
+		x = ci;
+		y = cj;
+		z = ck;
+		orientation = corientation;
+
+		if (orientation == null) {
+			orientation = ForgeDirection.UNKNOWN;
+		}
+	}
+
+	public Position(Position p) {
+		x = p.x;
+		y = p.y;
+		z = p.z;
+		orientation = p.orientation;
+	}
+
+	public Position(NBTTagCompound nbttagcompound) {
+		readFromNBT(nbttagcompound);
+	}
+
+	public Position(TileEntity tile) {
+		x = tile.xCoord;
+		y = tile.yCoord;
+		z = tile.zCoord;
+		orientation = ForgeDirection.UNKNOWN;
+	}
+
+	public Position(BlockIndex index) {
+		x = index.x;
+		y = index.y;
+		z = index.z;
+		orientation = ForgeDirection.UNKNOWN;
+	}
+
+	public void moveRight(double step) {
+		switch (orientation) {
+		case SOUTH:
+			x = x - step;
+			break;
+		case NORTH:
+			x = x + step;
+			break;
+		case EAST:
+			z = z + step;
+			break;
+		case WEST:
+			z = z - step;
+			break;
+		default:
+		}
+	}
+
+	public void moveLeft(double step) {
+		moveRight(-step);
+	}
+
+	public void moveForwards(double step) {
+		switch (orientation) {
+		case UP:
+			y = y + step;
+			break;
+		case DOWN:
+			y = y - step;
+			break;
+		case SOUTH:
+			z = z + step;
+			break;
+		case NORTH:
+			z = z - step;
+			break;
+		case EAST:
+			x = x + step;
+			break;
+		case WEST:
+			x = x - step;
+			break;
+		default:
+		}
+	}
+
+	public void moveBackwards(double step) {
+		moveForwards(-step);
+	}
+
+	public void moveUp(double step) {
+		switch (orientation) {
+		case SOUTH:
+		case NORTH:
+		case EAST:
+		case WEST:
+			y = y + step;
+			break;
+		default:
+		}
+
+	}
+
+	public void moveDown(double step) {
+		moveUp(-step);
+	}
+
+	public void writeToNBT(NBTTagCompound nbttagcompound) {
+		if (orientation == null) {
+			orientation = ForgeDirection.UNKNOWN;
+		}
+
+		nbttagcompound.setDouble("i", x);
+		nbttagcompound.setDouble("j", y);
+		nbttagcompound.setDouble("k", z);
+		nbttagcompound.setByte("orientation", (byte) orientation.ordinal());
+	}
+
+	public void readFromNBT(NBTTagCompound nbttagcompound) {
+		x = nbttagcompound.getDouble("i");
+		y = nbttagcompound.getDouble("j");
+		z = nbttagcompound.getDouble("k");
+		orientation = ForgeDirection.values() [nbttagcompound.getByte("orientation")];
+	}
+
+	@Override
+	public String toString() {
+		return "{" + x + ", " + y + ", " + z + "}";
+	}
+
+	public Position min(Position p) {
+		return new Position(p.x > x ? x : p.x, p.y > y ? y : p.y, p.z > z ? z : p.z);
+	}
+
+	public Position max(Position p) {
+		return new Position(p.x < x ? x : p.x, p.y < y ? y : p.y, p.z < z ? z : p.z);
+	}
+
+	public boolean isClose(Position newPosition, float f) {
+		double dx = x - newPosition.x;
+		double dy = y - newPosition.y;
+		double dz = z - newPosition.z;
+
+		double sqrDis = dx * dx + dy * dy + dz * dz;
+
+		return !(sqrDis > f * f);
+	}
+}

--- a/apis/buildcraft/api/core/SafeTimeTracker.java
+++ b/apis/buildcraft/api/core/SafeTimeTracker.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+import net.minecraft.world.World;
+
+public class SafeTimeTracker {
+
+	private long lastMark = Long.MIN_VALUE;
+	private long duration = -1;
+	private long randomRange = 0;
+	private long lastRandomDelay = 0;
+	private long internalDelay = 1;
+
+	/**
+	 * @deprecated should use constructors with parameters instead
+	 */
+	public SafeTimeTracker () {
+
+	}
+
+	public SafeTimeTracker (long delay) {
+		internalDelay = delay;
+	}
+
+	/**
+	 * In many situations, it is a bad idea to have all objects of the same
+	 * kind to be waiting for the exact same amount of time, as that can lead
+	 * to some situation where they're all synchronized and got to work all
+	 * at the same time. When created with a random range, the mark that is set
+	 * when reaching the expect delay will be added with a random number
+	 * between [0, range[, meaning that the event will take between 0 and range
+	 * more tick to run.
+	 */
+	public SafeTimeTracker (long delay, long random) {
+		internalDelay = delay;
+		randomRange = random;
+	}
+
+	public boolean markTimeIfDelay(World world) {
+		return markTimeIfDelay(world, internalDelay);
+	}
+
+	/**
+	 * Return true if a given delay has passed since last time marked was called
+	 * successfully.
+	 *
+	 * @deprecated should use the constructor with a delay instead, and call
+	 * this function without a parameter
+	 */
+	public boolean markTimeIfDelay(World world, long delay) {
+		if (world == null) {
+			return false;
+		}
+
+		long currentTime = world.getTotalWorldTime();
+
+		if (currentTime < lastMark) {
+			lastMark = currentTime;
+			return false;
+		} else if (lastMark + delay + lastRandomDelay <= currentTime) {
+			duration = currentTime - lastMark;
+			lastMark = currentTime;
+			lastRandomDelay = (int) (Math.random() * randomRange);
+
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	public long durationOfLastDelay() {
+		return duration > 0 ? duration : 0;
+	}
+
+	public void markTime(World world) {
+		lastMark = world.getTotalWorldTime();
+	}
+}

--- a/apis/buildcraft/api/core/StackKey.java
+++ b/apis/buildcraft/api/core/StackKey.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidContainerRegistry;
+import net.minecraftforge.fluids.FluidStack;
+
+/**
+ * This class is used whenever stacks needs to be stored as keys.
+ */
+public final class StackKey {
+	public final ItemStack stack;
+	public final FluidStack fluidStack;
+
+	public StackKey(FluidStack fluidStack) {
+		this(null, fluidStack);
+	}
+
+	public StackKey(ItemStack stack) {
+		this(stack, null);
+	}
+
+	public StackKey(ItemStack stack, FluidStack fluidStack) {
+		this.stack = stack;
+		this.fluidStack = fluidStack;
+	}
+
+	public static StackKey stack(Item item, int amount, int damage) {
+		return new StackKey(new ItemStack(item, amount, damage));
+	}
+
+	public static StackKey stack(Block block, int amount, int damage) {
+		return new StackKey(new ItemStack(block, amount, damage));
+	}
+
+	public static StackKey stack(Item item) {
+		return new StackKey(new ItemStack(item, 1, 0));
+	}
+
+	public static StackKey stack(Block block) {
+		return new StackKey(new ItemStack(block, 1, 0));
+	}
+
+	public static StackKey stack(ItemStack itemStack) {
+		return new StackKey(itemStack);
+	}
+
+	public static StackKey fluid(Fluid fluid, int amount) {
+		return new StackKey(new FluidStack(fluid, amount));
+	}
+
+	public static StackKey fluid(Fluid fluid) {
+		return new StackKey(new FluidStack(fluid, FluidContainerRegistry.BUCKET_VOLUME));
+	}
+
+	public static StackKey fluid(FluidStack fluidStack) {
+		return new StackKey(fluidStack);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || o.getClass() != StackKey.class) {
+			return false;
+		}
+		StackKey k = (StackKey) o;
+		if ((stack == null ^ k.stack == null) || (fluidStack == null ^ k.fluidStack == null)) {
+			return false;
+		}
+		if (stack != null) {
+			if (stack.getItem() != k.stack.getItem() ||
+					stack.getHasSubtypes() && stack.getItemDamage() != k.stack.getItemDamage() ||
+					!objectsEqual(stack.getTagCompound(), k.stack.getTagCompound())) {
+				return false;
+			}
+		}
+		if (fluidStack != null) {
+			if (fluidStack.fluidID != k.fluidStack.fluidID ||
+					fluidStack.amount != k.fluidStack.amount ||
+					!objectsEqual(fluidStack.tag, k.fluidStack.tag)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = 7;
+		if (stack != null) {
+			result = 31 * result + stack.getItem().hashCode();
+			result = 31 * result + stack.getItemDamage();
+			result = 31 * result + objectHashCode(stack.getTagCompound());
+		}
+		result = 31 * result + 7;
+		if (fluidStack != null) {
+			result = 31 * result + fluidStack.fluidID;
+			result = 31 * result + fluidStack.amount;
+			result = 31 * result + objectHashCode(fluidStack.tag);
+		}
+		return result;
+	}
+
+	private boolean objectsEqual(Object o1, Object o2) {
+		if (o1 == null && o2 == null) {
+			return true;
+		} else if (o1 == null || o2 == null) {
+			return false;
+		} else {
+			return o1.equals(o2);
+		}
+	}
+	
+	private int objectHashCode(Object o) {
+		return o != null ? o.hashCode() : 0;
+	}
+
+	public StackKey copy() {
+		return new StackKey(stack != null ? stack.copy() : null,
+				fluidStack != null ? fluidStack.copy() : null);
+	}
+}

--- a/apis/buildcraft/api/core/WorldBlockIndex.java
+++ b/apis/buildcraft/api/core/WorldBlockIndex.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.core;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
+
+/**
+ * This class is a comparable container for block positions. TODO: should this be merged with position?
+ */
+public class WorldBlockIndex implements Comparable<WorldBlockIndex> {
+
+	public int x;
+	public int y;
+	public int z;
+	public int dimension;
+
+	public WorldBlockIndex() {
+
+	}
+
+	/**
+	 * Creates an index for a block located on x, y. z
+	 */
+	public WorldBlockIndex(World world, int x, int y, int z) {
+
+		dimension = world.provider.dimensionId;
+		this.x = x;
+		this.y = y;
+		this.z = z;
+	}
+
+	public WorldBlockIndex(NBTTagCompound c) {
+		dimension = c.getInteger("dimension");
+		x = c.getInteger("x");
+		y = c.getInteger("y");
+		z = c.getInteger("z");
+	}
+
+	public WorldBlockIndex(Entity entity) {
+		dimension = entity.worldObj.provider.dimensionId;
+		x = (int) Math.floor(entity.posX);
+		y = (int) Math.floor(entity.posY);
+		z = (int) Math.floor(entity.posZ);
+	}
+
+	/**
+	 * Provides a deterministic and complete ordering of block positions.
+	 */
+	@Override
+	public int compareTo(WorldBlockIndex o) {
+
+		if (o.dimension < dimension) {
+			return 1;
+		} else if (o.dimension > dimension) {
+			return -1;
+		} else if (o.x < x) {
+			return 1;
+		} else if (o.x > x) {
+			return -1;
+		} else if (o.z < z) {
+			return 1;
+		} else if (o.z > z) {
+			return -1;
+		} else if (o.y < y) {
+			return 1;
+		} else if (o.y > y) {
+			return -1;
+		} else {
+			return 0;
+		}
+	}
+
+	public void writeTo(NBTTagCompound c) {
+		c.setInteger("dimension", dimension);
+		c.setInteger("x", x);
+		c.setInteger("y", y);
+		c.setInteger("z", z);
+	}
+
+	@Override
+	public String toString() {
+		return "{" + dimension + ":" + x + ", " + y + ", " + z + "}";
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof WorldBlockIndex) {
+			WorldBlockIndex b = (WorldBlockIndex) obj;
+
+			return b.dimension == dimension && b.x == x && b.y == y && b.z == z;
+		}
+
+		return super.equals(obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return (dimension * 37 + (x * 37 + y)) * 37 + z;
+	}
+}

--- a/apis/buildcraft/api/core/package-info.java
+++ b/apis/buildcraft/api/core/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+@API(apiVersion = "1.0", owner = "BuildCraft|Core", provides = "BuildCraftAPI|core")
+package buildcraft.api.core;
+import cpw.mods.fml.common.API;

--- a/apis/buildcraft/api/gates/GateExpansionController.java
+++ b/apis/buildcraft/api/gates/GateExpansionController.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.gates;
+
+import java.util.List;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+
+import buildcraft.api.statements.IActionInternal;
+import buildcraft.api.statements.IStatement;
+import buildcraft.api.statements.IStatementParameter;
+import buildcraft.api.statements.ITriggerInternal;
+
+public abstract class GateExpansionController {
+
+	public final IGateExpansion type;
+	public final TileEntity pipeTile;
+
+	public GateExpansionController(IGateExpansion type, TileEntity pipeTile) {
+		this.pipeTile = pipeTile;
+		this.type = type;
+	}
+
+	public IGateExpansion getType() {
+		return type;
+	}
+
+	public boolean isActive() {
+		return false;
+	}
+
+	public void tick(IGate gate) {
+	}
+
+	public void startResolution() {
+	}
+
+	public boolean resolveAction(IStatement action) {
+		return false;
+	}
+
+	public boolean isTriggerActive(IStatement trigger, IStatementParameter[] parameters) {
+		return false;
+	}
+
+	public void addTriggers(List<ITriggerInternal> list) {
+	}
+
+	public void addActions(List<IActionInternal> list) {
+	}
+
+	public void writeToNBT(NBTTagCompound nbt) {
+	}
+
+	public void readFromNBT(NBTTagCompound nbt) {
+	}
+}

--- a/apis/buildcraft/api/gates/GateExpansions.java
+++ b/apis/buildcraft/api/gates/GateExpansions.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.gates;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public final class GateExpansions {
+
+	private static final Map<String, IGateExpansion> expansions = new HashMap<String, IGateExpansion>();
+	private static final ArrayList<IGateExpansion> expansionIDs = new ArrayList<IGateExpansion>();
+
+	private GateExpansions() {
+	}
+
+	public static void registerExpansion(IGateExpansion expansion) {
+		registerExpansion(expansion.getUniqueIdentifier(), expansion);
+	}
+
+	public static void registerExpansion(String identifier, IGateExpansion expansion) {
+		expansions.put(identifier, expansion);
+		expansionIDs.add(expansion);
+	}
+
+	public static IGateExpansion getExpansion(String identifier) {
+		return expansions.get(identifier);
+	}
+
+	public static Set<IGateExpansion> getExpansions() {
+		Set<IGateExpansion> set = new HashSet<IGateExpansion>();
+		set.addAll(expansionIDs);
+		return set;
+	}
+	
+	// The code below is used by networking.
+	
+	public static IGateExpansion getExpansionByID(int id) {
+		return expansionIDs.get(id);
+	}
+	
+	public static int getExpansionID(IGateExpansion expansion) {
+		return expansionIDs.indexOf(expansion);
+	}
+}

--- a/apis/buildcraft/api/gates/IGate.java
+++ b/apis/buildcraft/api/gates/IGate.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.gates;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+import buildcraft.api.transport.IPipe;
+
+public interface IGate {
+	@Deprecated
+	void setPulsing(boolean pulse);
+	
+	ForgeDirection getSide();
+
+	IPipe getPipe();
+}

--- a/apis/buildcraft/api/gates/IGateExpansion.java
+++ b/apis/buildcraft/api/gates/IGateExpansion.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.gates;
+
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.IIcon;
+
+public interface IGateExpansion {
+
+	String getUniqueIdentifier();
+
+	String getDisplayName();
+
+	GateExpansionController makeController(TileEntity pipeTile);
+
+	void registerBlockOverlay(IIconRegister iconRegister);
+
+	void registerItemOverlay(IIconRegister iconRegister);
+
+	IIcon getOverlayBlock();
+
+	IIcon getOverlayItem();
+}

--- a/apis/buildcraft/api/gates/package-info.java
+++ b/apis/buildcraft/api/gates/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+@API(apiVersion = "3.0", owner = "BuildCraftAPI|core", provides = "BuildCraftAPI|gates")
+package buildcraft.api.gates;
+import cpw.mods.fml.common.API;
+

--- a/apis/buildcraft/api/statements/ActionState.java
+++ b/apis/buildcraft/api/statements/ActionState.java
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.statements;
+
+public class ActionState {
+
+}

--- a/apis/buildcraft/api/statements/IActionExternal.java
+++ b/apis/buildcraft/api/statements/IActionExternal.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.statements;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public interface IActionExternal extends IStatement {
+
+	void actionActivate(TileEntity target, ForgeDirection side, IStatementContainer source, IStatementParameter[] parameters);
+	
+}

--- a/apis/buildcraft/api/statements/IActionInternal.java
+++ b/apis/buildcraft/api/statements/IActionInternal.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.statements;
+
+public interface IActionInternal extends IStatement {
+
+	void actionActivate(IStatementContainer source, IStatementParameter[] parameters);
+	
+}

--- a/apis/buildcraft/api/statements/IActionProvider.java
+++ b/apis/buildcraft/api/statements/IActionProvider.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.statements;
+
+import java.util.Collection;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public interface IActionProvider {
+
+	/**
+	 * Returns the list of actions that are available from the statement container holding the
+	 * gate.
+	 */
+	Collection<IActionInternal> getInternalActions(IStatementContainer container);
+
+	/**
+	 * Returns the list of actions available to a gate next to the given block.
+	 */
+	Collection<IActionExternal> getExternalActions(ForgeDirection side, TileEntity tile);
+}

--- a/apis/buildcraft/api/statements/IActionReceptor.java
+++ b/apis/buildcraft/api/statements/IActionReceptor.java
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.statements;
+
+public interface IActionReceptor {
+	void actionActivated(IStatement statement, IStatementParameter[] parameters);
+}

--- a/apis/buildcraft/api/statements/IOverrideDefaultStatements.java
+++ b/apis/buildcraft/api/statements/IOverrideDefaultStatements.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.statements;
+
+import java.util.List;
+
+public interface IOverrideDefaultStatements {
+	List<ITriggerExternal> overrideTriggers();
+	List<IActionExternal> overrideActions();
+}

--- a/apis/buildcraft/api/statements/IStatement.java
+++ b/apis/buildcraft/api/statements/IStatement.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.statements;
+
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.util.IIcon;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public interface IStatement {
+
+	/**
+	 * Every trigger needs a unique tag, it should be in the format of
+	 * "<modid>:<name>".
+	 *
+	 * @return the unique id
+	 */
+	String getUniqueTag();
+
+	@SideOnly(Side.CLIENT)
+	IIcon getIcon();
+
+	@SideOnly(Side.CLIENT)
+	void registerIcons(IIconRegister iconRegister);
+
+	/**
+	 * Return the maximum number of parameter this trigger can have, 0 if none.
+	 */
+	int maxParameters();
+
+	/**
+	 * Return the minimum number of parameter this trigger can have, 0 if none.
+	 */
+	int minParameters();
+
+	/**
+	 * Return the trigger description in the UI
+	 */
+	String getDescription();
+
+	/**
+	 * Create parameters for the trigger.
+	 */
+	IStatementParameter createParameter(int index);
+
+	/**
+	 * This returns the trigger after a left rotation. Used in particular in
+	 * blueprints orientation.
+	 */
+	IStatement rotateLeft();
+}

--- a/apis/buildcraft/api/statements/IStatementContainer.java
+++ b/apis/buildcraft/api/statements/IStatementContainer.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.statements;
+
+import net.minecraft.tileentity.TileEntity;
+
+/**
+ * This is implemented by objects containing Statements, such as
+ * Gates and TileEntities.
+ */
+public interface IStatementContainer {
+	TileEntity getTile();
+}

--- a/apis/buildcraft/api/statements/IStatementParameter.java
+++ b/apis/buildcraft/api/statements/IStatementParameter.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.statements;
+
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.IIcon;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public interface IStatementParameter {
+	
+	/**
+	 * Every parameter needs a unique tag, it should be in the format of
+	 * "<modid>:<name>".
+	 *
+	 * @return the unique id
+	 */
+	String getUniqueTag();
+	
+	@SideOnly(Side.CLIENT)
+	IIcon getIcon();
+
+	ItemStack getItemStack();
+
+	/**
+	 * Something that is initially unintuitive: you HAVE to
+	 * keep your icons as static variables, due to the fact
+	 * that every IStatementParameter is instantiated upon creation,
+	 * in opposition to IStatements which are singletons (due to the
+	 * fact that they, unlike Parameters, store no additional data)
+	 */
+	@SideOnly(Side.CLIENT)
+	void registerIcons(IIconRegister iconRegister);
+	
+	/**
+	 * Return the parameter description in the UI
+	 */
+	String getDescription();
+
+	void onClick(IStatementContainer source, IStatement stmt, ItemStack stack, StatementMouseClick mouse);
+
+	void readFromNBT(NBTTagCompound compound);
+
+	void writeToNBT(NBTTagCompound compound);
+
+	/**
+	 * This returns the parameter after a left rotation. Used in particular in
+	 * blueprints orientation.
+	 */
+	IStatementParameter rotateLeft();
+}

--- a/apis/buildcraft/api/statements/ITriggerExternal.java
+++ b/apis/buildcraft/api/statements/ITriggerExternal.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.statements;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public interface ITriggerExternal extends IStatement {
+
+	boolean isTriggerActive(TileEntity target, ForgeDirection side, IStatementContainer source, IStatementParameter[] parameters);
+	
+}

--- a/apis/buildcraft/api/statements/ITriggerInternal.java
+++ b/apis/buildcraft/api/statements/ITriggerInternal.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.statements;
+
+public interface ITriggerInternal extends IStatement {
+
+	boolean isTriggerActive(IStatementContainer source, IStatementParameter[] parameters);
+
+}

--- a/apis/buildcraft/api/statements/ITriggerProvider.java
+++ b/apis/buildcraft/api/statements/ITriggerProvider.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.statements;
+
+import java.util.Collection;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public interface ITriggerProvider {
+
+	/**
+	 * Returns the list of triggers that are available from the object holding the gate.
+	 */
+	Collection<ITriggerInternal> getInternalTriggers(IStatementContainer container);
+
+	/**
+	 * Returns the list of triggers available to a gate next to the given block.
+	 */
+	Collection<ITriggerExternal> getExternalTriggers(ForgeDirection side, TileEntity tile);
+
+}

--- a/apis/buildcraft/api/statements/StatementManager.java
+++ b/apis/buildcraft/api/statements/StatementManager.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.statements;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.tileentity.TileEntity;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public final class StatementManager {
+
+	public static Map<String, IStatement> statements = new HashMap<String, IStatement>();
+	public static Map<String, Class<? extends IStatementParameter>> parameters = new HashMap<String, Class<? extends IStatementParameter>>();
+	private static List<ITriggerProvider> triggerProviders = new LinkedList<ITriggerProvider>();
+	private static List<IActionProvider> actionProviders = new LinkedList<IActionProvider>();
+
+	/**
+	 * Deactivate constructor
+	 */
+	private StatementManager() {
+	}
+
+	public static void registerTriggerProvider(ITriggerProvider provider) {
+		if (provider != null && !triggerProviders.contains(provider)) {
+			triggerProviders.add(provider);
+		}
+	}
+
+	public static void registerActionProvider(IActionProvider provider) {
+		if (provider != null && !actionProviders.contains(provider)) {
+			actionProviders.add(provider);
+		}
+	}
+
+	public static void registerStatement(IStatement statement) {
+		statements.put(statement.getUniqueTag(), statement);
+	}
+
+	public static void registerParameterClass(Class<? extends IStatementParameter> param) {
+		parameters.put(createParameter(param).getUniqueTag(), param);
+	}
+	
+	@Deprecated
+	public static void registerParameterClass(String name, Class<? extends IStatementParameter> param) {
+		parameters.put(name, param);
+	}
+
+	public static List<ITriggerExternal> getExternalTriggers(ForgeDirection side, TileEntity entity) {
+		List<ITriggerExternal> result;
+
+		if (entity instanceof IOverrideDefaultStatements) {
+			result = ((IOverrideDefaultStatements) entity).overrideTriggers();
+			if (result != null) {
+				return result;
+			}
+		}
+		
+		result = new LinkedList<ITriggerExternal>();
+		
+		for (ITriggerProvider provider : triggerProviders) {
+			Collection<ITriggerExternal> toAdd = provider.getExternalTriggers(side, entity);
+
+			if (toAdd != null) {
+				for (ITriggerExternal t : toAdd) {
+					if (!result.contains(t)) {
+						result.add(t);
+					}
+				}
+			}
+		}
+
+		return result;
+	}
+
+	public static List<IActionExternal> getExternalActions(ForgeDirection side, TileEntity entity) {
+		List<IActionExternal> result = new LinkedList<IActionExternal>();
+
+		if (entity instanceof IOverrideDefaultStatements) {
+			result = ((IOverrideDefaultStatements) entity).overrideActions();
+			if (result != null) {
+				return result;
+			}
+		}
+		
+		for (IActionProvider provider : actionProviders) {
+			Collection<IActionExternal> toAdd = provider.getExternalActions(side, entity);
+
+			if (toAdd != null) {
+				for (IActionExternal t : toAdd) {
+					if (!result.contains(t)) {
+						result.add(t);
+					}
+				}
+			}
+		}
+
+		return result;
+	}
+
+	public static List<ITriggerInternal> getInternalTriggers(IStatementContainer container) {
+		List<ITriggerInternal> result = new LinkedList<ITriggerInternal>();
+
+		for (ITriggerProvider provider : triggerProviders) {
+			Collection<ITriggerInternal> toAdd = provider.getInternalTriggers(container);
+
+			if (toAdd != null) {
+				for (ITriggerInternal t : toAdd) {
+					if (!result.contains(t)) {
+						result.add(t);
+					}
+				}
+			}
+		}
+
+		return result;
+	}
+
+	public static List<IActionInternal> getInternalActions(IStatementContainer container) {
+		List<IActionInternal> result = new LinkedList<IActionInternal>();
+
+		for (IActionProvider provider : actionProviders) {
+			Collection<IActionInternal> toAdd = provider.getInternalActions(container);
+
+			if (toAdd != null) {
+				for (IActionInternal t : toAdd) {
+					if (!result.contains(t)) {
+						result.add(t);
+					}
+				}
+			}
+		}
+
+		return result;
+	}
+
+	public static IStatementParameter createParameter(String kind) {
+		return createParameter(parameters.get(kind));
+	}
+	
+	private static IStatementParameter createParameter(Class<? extends IStatementParameter> param) {
+		try {
+			return param.newInstance();
+		} catch (InstantiationException e) {
+			e.printStackTrace();
+		} catch (IllegalAccessException e) {
+			e.printStackTrace();
+		}
+
+		return null;
+	}
+	
+	/**
+	 * Generally, this function should be called by every mod implementing
+	 * the Statements API ***as a container*** (that is, adding its own gates)
+	 * on the client side from a given Item of choice.
+	 */
+	@SideOnly(Side.CLIENT)
+	public static void registerIcons(IIconRegister register) {
+		for (IStatement statement : statements.values()) {
+			statement.registerIcons(register);
+		}
+
+		for (Class<? extends IStatementParameter> parameter : parameters.values()) {
+			createParameter(parameter).registerIcons(register);
+		}
+	}
+}

--- a/apis/buildcraft/api/statements/StatementMouseClick.java
+++ b/apis/buildcraft/api/statements/StatementMouseClick.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.statements;
+
+public final class StatementMouseClick {
+	private int button;
+	private boolean shift;
+	
+	public StatementMouseClick(int button, boolean shift) {
+		this.button = button;
+		this.shift = shift;
+	}
+	
+	public boolean isShift() {
+		return shift;
+	}
+	
+	public int getButton() {
+		return button;
+	}
+}

--- a/apis/buildcraft/api/statements/StatementParameterItemStack.java
+++ b/apis/buildcraft/api/statements/StatementParameterItemStack.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.statements;
+
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.IIcon;
+
+public class StatementParameterItemStack implements IStatementParameter {
+	
+	protected ItemStack stack;
+
+	@Override
+	public IIcon getIcon() {
+		return null;
+	}
+
+	@Override
+	public ItemStack getItemStack() {
+		return stack;
+	}
+
+	@Override
+	public void onClick(IStatementContainer source, IStatement stmt, ItemStack stack, StatementMouseClick mouse) {
+		if (stack != null) {
+			this.stack = stack.copy();
+			this.stack.stackSize = 1;
+		}
+	}
+
+	@Override
+	public void writeToNBT(NBTTagCompound compound) {
+		if (stack != null) {
+			NBTTagCompound tagCompound = new NBTTagCompound();
+			stack.writeToNBT(tagCompound);
+			compound.setTag("stack", tagCompound);
+		}
+	}
+
+	@Override
+	public void readFromNBT(NBTTagCompound compound) {
+		stack = ItemStack.loadItemStackFromNBT(compound.getCompoundTag("stack"));
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (object instanceof StatementParameterItemStack) {
+			StatementParameterItemStack param = (StatementParameterItemStack) object;
+
+			return ItemStack.areItemStacksEqual(stack, param.stack)
+					&& ItemStack.areItemStackTagsEqual(stack, param.stack);
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public String getDescription() {
+		if (stack != null) {
+			return stack.getDisplayName();
+		} else {
+			return "";
+		}
+	}
+
+	@Override
+	public String getUniqueTag() {
+		return "buildcraft:stack";
+	}
+
+	@Override
+	public void registerIcons(IIconRegister iconRegister) {
+		
+	}
+
+	@Override
+	public IStatementParameter rotateLeft() {
+		return this;
+	}
+}

--- a/apis/buildcraft/api/statements/package-info.java
+++ b/apis/buildcraft/api/statements/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+@API(apiVersion = "1.0", owner = "BuildCraftAPI|core", provides = "BuildCraftAPI|statements")
+package buildcraft.api.statements;
+import cpw.mods.fml.common.API;
+

--- a/apis/buildcraft/api/transport/IExtractionHandler.java
+++ b/apis/buildcraft/api/transport/IExtractionHandler.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.transport;
+
+import net.minecraft.world.World;
+
+/**
+ * Implement and register with the PipeManager if you want to suppress connections from wooden pipes.
+ */
+public interface IExtractionHandler {
+
+	/**
+	 * Can this pipe extract items from the block located at these coordinates?
+	 * param extractor can be null
+	 */
+	boolean canExtractItems(Object extractor, World world, int i, int j, int k);
+
+	/**
+	 * Can this pipe extract liquids from the block located at these coordinates?
+	 * param extractor can be null
+	 */
+	boolean canExtractFluids(Object extractor, World world, int i, int j, int k);
+}

--- a/apis/buildcraft/api/transport/IPipe.java
+++ b/apis/buildcraft/api/transport/IPipe.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.transport;
+
+import net.minecraftforge.common.util.ForgeDirection;
+import buildcraft.api.gates.IGate;
+
+public interface IPipe {
+
+	int x();
+
+	int y();
+
+	int z();
+
+	IPipeTile getTile();
+
+	IGate getGate(ForgeDirection side);
+	
+	boolean hasGate(ForgeDirection side);
+	
+	boolean isWired(PipeWire wire);
+	
+	boolean isWireActive(PipeWire wire);
+}

--- a/apis/buildcraft/api/transport/IPipeConnection.java
+++ b/apis/buildcraft/api/transport/IPipeConnection.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.transport;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+import buildcraft.api.transport.IPipeTile.PipeType;
+
+public interface IPipeConnection {
+
+	enum ConnectOverride {
+
+		CONNECT, DISCONNECT, DEFAULT
+	};
+
+	/**
+	 * Allows you to override pipe connection logic.
+	 *
+	 * @param type
+	 * @param with
+	 * @return CONNECT to force a connection, DISCONNECT to force no connection,
+	 * and DEFAULT to let the pipe decide.
+	 */
+	ConnectOverride overridePipeConnection(PipeType type, ForgeDirection with);
+}

--- a/apis/buildcraft/api/transport/IPipePluggable.java
+++ b/apis/buildcraft/api/transport/IPipePluggable.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.transport;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+public interface IPipePluggable {
+	void writeToNBT(NBTTagCompound nbt);
+
+	void readFromNBT(NBTTagCompound nbt);
+
+	ItemStack[] getDropItems(IPipeTile pipe);
+
+	void onAttachedPipe(IPipeTile pipe, ForgeDirection direction);
+
+	void onDetachedPipe(IPipeTile pipe, ForgeDirection direction);
+
+	boolean blocking(IPipeTile pipe, ForgeDirection direction);
+
+	void invalidate();
+
+	void validate(IPipeTile pipe, ForgeDirection direction);
+}

--- a/apis/buildcraft/api/transport/IPipeTile.java
+++ b/apis/buildcraft/api/transport/IPipeTile.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.transport;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+import buildcraft.api.core.EnumColor;
+
+public interface IPipeTile {
+
+	public enum PipeType {
+
+		ITEM, FLUID, POWER, STRUCTURE;
+	}
+
+	PipeType getPipeType();
+
+	/**
+	 * Offers an ItemStack for addition to the pipe. Will be rejected if the
+	 * pipe doesn't accept items from that side.
+	 *
+	 * @param stack ItemStack offered for addition. Do not manipulate this!
+	 * @param doAdd If false no actual addition should take place. Implementors
+	 * should simulate.
+	 * @param from Orientation the ItemStack is offered from.
+	 * @param color The color of the item to be added to the pipe, or null for no color.
+	 * @return Amount of items used from the passed stack.
+	 */
+	int injectItem(ItemStack stack, boolean doAdd, ForgeDirection from, EnumColor color);
+
+	/**
+	 * Same as
+	 * {@link #injectItem(ItemStack, boolean, ForgeDirection, EnumColor)}
+	 * but with no color attribute.
+	 */
+	int injectItem(ItemStack stack, boolean doAdd, ForgeDirection from);
+
+	/**
+	 * True if the pipe is connected to the block/pipe in the specific direction
+	 * 
+	 * @param with
+	 * @return true if connect
+	 */
+	boolean isPipeConnected(ForgeDirection with);
+
+	TileEntity getAdjacentTile(ForgeDirection dir);
+	
+	IPipe getPipe();
+}

--- a/apis/buildcraft/api/transport/IStripesHandler.java
+++ b/apis/buildcraft/api/transport/IStripesHandler.java
@@ -1,0 +1,20 @@
+package buildcraft.api.transport;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public interface IStripesHandler {
+	public static enum StripesHandlerType {
+		ITEM_USE,
+		BLOCK_BREAK
+	}
+	
+	StripesHandlerType getType();
+	
+	boolean shouldHandle(ItemStack stack);
+	
+	boolean handle(World world, int x, int y, int z, ForgeDirection direction,
+			ItemStack stack, EntityPlayer player, IStripesPipe pipe);
+}

--- a/apis/buildcraft/api/transport/IStripesPipe.java
+++ b/apis/buildcraft/api/transport/IStripesPipe.java
@@ -1,0 +1,9 @@
+package buildcraft.api.transport;
+
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public interface IStripesPipe extends IPipe {
+	void sendItem(ItemStack itemStack, ForgeDirection direction);
+	void dropItem(ItemStack itemStack, ForgeDirection direction);
+}

--- a/apis/buildcraft/api/transport/PipeManager.java
+++ b/apis/buildcraft/api/transport/PipeManager.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.transport;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.world.World;
+
+public abstract class PipeManager {
+
+	public static List<IStripesHandler> stripesHandlers = new ArrayList<IStripesHandler>();
+	public static List<IExtractionHandler> extractionHandlers = new ArrayList<IExtractionHandler>();
+
+	public static void registerExtractionHandler(IExtractionHandler handler) {
+		extractionHandlers.add(handler);
+	}
+	
+	public static void registerStripesHandler(IStripesHandler handler) {
+		stripesHandlers.add(handler);
+	}
+
+	/**
+	 * param extractor can be null
+	 */
+	public static boolean canExtractItems(Object extractor, World world, int i, int j, int k) {
+		for (IExtractionHandler handler : extractionHandlers) {
+			if (!handler.canExtractItems(extractor, world, i, j, k)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * param extractor can be null
+	 */
+	public static boolean canExtractFluids(Object extractor, World world, int i, int j, int k) {
+		for (IExtractionHandler handler : extractionHandlers) {
+			if (!handler.canExtractFluids(extractor, world, i, j, k)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/apis/buildcraft/api/transport/PipeWire.java
+++ b/apis/buildcraft/api/transport/PipeWire.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+package buildcraft.api.transport;
+
+import java.util.Locale;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+public enum PipeWire {
+
+	RED, BLUE, GREEN, YELLOW;
+	public static Item item;
+	public static final PipeWire[] VALUES = values();
+
+	public PipeWire reverse() {
+		switch (this) {
+			case RED:
+				return YELLOW;
+			case BLUE:
+				return GREEN;
+			case GREEN:
+				return BLUE;
+			default:
+				return RED;
+		}
+	}
+
+	public String getTag() {
+		return name().toLowerCase(Locale.ENGLISH) + "PipeWire";
+	}
+
+	public String getColor() {
+		String name = this.toString().toLowerCase(Locale.ENGLISH);
+		char first = Character.toUpperCase(name.charAt(0));
+		return first + name.substring(1);
+	}
+
+	public ItemStack getStack() {
+		return getStack(1);
+	}
+
+	public ItemStack getStack(int qty) {
+		if (item == null) {
+			return null;
+		} else {
+			return new ItemStack(item, qty, ordinal());
+		}
+	}
+
+	public boolean isPipeWire(ItemStack stack) {
+		if (stack == null) {
+			return false;
+		} else if (stack.getItem() != item) {
+			return false;
+		} else {
+			return stack.getItemDamage() == ordinal();
+		}
+	}
+
+	public static PipeWire fromOrdinal(int ordinal) {
+		if (ordinal < 0 || ordinal >= VALUES.length) {
+			return RED;
+		} else {
+			return VALUES[ordinal];
+		}
+	}
+}

--- a/apis/buildcraft/api/transport/package-info.java
+++ b/apis/buildcraft/api/transport/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2011-2014, SpaceToad and the BuildCraft Team
+ * http://www.mod-buildcraft.com
+ *
+ * BuildCraft is distributed under the terms of the Minecraft Mod Public
+ * License 1.0, or MMPL. Please check the contents of the license located in
+ * http://www.mod-buildcraft.com/MMPL-1.0.txt
+ */
+@API(apiVersion = "2.1", owner = "BuildCraftAPI|core", provides = "BuildCraftAPI|transport")
+package buildcraft.api.transport;
+import cpw.mods.fml.common.API;
+

--- a/resources/assets/botania/lang/en_US.lang
+++ b/resources/assets/botania/lang/en_US.lang
@@ -1707,3 +1707,11 @@ botania.page.tcIntegration2=Helmets of Revealing (works with any Botania helm)
 botania.page.tcIntegration3=Carrying on, &4Mana&0 can also serve as an interesting type of Ink. Infusing a set of black &1Scribing Tools&0 with &4Mana&0 from a &1Mana Pool&0 allows for them to use said &4Mana&0 as their source of color.<br>Refilling these tools works similarly to a &1Mana Tablet&0, done by tossing it on top of the pool.
 botania.page.tcIntegration4=Making the &1Botanurgist's Inkwell
 botania.page.tcIntegration5=Last but not least, there's a few varied resources or constructs that can work as paraphernalia for an &1Infusion Altar&0, to lower its' instability.<br>These come in the form of &1Glimmering Flowers, Floating Flowers and any variety of Pylons&0.
+
+# -- BUILDCRAFT TRIGGER API INTEGRATION
+botania.trigger.manaDetector=Mana Burst
+botania.trigger.manaEmpty=Mana Empty
+botania.trigger.manaSpace=Space for Mana
+botania.trigger.manaContains=Contains Mana
+botania.trigger.manaFull=Mana Full
+botania.trigger.runeAltarCanCraft=Altar Can Craft


### PR DESCRIPTION
Some notes:
- A few textures need to be made. In textures/items: triggers/manaDetector, triggers/manaEmpty, triggers/manaContains, triggers/manaSpace, triggers/manaFull and triggers/runeAltarCanCraft.
- A few lines of code now depend on the existence of buildcraft.api.transport, which carries in the other APIs. It would be nice if those were bundled in the JAR.
