### PR TITLE
Finally Terra Helm crafting closing #766

### DIFF
--- a/src/main/java/vazkii/botania/common/crafting/ModCraftingRecipes.java
+++ b/src/main/java/vazkii/botania/common/crafting/ModCraftingRecipes.java
@@ -1727,11 +1727,9 @@ public final class ModCraftingRecipes {
 
 		// Revealing Helmet Recipes
 		if(Botania.thaumcraftLoaded) {
-			Item goggles = (Item) Item.itemRegistry.getObject("Thaumcraft:ItemGoggles");
-			GameRegistry.addShapelessRecipe(new ItemStack(ModItems.manasteelHelmRevealing), new ItemStack(ModItems.manasteelHelm), new ItemStack(goggles));
+			GameRegistry.addRecipe(new HelmRevealingRecipe());
+			RecipeSorter.register("botania:helmRevealing", HelmRevealingRecipe.class, Category.SHAPELESS, "");
 			recipeHelmetOfRevealing = BotaniaAPI.getLatestAddedRecipe();
-			GameRegistry.addShapelessRecipe(new ItemStack(ModItems.terrasteelHelmRevealing), new ItemStack(ModItems.terrasteelHelm), new ItemStack(goggles));
-			GameRegistry.addShapelessRecipe(new ItemStack(ModItems.elementiumHelmRevealing), new ItemStack(ModItems.elementiumHelm), new ItemStack(goggles));
 		}
 
 		// Slab & Stair Recipes

--- a/src/main/java/vazkii/botania/common/crafting/recipe/HelmRevealingRecipe.java
+++ b/src/main/java/vazkii/botania/common/crafting/recipe/HelmRevealingRecipe.java
@@ -18,6 +18,9 @@ import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.equipment.armor.manasteel.ItemManasteelHelm;
 import vazkii.botania.common.item.equipment.armor.terrasteel.ItemTerrasteelHelm;
 import vazkii.botania.common.item.equipment.armor.elementium.ItemElementiumHelm;
+import vazkii.botania.common.item.interaction.thaumcraft.ItemElementiumHelmRevealing;
+import vazkii.botania.common.item.interaction.thaumcraft.ItemManasteelHelmRevealing;
+import vazkii.botania.common.item.interaction.thaumcraft.ItemTerrasteelHelmRevealing;
 
 public class HelmRevealingRecipe implements IRecipe {
 
@@ -56,13 +59,21 @@ public class HelmRevealingRecipe implements IRecipe {
 			return null;
 
 		ItemStack helmCopy = Helm.copy();
-		ItemStack newHelm = 
-		return terraPickCopy;
+		switch (checkHelm(helmCopy)):
+			case 1:	ItemStack newHelm = new ItemManasteelHelmRevealing(helmCopy);
+				break;
+			case 2: ItemStack newHelm = new ItemTerrasteelHelmRevealing(helmCopy);
+				break;
+			case 3: ItemStack newHelm = new ItemElementiumHelmRevealing(helmCopy);
+				break;
+			default: ItemStack newHelm = null;
+				break;
+		return newHelm;
 	}
 
 	@Override
 	public int getRecipeSize() {
-		return 10;
+		return 10; //WTF does this do?
 	}
 
 	@Override
@@ -70,10 +81,11 @@ public class HelmRevealingRecipe implements IRecipe {
 		return null;
 	}
 	
-	private boolean checkHelm(ItemStack helmStack){
+	private int checkHelm(ItemStack helmStack) { //Tried to do a switch/case but got too complex
 	if(helmStack instanceof ItemManasteelHelm){return 1;}
-	if(helmStack instanceof ItemManasteelHelm){return 1;}
-	return (helmStack instanceof ItemManasteelHelm || helmStack instanceof ItemTerrasteelHelm || helmStack instanceof ItemElementiumHelm);
+	if(helmStack instanceof ItemTerrasteelHelm){return 2;}
+	if(helmStack instanceof ItemElementiumHelm){return 3;}
+	return 0;
 	}
 
 }

--- a/src/main/java/vazkii/botania/common/crafting/recipe/HelmRevealingRecipe.java
+++ b/src/main/java/vazkii/botania/common/crafting/recipe/HelmRevealingRecipe.java
@@ -1,0 +1,79 @@
+/**
+ * This class was created by <Lazersmoke>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ * 
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ * 
+ * File Created @ [May 6, 2015, 9:45:56 PM (GMT)]
+ */
+package vazkii.botania.common.crafting.recipe;
+
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.world.World;
+import vazkii.botania.common.item.ModItems;
+import vazkii.botania.common.item.equipment.armor.manasteel.ItemManasteelHelm;
+import vazkii.botania.common.item.equipment.armor.terrasteel.ItemTerrasteelHelm;
+import vazkii.botania.common.item.equipment.armor.elementium.ItemElementiumHelm;
+
+public class HelmRevealingRecipe implements IRecipe {
+
+	@Override
+	public boolean matches(InventoryCrafting var1, World var2) {
+		boolean foundGoggles = false;
+		boolean foundHelm = false;
+
+		for(int i = 0; i < var1.getSizeInventory(); i++) {
+			ItemStack stack = var1.getStackInSlot(i);
+			if(stack != null) {
+				if(checkIfHelm(stack))
+					foundHelm = true;
+
+				else if(stack.getItem() == (Item) Item.itemRegistry.getObject("Thaumcraft:ItemGoggles");)
+					foundGoggles = true;
+
+				else return false; // Found an invalid item, breaking the recipe
+			}
+		}
+
+		return foundGoggles && foundHelm;
+	}
+
+	@Override
+	public ItemStack getCraftingResult(InventoryCrafting var1) {
+		ItemStack Helm = null;
+
+		for(int i = 0; i < var1.getSizeInventory(); i++) {
+			ItemStack stack = var1.getStackInSlot(i);
+			if(stack != null && checkIfHelm(stack))
+				Helm = stack;
+		}
+
+		if(Helm == null)
+			return null;
+
+		ItemStack helmCopy = Helm.copy();
+		ItemStack newHelm = 
+		return terraPickCopy;
+	}
+
+	@Override
+	public int getRecipeSize() {
+		return 10;
+	}
+
+	@Override
+	public ItemStack getRecipeOutput() {
+		return null;
+	}
+	
+	private boolean checkHelm(ItemStack helmStack){
+	if(helmStack instanceof ItemManasteelHelm){return 1;}
+	if(helmStack instanceof ItemManasteelHelm){return 1;}
+	return (helmStack instanceof ItemManasteelHelm || helmStack instanceof ItemTerrasteelHelm || helmStack instanceof ItemElementiumHelm);
+	}
+
+}

--- a/src/main/java/vazkii/botania/common/item/equipment/armor/terrasteel/ItemTerrasteelHelm.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/armor/terrasteel/ItemTerrasteelHelm.java
@@ -53,8 +53,6 @@ public class ItemTerrasteelHelm extends ItemTerrasteelArmor implements IManaDisc
 
 	public ItemTerrasteelHelm(String name) {
 		super(0, name);
-		GameRegistry.addRecipe(new TerrasteelHelmRevealingRecipe());
-		RecipeSorter.register("botania:terraHelmRevealing", TerrasteelHelmRevealingRecipe.class, Category.SHAPELESS, "");
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/item/equipment/armor/terrasteel/ItemTerrasteelHelm.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/armor/terrasteel/ItemTerrasteelHelm.java
@@ -53,6 +53,8 @@ public class ItemTerrasteelHelm extends ItemTerrasteelArmor implements IManaDisc
 
 	public ItemTerrasteelHelm(String name) {
 		super(0, name);
+		GameRegistry.addRecipe(new TerrasteelHelmRevealingRecipe());
+		RecipeSorter.register("botania:terraHelmRevealing", TerrasteelHelmRevealingRecipe.class, Category.SHAPELESS, "");
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/item/interaction/thaumcraft/ItemElementiumHelmRevealing.java
+++ b/src/main/java/vazkii/botania/common/item/interaction/thaumcraft/ItemElementiumHelmRevealing.java
@@ -28,6 +28,13 @@ public class ItemElementiumHelmRevealing extends ItemElementiumHelm implements I
 		super(LibItemNames.ELEMENTIUM_HELM_R);
 	}
 
+	public ItemElementiumHelmRevealing(ItemElementiumHelm oldHelm) { //Used when crafting
+
+		super(LibItemNames.ELEMENTIUM_HELM_R);
+
+
+	}
+
 	@Override
 	public boolean showNodes(ItemStack itemstack, EntityLivingBase player) {
 		return true;

--- a/src/main/java/vazkii/botania/common/item/interaction/thaumcraft/ItemElementiumHelmRevealing.java
+++ b/src/main/java/vazkii/botania/common/item/interaction/thaumcraft/ItemElementiumHelmRevealing.java
@@ -32,6 +32,7 @@ public class ItemElementiumHelmRevealing extends ItemElementiumHelm implements I
 
 		super(LibItemNames.ELEMENTIUM_HELM_R);
 
+		ItemNBTHelper.injectNBT(this, ItemNBTHelper.getNBT(oldHelm)); //Nuke the defaults and add the old
 
 	}
 

--- a/src/main/java/vazkii/botania/common/item/interaction/thaumcraft/ItemManasteelHelmRevealing.java
+++ b/src/main/java/vazkii/botania/common/item/interaction/thaumcraft/ItemManasteelHelmRevealing.java
@@ -28,6 +28,14 @@ public class ItemManasteelHelmRevealing extends ItemManasteelHelm implements IGo
 		super(LibItemNames.MANASTEEL_HELM_R);
 	}
 
+	public ItemManasteelHelmRevealing(ItemManasteelHelm oldHelm) { //Used when crafting
+
+		super(LibItemNames.MANASTEEL_HELM_R);
+
+		ItemNBTHelper.injectNBT(this, ItemNBTHelper.getNBT(oldHelm)); //Nuke the defaults and add the old
+
+	}
+
 	@Override
 	public boolean showNodes(ItemStack itemstack, EntityLivingBase player) {
 		return true;

--- a/src/main/java/vazkii/botania/common/item/interaction/thaumcraft/ItemTerrasteelHelmRevealing.java
+++ b/src/main/java/vazkii/botania/common/item/interaction/thaumcraft/ItemTerrasteelHelmRevealing.java
@@ -28,6 +28,14 @@ public class ItemTerrasteelHelmRevealing extends ItemTerrasteelHelm implements I
 		super(LibItemNames.TERRASTEEL_HELM_R);
 	}
 
+	public ItemTerrasteelHelmRevealing(ItemTerrasteelHelm oldHelm) { //Used when crafting
+
+		super(LibItemNames.TERRASTEEL_HELM_R);
+
+		ItemNBTHelper.injectNBT(this, ItemNBTHelper.getNBT(oldHelm)); //Nuke the defaults and add the old
+
+	}
+	
 	@Override
 	public boolean showNodes(ItemStack itemstack, EntityLivingBase player) {
 		return true;


### PR DESCRIPTION
I added a crafting handler for Helm's of revealing that copy the NBT from the input helm to the output helm. I am only 40% sure that this will not completely break something, but if it does then blame [my cat](http://popcorn.no-ip.info/Ninja%20Flail.gif). The class was derived from the Terra Shatterer Tipping recipe FYI. #766 