### PR TITLE
Close loophole in open-source clause of license

### DIFF
--- a/web/module/license.php
+++ b/web/module/license.php
@@ -24,7 +24,7 @@
 	
 	$clause_thief = build_clause('Thief', 'lock', "You must not claim that you made $mod_name. Giving appropriate credit to $mod_creator as the creator of $mod_name makes you cooler, but you don't have to do it if you don't want to.");
 	
-	$clause_open_source = build_clause('Open Source', 'random', 'Your project must be open source (have its source visible and allow for redistribution and modification).');
+	$clause_open_source = build_clause('Copyleft', 'random', 'Your project must be open source (have its source visible and allow for redistribution and modification) and include a clause similar to this one in its license.');
 	
 	function add_clause($clause) {
 		global $clauses;


### PR DESCRIPTION
Considering the previous license was Share-Alike, I doubt, though I acknowledge that I may be wrong in doubting, that this loophole's existence is intentional, considering it allows trivial bypassing of the original clause.