### PR TITLE
Fixes rendering default Loki/Aesir origin...

### DIFF
--- a/src/main/java/vazkii/botania/client/core/handler/BoundTileRenderer.java
+++ b/src/main/java/vazkii/botania/client/core/handler/BoundTileRenderer.java
@@ -76,7 +76,7 @@ public final class BoundTileRenderer {
 
 				if(stackInSlot.getItem() instanceof IExtendedWireframeCoordinateListProvider) {
 					ChunkCoordinates coords = ((IExtendedWireframeCoordinateListProvider) stackInSlot.getItem()).getSourceWireframe(player, stackInSlot);
-					if(coords != null)
+					if(coords != null && coords.y > -1)
 						renderBlockOutlineAt(coords, color, 5F);
 				}
 			}


### PR DESCRIPTION
wireframe, and doesn't break anything else, as all outlines will be in the world (greater than y=-1) closes #872