### PR TITLE
Update zh_CN.lang

### DIFF
--- a/src/main/resources/assets/botania/lang/zh_CN.lang
+++ b/src/main/resources/assets/botania/lang/zh_CN.lang
@@ -1,6 +1,6 @@
 # MISC
 itemGroup.Botania=植物魔法
-# 汉化:绿冰,2015.6.2
+
 #并非本地化条目,请翻译者不要修改此行文本.
 botaniamisc.noloc=botaniamisc.noloc
 


### PR DESCRIPTION
Removed "汉化:绿冰" (means "Localized by Greenice") because this localization was made by serval people, and there is no sense to add anyone's name in the lang file.