### PR TITLE
Added null checks when accessing item frames...

### DIFF
--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaFunnel.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaFunnel.java
@@ -70,9 +70,12 @@ public class TileCorporeaFunnel extends TileCorporeaBase {
 			for(EntityItemFrame frame : frames) {
 				int orientation = frame.hangingDirection;
 				if(orientationToDir[orientation] == dir.ordinal()) {
-					ItemStack copy = frame.getDisplayedItem().copy();
-					copy.stackSize = rotationToStackSize[frame.getRotation()];
-					filter.add(copy);
+					ItemStack displayItem = frame.getDisplayedItem()
+					if(displayItem) {
+						ItemStack copy = displayItem.copy();
+						copy.stackSize = rotationToStackSize[frame.getRotation()];
+						filter.add(copy);
+					}
 				}
 			}
 		}

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaInterceptor.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaInterceptor.java
@@ -85,8 +85,9 @@ public class TileCorporeaInterceptor extends TileCorporeaBase implements ICorpor
 			List<EntityItemFrame> frames = worldObj.getEntitiesWithinAABB(EntityItemFrame.class, AxisAlignedBB.getBoundingBox(xCoord + dir.offsetX, yCoord + dir.offsetY, zCoord + dir.offsetZ, xCoord + dir.offsetX + 1, yCoord + dir.offsetY + 1, zCoord + dir.offsetZ + 1));
 			for(EntityItemFrame frame : frames) {
 				int orientation = frame.hangingDirection;
-				if(orientationToDir[orientation] == dir.ordinal())
-					filter.add(frame.getDisplayedItem());
+				ItemStack displayItem = frame.getDisplayedItem()
+				if(orientationToDir[orientation] == dir.ordinal() && displayItem)
+					filter.add(displayItem);
 			}
 		}
 


### PR DESCRIPTION
from coporea things
1 commit for interceptor, 1 commit for funnel

theory is that frame.getDisplayedItem() returns null or empty or something weird when frame is empty, so if(frame.getDisplayedItem()){CODE} replacing CODE should work 
closes #897 