### PR TITLE
Use the stack sensitive unloc name in seed matcher

### DIFF
--- a/src/main/java/vazkii/botania/common/block/tile/TileAltar.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileAltar.java
@@ -97,7 +97,7 @@ public class TileAltar extends TileSimpleInventory implements ISidedInventory, I
 						break;
 					}
 			}
-		} else if(stack.getItem() != null && SEED_PATTERN.matcher(stack.getItem().getUnlocalizedName()).find()) {
+		} else if(stack.getItem() != null && SEED_PATTERN.matcher(stack.getItem().getUnlocalizedName(stack)).find()) {
 			for(RecipePetals recipe : BotaniaAPI.petalRecipes) {
 				if(recipe.matches(this)) {
 					for(int i = 0; i < getSizeInventory(); i++)


### PR DESCRIPTION
Fixes KitchenCraft seeds not working with the apothecary