### PR TITLE
Typo in Lexica entry for Cocoon of Caprice

### DIFF
--- a/src/main/resources/assets/botania/lang/en_US.lang
+++ b/src/main/resources/assets/botania/lang/en_US.lang
@@ -2246,7 +2246,7 @@ botania.page.canopyDrum1=The Pinking Drum
 
 # -- COCOON OF CAPRICE
 botania.entry.cocoon=Cocoon of Caprice
-botania.page.cocoon0=A cocoon is usually a symbol of change, of evolution.<br>Creating a &1Cocoon of Carpice&0 and placing it down will slowly evolve the rudimentary contents inside it into a &1Baby Animal&0. More often than not the animal hatched will be a farm animal, but on rare ocasions, different animals such as &1Wolves&0 or &1Horses&0 may be created.
+botania.page.cocoon0=A cocoon is usually a symbol of change, of evolution.<br>Creating a &1Cocoon of Caprice&0 and placing it down will slowly evolve the rudimentary contents inside it into a &1Baby Animal&0. More often than not the animal hatched will be a farm animal, but on rare ocasions, different animals such as &1Wolves&0 or &1Horses&0 may be created.
 botania.page.cocoon1=Speculation says that giving the cocoon &1Emeralds&0 influences the outcome towards something a bit different.<br>What could come out of such experiment is anyone's guess, really.  
 botania.page.cocoon2=New World, Perfect World
 

--- a/src/main/resources/assets/botania/lang/fr_FR.lang
+++ b/src/main/resources/assets/botania/lang/fr_FR.lang
@@ -2246,7 +2246,7 @@ botania.page.canopyDrum1=Émondage avec style
 
 # -- COCOON OF CAPRICE
 botania.entry.cocoon=Cocoon of Caprice
-botania.page.cocoon0=A cocoon is usually a symbol of change, of evolution.<br>Creating a &1Cocoon of Carpice&0 and placing it down will slowly evolve the rudimentary contents inside it into a &1Baby Animal&0. More often than not the animal hatched will be a farm animal, but on rare ocasions, different animals such as &1Wolves&0 or &1Horses&0 may be created.
+botania.page.cocoon0=A cocoon is usually a symbol of change, of evolution.<br>Creating a &1Cocoon of Caprice&0 and placing it down will slowly evolve the rudimentary contents inside it into a &1Baby Animal&0. More often than not the animal hatched will be a farm animal, but on rare ocasions, different animals such as &1Wolves&0 or &1Horses&0 may be created.
 botania.page.cocoon1=Speculation says that giving the cocoon &1Emeralds&0 influences the outcome towards something a bit different.<br>What could come out of such experiment is anyone's guess, really.  
 botania.page.cocoon2=New World, Perfect World
 

--- a/src/main/resources/assets/botania/lang/ko_KR.lang
+++ b/src/main/resources/assets/botania/lang/ko_KR.lang
@@ -2197,7 +2197,7 @@ botania.page.canopyDrum1=The Pinking Drum
 
 # -- COCOON OF CAPRICE
 botania.entry.cocoon=Cocoon of Caprice
-botania.page.cocoon0=A cocoon is usually a symbol of change, of evolution.<br>Creating a &1Cocoon of Carpice&0 and placing it down will slowly evolve the rudimentary contents inside it into a &1Baby Animal&0. More often than not the animal hatched will be a farm animal, but on rare ocasions, different animals such as &1Wolves&0 or &1Horses&0 may be created.  
+botania.page.cocoon0=A cocoon is usually a symbol of change, of evolution.<br>Creating a &1Cocoon of Caprice&0 and placing it down will slowly evolve the rudimentary contents inside it into a &1Baby Animal&0. More often than not the animal hatched will be a farm animal, but on rare ocasions, different animals such as &1Wolves&0 or &1Horses&0 may be created.  
 botania.page.cocoon1=New World, Perfect World
 
 # - MYSTICAL INSTRUMENTS

--- a/src/main/resources/assets/botania/lang/zh_TW.lang
+++ b/src/main/resources/assets/botania/lang/zh_TW.lang
@@ -2250,7 +2250,7 @@ botania.page.canopyDrum2=修出我的范兒
 
 # -- COCOON OF CAPRICE
 botania.entry.cocoon=Cocoon of Caprice
-botania.page.cocoon0=A cocoon is usually a symbol of change, of evolution.<br>Creating a &1Cocoon of Carpice&0 and placing it down will slowly evolve the rudimentary contents inside it into a &1Baby Animal&0. More often than not the animal hatched will be a farm animal, but on rare ocasions, different animals such as &1Wolves&0 or &1Horses&0 may be created.
+botania.page.cocoon0=A cocoon is usually a symbol of change, of evolution.<br>Creating a &1Cocoon of Caprice&0 and placing it down will slowly evolve the rudimentary contents inside it into a &1Baby Animal&0. More often than not the animal hatched will be a farm animal, but on rare ocasions, different animals such as &1Wolves&0 or &1Horses&0 may be created.
 botania.page.cocoon1=Speculation says that giving the cocoon &1Emeralds&0 influences the outcome towards something a bit different.<br>What could come out of such experiment is anyone's guess, really.  
 botania.page.cocoon2=New World, Perfect World
 


### PR DESCRIPTION
Fix typo in lang files for botania.page.cocoon0. If this PR is incorrect in any way, the typo is simply "Carpice" in *.lang.