### PR TITLE
Tweaked Mana Star behavior to include any instan...

### DIFF
--- a/src/main/java/vazkii/botania/common/block/subtile/SubTileManastar.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/SubTileManastar.java
@@ -13,11 +13,10 @@ package vazkii.botania.common.block.subtile;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.util.ForgeDirection;
 import vazkii.botania.api.lexicon.LexiconEntry;
-import vazkii.botania.api.mana.IManaPool;
+import vazkii.botania.api.mana.IManaBlock;
 import vazkii.botania.api.subtile.SubTileEntity;
 import vazkii.botania.common.Botania;
 import vazkii.botania.common.lexicon.LexiconData;
-import vazkii.botania.common.lib.LibMisc;
 
 public class SubTileManastar extends SubTileEntity {
 
@@ -28,10 +27,11 @@ public class SubTileManastar extends SubTileEntity {
 		super.onUpdate();
 
 		int mana = 0;
-		for(ForgeDirection dir : LibMisc.CARDINAL_DIRECTIONS) {
-			TileEntity tile = supertile.getWorldObj().getTileEntity(supertile.xCoord + dir.offsetX, supertile.yCoord, supertile.zCoord + dir.offsetZ);
-			if(tile instanceof IManaPool)
-				mana += ((IManaPool) tile).getCurrentMana();
+		ForgeDirection[] directions = {ForgeDirection.NORTH, ForgeDirection.SOUTH, ForgeDirection.EAST, ForgeDirection.WEST, ForgeDirection.UP};
+		for(ForgeDirection dir : directions) {
+			TileEntity tile = supertile.getWorldObj().getTileEntity(supertile.xCoord + dir.offsetX, supertile.yCoord + dir.offsetY, supertile.zCoord + dir.offsetZ);
+			if(tile instanceof IManaBlock)
+				mana += ((IManaBlock) tile).getCurrentMana();
 		}
 
 		if(manaLastTick != -1 && mana != manaLastTick && Math.random() > 0.6) {

--- a/src/main/resources/assets/botania/lang/en_US.lang
+++ b/src/main/resources/assets/botania/lang/en_US.lang
@@ -1611,7 +1611,7 @@ botania.page.redstoneSpreader1=Just add redstone
 
 # -- MANASTAR
 botania.entry.manastar=Manastar
-botania.page.manastar0=The imprecise measurements of the &1Wand of the Forest&0 sometimes won't cut it for telling if you're turning a profit or loss in your &1Mana Pools&0.<br>Creating a &1Manastar&0 and placing it next to your pools will have it shine red if there's a loss or blue if there's a profit. The measurement happens every few seconds.
+botania.page.manastar0=The imprecise measurements of the &1Wand of the Forest&0 sometimes won't cut it for telling if you're turning a profit or loss in your &1Mana Pools&0.<br>Creating a &1Manastar&0 and placing it next to or below your pools (or other mana containing blocks) will have it shine red if there's a loss or blue if there's a profit. The measurement happens every few seconds.
 botania.page.manastar1=&rI'm a shooting star leaping through the skies&r.
 
 # -- ELVEN MANA SPREADERS


### PR DESCRIPTION
ce of IManaBlock, not just mana pools. Also allows manastars to check
the block above. This change was made to allow Mana Stars to be used
more easily by addons for non-pool blocks. Specifically, for Botanical
Workshop's Gateway, which is a multiblock structure for crafting and
other things that contains a bunch of mana pools that can be accessed
collectively:
https://github.com/Lazersmoke/Botanical-Workshop/blob/master/src/main/java/lazersmoke/botanicalworkshop/common/block/tile/TileGatewayCore.java

This is tested, backwards compatible, etc. and allows some more careful diagnoses in regular Botania as well as with addons. I am aware that I could implement my own mana star, but it makes much more sense for the player to only have one of those to work with.