### PR TITLE
Finally Helm Revealing crafting closing #766

### DIFF
--- a/src/main/java/vazkii/botania/client/core/handler/BoundTileRenderer.java
+++ b/src/main/java/vazkii/botania/client/core/handler/BoundTileRenderer.java
@@ -76,7 +76,7 @@ public final class BoundTileRenderer {
 
 				if(stackInSlot.getItem() instanceof IExtendedWireframeCoordinateListProvider) {
 					ChunkCoordinates coords = ((IExtendedWireframeCoordinateListProvider) stackInSlot.getItem()).getSourceWireframe(player, stackInSlot);
-					if(coords != null && coords.y > -1)
+					if(coords != null && coords.posY > -1)
 						renderBlockOutlineAt(coords, color, 5F);
 				}
 			}

--- a/src/main/java/vazkii/botania/common/crafting/ModCraftingRecipes.java
+++ b/src/main/java/vazkii/botania/common/crafting/ModCraftingRecipes.java
@@ -21,6 +21,9 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.oredict.RecipeSorter;
+import net.minecraftforge.oredict.RecipeSorter.Category;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 import vazkii.botania.api.BotaniaAPI;
@@ -29,10 +32,12 @@ import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.block.ModFluffBlocks;
 import vazkii.botania.common.block.tile.TileCraftCrate;
 import vazkii.botania.common.core.handler.ConfigHandler;
+import vazkii.botania.common.crafting.recipe.HelmRevealingRecipe;
 import vazkii.botania.common.item.ItemSignalFlare;
 import vazkii.botania.common.item.ItemTwigWand;
 import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.lib.LibOreDict;
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.registry.GameRegistry;
 
 public final class ModCraftingRecipes {
@@ -201,6 +206,7 @@ public final class ModCraftingRecipes {
 	public static IRecipe recipeRegenIvy;
 	public static IRecipe recipeUltraSpreader;
 	public static IRecipe recipeHelmetOfRevealing;
+	public static IRecipe recipeFakeHelmetOfRevealing;
 	public static IRecipe recipeVial;
 	public static IRecipe recipeFlask;
 	public static IRecipe recipeBrewery;
@@ -256,7 +262,7 @@ public final class ModCraftingRecipes {
 	public static IRecipe recipeBlazeBlock;
 	public static List<IRecipe> recipesAltarMeta;
 	public static IRecipe recipeCorporeaCrystalCube;
-
+	private static ItemStack impossibleHelm;
 	public static void init() {
 		// Lexicon Recipe
 		addShapelessOreDictRecipe(new ItemStack(ModItems.lexicon), "treeSapling", Items.book);
@@ -1727,11 +1733,10 @@ public final class ModCraftingRecipes {
 
 		// Revealing Helmet Recipes
 		if(Botania.thaumcraftLoaded) {
-			Item goggles = (Item) Item.itemRegistry.getObject("Thaumcraft:ItemGoggles");
-			GameRegistry.addShapelessRecipe(new ItemStack(ModItems.manasteelHelmRevealing), new ItemStack(ModItems.manasteelHelm), new ItemStack(goggles));
-			recipeHelmetOfRevealing = BotaniaAPI.getLatestAddedRecipe();
-			GameRegistry.addShapelessRecipe(new ItemStack(ModItems.terrasteelHelmRevealing), new ItemStack(ModItems.terrasteelHelm), new ItemStack(goggles));
-			GameRegistry.addShapelessRecipe(new ItemStack(ModItems.elementiumHelmRevealing), new ItemStack(ModItems.elementiumHelm), new ItemStack(goggles));
+			impossibleHelm = new ItemStack(ModItems.manasteelHelm);
+			impossibleHelm.setItemDamage(5);
+			GameRegistry.addShapelessRecipe(new ItemStack(ModItems.manasteelHelmRevealing), impossibleHelm, (Item) Item.itemRegistry.getObject("Thaumcraft:ItemGoggles"));
+			recipeFakeHelmetOfRevealing = BotaniaAPI.getLatestAddedRecipe();
 		}
 
 		// Slab & Stair Recipes

--- a/src/main/java/vazkii/botania/common/crafting/recipe/HelmRevealingRecipe.java
+++ b/src/main/java/vazkii/botania/common/crafting/recipe/HelmRevealingRecipe.java
@@ -1,0 +1,98 @@
+/**
+ * This class was created by <Lazersmoke>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ * 
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ * 
+ * File Created @ [May 6, 2015, 9:45:56 PM (GMT)]
+ */
+package vazkii.botania.common.crafting.recipe;
+
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Item;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.world.World;
+import vazkii.botania.common.item.ModItems;
+import vazkii.botania.common.core.helper.ItemNBTHelper;
+import net.minecraft.nbt.NBTTagList;
+
+public class HelmRevealingRecipe implements IRecipe {
+
+	@Override
+	public boolean matches(InventoryCrafting var1, World var2) {
+		
+		boolean foundGoggles = false;
+		boolean foundHelm = false;
+		for(int i = 0; i < var1.getSizeInventory(); i++) {
+			ItemStack stack = var1.getStackInSlot(i);
+			if(stack != null) {
+				if(checkHelm(stack) != 0)
+					foundHelm = true;
+
+				else if(stack.getItem() == (Item) Item.itemRegistry.getObject("Thaumcraft:ItemGoggles"))
+					foundGoggles = true;
+
+				else return false; // Found an invalid item, breaking the recipe
+			}
+		}
+		return foundGoggles && foundHelm;
+	}
+
+	@Override
+	public ItemStack getCraftingResult(InventoryCrafting var1) {
+		ItemStack helm = null;
+
+		for(int i = 0; i < var1.getSizeInventory(); i++) {
+			ItemStack stack = var1.getStackInSlot(i);
+			if(stack != null && checkHelm(stack) != 0)
+				helm = stack;
+		}
+
+		if(helm == null)
+			return null;
+
+		ItemStack helmCopy = helm.copy();
+		ItemStack newHelm;
+		switch (checkHelm(helmCopy)) {
+			case 1:	newHelm = new ItemStack(ModItems.manasteelHelmRevealing);
+				break;
+			case 2: newHelm = new ItemStack(ModItems.terrasteelHelmRevealing);
+				break;
+			case 3: newHelm = new ItemStack(ModItems.elementiumHelmRevealing);
+				break;
+			default: newHelm = null;
+				break;
+		}
+		for(int i = 0; i < 6; i++){
+			if(ItemNBTHelper.getBoolean(helmCopy, "AncientWill" + i, false)){
+				ItemNBTHelper.setBoolean(newHelm, "AncientWill" + i, true);
+			}
+		}
+		NBTTagList enchList = ItemNBTHelper.getList(helmCopy, "ench", 10, true);
+		if(enchList != null){
+			ItemNBTHelper.setList(newHelm, "ench", enchList);
+		}
+		return newHelm;
+	}
+
+	@Override
+	public int getRecipeSize() {
+		return 10;
+	}
+
+	@Override
+	public ItemStack getRecipeOutput() {
+		return null;
+	}
+	
+	private int checkHelm(ItemStack helmStack) {
+		if(helmStack.getUnlocalizedName().contains("item.manasteelHelm") && !helmStack.getUnlocalizedName().contains("Reveal")){return 1;}
+		if(helmStack.getUnlocalizedName().contains("item.terrasteelHelm") && !helmStack.getUnlocalizedName().contains("Reveal")){return 2;}
+		if(helmStack.getUnlocalizedName().contains("item.elementiumHelm") && !helmStack.getUnlocalizedName().contains("Reveal")){return 3;}
+		return 0;
+	}
+
+}

--- a/src/main/java/vazkii/botania/common/item/interaction/thaumcraft/ItemElementiumHelmRevealing.java
+++ b/src/main/java/vazkii/botania/common/item/interaction/thaumcraft/ItemElementiumHelmRevealing.java
@@ -12,11 +12,14 @@ package vazkii.botania.common.item.interaction.thaumcraft;
 
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
 import thaumcraft.api.IGoggles;
 import thaumcraft.api.nodes.IRevealer;
 import vazkii.botania.client.lib.LibResources;
+import vazkii.botania.common.core.helper.ItemNBTHelper;
 import vazkii.botania.common.item.equipment.armor.elementium.ItemElementiumHelm;
 import vazkii.botania.common.lib.LibItemNames;
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Optional;
 
 @Optional.InterfaceList({

--- a/src/main/java/vazkii/botania/common/item/interaction/thaumcraft/ItemManasteelHelmRevealing.java
+++ b/src/main/java/vazkii/botania/common/item/interaction/thaumcraft/ItemManasteelHelmRevealing.java
@@ -12,12 +12,21 @@ package vazkii.botania.common.item.interaction.thaumcraft;
 
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.oredict.RecipeSorter;
+import net.minecraftforge.oredict.RecipeSorter.Category;
 import thaumcraft.api.IGoggles;
 import thaumcraft.api.nodes.IRevealer;
+import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.client.lib.LibResources;
+import vazkii.botania.common.core.helper.ItemNBTHelper;
+import vazkii.botania.common.crafting.recipe.HelmRevealingRecipe;
 import vazkii.botania.common.item.equipment.armor.manasteel.ItemManasteelHelm;
 import vazkii.botania.common.lib.LibItemNames;
+import vazkii.botania.common.crafting.ModCraftingRecipes;
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.common.registry.GameRegistry;
 
 @Optional.InterfaceList({
 	@Optional.Interface(modid = "Thaumcraft", iface = "thaumcraft.api.IGoggles", striprefs = true),
@@ -26,6 +35,11 @@ public class ItemManasteelHelmRevealing extends ItemManasteelHelm implements IGo
 
 	public ItemManasteelHelmRevealing() {
 		super(LibItemNames.MANASTEEL_HELM_R);
+		GameRegistry.addRecipe(new HelmRevealingRecipe());
+		ModCraftingRecipes.recipeHelmetOfRevealing = BotaniaAPI.getLatestAddedRecipe();
+		//RecipeSorter.register("botania:helmRevealing", HelmRevealingRecipe.class, Category.SHAPELESS, "");
+		MinecraftForge.EVENT_BUS.register(this);
+		FMLCommonHandler.instance().bus().register(this);
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/item/interaction/thaumcraft/ItemTerrasteelHelmRevealing.java
+++ b/src/main/java/vazkii/botania/common/item/interaction/thaumcraft/ItemTerrasteelHelmRevealing.java
@@ -12,12 +12,20 @@ package vazkii.botania.common.item.interaction.thaumcraft;
 
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.oredict.RecipeSorter;
+import net.minecraftforge.oredict.RecipeSorter.Category;
 import thaumcraft.api.IGoggles;
 import thaumcraft.api.nodes.IRevealer;
 import vazkii.botania.client.lib.LibResources;
+import vazkii.botania.common.core.helper.ItemNBTHelper;
+import vazkii.botania.common.crafting.recipe.TerraPickTippingRecipe;
 import vazkii.botania.common.item.equipment.armor.terrasteel.ItemTerrasteelHelm;
 import vazkii.botania.common.lib.LibItemNames;
+import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Optional;
+import cpw.mods.fml.common.registry.GameRegistry;
+import vazkii.botania.common.crafting.recipe.HelmRevealingRecipe;
 
 @Optional.InterfaceList({
 	@Optional.Interface(modid = "Thaumcraft", iface = "thaumcraft.api.IGoggles", striprefs = true),
@@ -26,8 +34,10 @@ public class ItemTerrasteelHelmRevealing extends ItemTerrasteelHelm implements I
 
 	public ItemTerrasteelHelmRevealing() {
 		super(LibItemNames.TERRASTEEL_HELM_R);
+		GameRegistry.addRecipe(new HelmRevealingRecipe());
+		RecipeSorter.register("botania:helmRevealingRecipe", HelmRevealingRecipe.class, Category.SHAPELESS, "");
 	}
-
+	
 	@Override
 	public boolean showNodes(ItemStack itemstack, EntityLivingBase player) {
 		return true;

--- a/src/main/java/vazkii/botania/common/lexicon/LexiconData.java
+++ b/src/main/java/vazkii/botania/common/lexicon/LexiconData.java
@@ -917,7 +917,7 @@ public final class LexiconData {
 
 		if(Botania.thaumcraftLoaded) {
 			tcIntegration = new BLexiconEntry(LibLexicon.MISC_TC_INTEGRATION, BotaniaAPI.categoryMisc);
-			tcIntegration.setLexiconPages(new PageText("0"), new PageText("1"), new PageCraftingRecipe("2", ModCraftingRecipes.recipeHelmetOfRevealing), new PageText("3"), new PageManaInfusionRecipe("4", ModManaInfusionRecipes.manaInkwellRecipe), new PageText("5"), new PageBrew(ModBrewRecipes.warpWardBrew, "6a", "6b")).setIcon(new ItemStack(ModItems.manaInkwell));
+			tcIntegration.setLexiconPages(new PageText("0"), new PageText("1"), new PageCraftingRecipe("2", ModCraftingRecipes.recipeFakeHelmetOfRevealing), new PageText("3"), new PageManaInfusionRecipe("4", ModManaInfusionRecipes.manaInkwellRecipe), new PageText("5"), new PageBrew(ModBrewRecipes.warpWardBrew, "6a", "6b")).setIcon(new ItemStack(ModItems.manaInkwell));
 		}
 	}
 }


### PR DESCRIPTION
Please excuse the mangled commit. I had to squash 8-ish of them from when I was still using the web interface. I tested this pretty well, but some of it is a bit hacky. I also wasn't entirely sure what semantics to use (i.e. yes or no newline for 1-line if's) so they may be a bit non-standard. This also includes the y -> posY patch because I couldn't compile otherwise. The only things being copied are the ench tag and the ancient wills. NOTE: the wills use straight NBTHelper calls because I couldn't get addAncientWill() to work :{ #766 