### PR TITLE
Fix Star Signs Typo

### DIFF
--- a/src/main/resources/assets/botania/lang/en_US.lang
+++ b/src/main/resources/assets/botania/lang/en_US.lang
@@ -156,7 +156,7 @@ botania.rank4=&dS
 botania.rank5=&6SS
 
 # ZODIAC SIGNS
-botania.sign0=Aires
+botania.sign0=Aries
 botania.sign1=Taurus
 botania.sign2=Gemini
 botania.sign3=Cancer


### PR DESCRIPTION
I noticed that Aries was spelled incorrectly on the Eye of the Flugal, so I fixed it.