### PR TITLE
Fix Bore Warp Lens not dropping blocks if fired from Mana Blaster.

### DIFF
--- a/src/main/java/vazkii/botania/common/entity/EntityManaBurst.java
+++ b/src/main/java/vazkii/botania/common/entity/EntityManaBurst.java
@@ -71,6 +71,8 @@ public class EntityManaBurst extends EntityThrowable implements IManaBurst {
 	List<String> alreadyCollidedAt = new ArrayList();
 
 	boolean fullManaLastTick = true;
+    
+	private EntityPlayer sourcePlayer;
 
 	int _ticksExisted = 0;
 	boolean scanBeam = false;
@@ -109,7 +111,9 @@ public class EntityManaBurst extends EntityThrowable implements IManaBurst {
 
 	public EntityManaBurst(EntityPlayer player) {
 		this(player.worldObj);
-
+        
+        	sourcePlayer = player;
+        
 		setBurstSourceCoords(0, -1, 0);
 		setLocationAndAngles(player.posX, player.posY + player.getEyeHeight(), player.posZ, player.rotationYaw + 180, -player.rotationPitch);
 
@@ -741,6 +745,8 @@ public class EntityManaBurst extends EntityThrowable implements IManaBurst {
 
 		return null;
 	}
+
+	public EntityPlayer getSourcePlayer() { return sourcePlayer; }
 
 	final int motionStart = dataWatcherStart + 10;
 

--- a/src/main/java/vazkii/botania/common/item/lens/LensMine.java
+++ b/src/main/java/vazkii/botania/common/item/lens/LensMine.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.projectile.EntityThrowable;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
@@ -26,6 +27,7 @@ import vazkii.botania.api.internal.IManaBurst;
 import vazkii.botania.api.mana.IManaBlock;
 import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.core.handler.ConfigHandler;
+import vazkii.botania.common.entity.EntityManaBurst;
 import vazkii.botania.common.item.ModItems;
 
 public class LensMine extends Lens {
@@ -62,13 +64,24 @@ public class LensMine extends Lens {
 					if(ConfigHandler.blockBreakParticles)
 						entity.worldObj.playAuxSFX(2001, x, y, z, Block.getIdFromBlock(block) + (meta << 12));
 
-					int dropX = warp ? coords.posX : x;
-					int dropY = warp ? coords.posY : y;
-					int dropZ = warp ? coords.posZ : z;
+					if(warp && coords.posY == -1) {
+						if(burst instanceof EntityManaBurst) {
+							EntityPlayer sourcePlayer = ((EntityManaBurst) burst).getSourcePlayer();
+							if(sourcePlayer != null) {
+								for (ItemStack stack_ : items) {
+									sourcePlayer.inventory.addItemStackToInventory(stack_);
+									if(stack_.stackSize > 0) world.spawnEntityInWorld(new EntityItem(world, sourcePlayer.posX, sourcePlayer.posY + sourcePlayer.getEyeHeight(), sourcePlayer.posZ, stack_));								}
+							}
+						}
+                			 }
+                    			else {
+						int dropX = warp ? coords.posX : x;
+						int dropY = warp ? coords.posY : y;
+						int dropZ = warp ? coords.posZ : z;
 
-					for(ItemStack stack_ : items)
-						world.spawnEntityInWorld(new EntityItem(world, dropX + 0.5, dropY + 0.5, dropZ + 0.5, stack_));
-
+						for(ItemStack stack_ : items)
+							world.spawnEntityInWorld(new EntityItem(world, dropX + 0.5, dropY + 0.5, dropZ + 0.5, stack_));
+                    			}
 					burst.setMana(mana - 24);
 				}
 			}


### PR DESCRIPTION
- Add getter to EntityManaBurst to get source player if burst was initialized with a EntityPlayer object.
- Make LensMine add mined items to inventory of EntityPlayer who fired burst, drop on player coords if inventory is full.

I'm casting to EntityManaBurst because at this point, I am reluctant to change anything in the API, although IManaBurst appears to be internal?