### PR TITLE
Add DarkOre to OreChid weights

### DIFF
--- a/src/main/java/vazkii/botania/api/BotaniaAPI.java
+++ b/src/main/java/vazkii/botania/api/BotaniaAPI.java
@@ -116,6 +116,7 @@ public final class BotaniaAPI {
 		addOreWeight("oreCoal", 46525); // Vanilla
 		addOreWeight("oreCooperite", 5); // GregTech
 		addOreWeight("oreCopper", 8325); // IC2, Thermal Expansion, Tinkers' Construct, etc.
+		addOreWeight("oreDark", 1350); // EvilCraft
 		addOreWeight("oreDarkIron", 1700); // Factorization
 		addOreWeight("oreDiamond", 1265); // Vanilla
 		addOreWeight("oreEmerald", 780); // Vanilla

--- a/src/main/java/vazkii/botania/api/package-info.java
+++ b/src/main/java/vazkii/botania/api/package-info.java
@@ -1,4 +1,4 @@
-@API(owner = "Botania", apiVersion = "32", provides = "BotaniaAPI")
+@API(owner = "Botania", apiVersion = "33", provides = "BotaniaAPI")
 package vazkii.botania.api;
 import cpw.mods.fml.common.API;
 


### PR DESCRIPTION
It seemed easier this way than to include the Botania API to only call one of code.