### PR TITLE
Make Hopperhocks check all 6 sides for chests

### DIFF
--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileHopperhock.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileHopperhock.java
@@ -74,7 +74,7 @@ public class SubTileHopperhock extends SubTileFunctional {
 			ForgeDirection sideToPutItemIn = ForgeDirection.UNKNOWN;
 			boolean priorityInv = false;
 
-			for(ForgeDirection dir : LibMisc.CARDINAL_DIRECTIONS) {
+			for(ForgeDirection dir : ForgeDirection.VALID_DIRECTIONS) {
 				int x_ = x + dir.offsetX;
 				int y_ = y + dir.offsetY;
 				int z_ = z + dir.offsetZ;


### PR DESCRIPTION
This commit should make Hopperhocks check all 6 sides for output inventories, rather than just the 4 cardinal directions. This is useful for floating hopperhocks, and for placing an inventory above a hopperhock.