### PR TITLE
Add mobGriefing check to block breaking section

### DIFF
--- a/src/main/java/vazkii/botania/common/entity/EntityDoppleganger.java
+++ b/src/main/java/vazkii/botania/common/entity/EntityDoppleganger.java
@@ -390,7 +390,7 @@ public class EntityDoppleganger extends EntityCreature implements IBotaniaBossWi
 		if(!worldObj.isRemote && worldObj.difficultySetting == EnumDifficulty.PEACEFUL)
 			setDead();
 
-		if(!worldObj.isRemote) {
+		if(!worldObj.isRemote && worldObj.getGameRules().getGameRuleBooleanValue("mobGriefing")) {
 			int posXInt = MathHelper.floor_double(posX);
 			int posYInt = MathHelper.floor_double(posY);
 			int posZInt = MathHelper.floor_double(posZ);


### PR DESCRIPTION
previously, ghost block destruction was created client side, as in #1147 
closes #1147 
NOTE: check pulled directly from minecraft source code for endermen picking up blocks