### PR TITLE
Make Mana Bursts use the correct source coordinates when fired from a Blaster. Fixes #621

### DIFF
--- a/src/main/java/vazkii/botania/common/entity/EntityManaBurst.java
+++ b/src/main/java/vazkii/botania/common/entity/EntityManaBurst.java
@@ -110,7 +110,7 @@ public class EntityManaBurst extends EntityThrowable implements IManaBurst {
 	public EntityManaBurst(EntityPlayer player) {
 		this(player.worldObj);
 
-		setBurstSourceCoords(0, -1, 0);
+		setBurstSourceCoords((int) player.posX, (int) (player.posY + player.getEyeHeight()),(int) player.posZ);
 		setLocationAndAngles(player.posX, player.posY + player.getEyeHeight(), player.posZ, player.rotationYaw + 180, -player.rotationPitch);
 
 		posX -= MathHelper.cos((rotationYaw + 180) / 180.0F * (float) Math.PI) * 0.16F;


### PR DESCRIPTION
Make the constructor set the burst source as the players coordinates, when its initialized with a EntityPlayer object.