### PR TITLE
make ItemLens combination checking more generic

### DIFF
--- a/src/main/java/vazkii/botania/api/mana/ILens.java
+++ b/src/main/java/vazkii/botania/api/mana/ILens.java
@@ -39,4 +39,14 @@ public interface ILens extends ILensEffect {
 	 */
 	public ItemStack setCompositeLens(ItemStack sourceLens, ItemStack compositeLens);
 
+	/**
+	* Returns the properties of the itemstack, used to check if two lenses can combine.
+	*/
+	public int getProps(ItemStack stack);
+
+	/**
+	* Checks if the lens is combinable.
+	*/
+	public boolean isCombinable(ItemStack stack);
+
 }

--- a/src/main/java/vazkii/botania/common/item/lens/ItemLens.java
+++ b/src/main/java/vazkii/botania/common/item/lens/ItemLens.java
@@ -287,8 +287,10 @@ public class ItemLens extends ItemMod implements ILensControl, ITinyPlanetExcemp
 		lenses[index] = lens;
 	}
 
-	public static boolean isBlacklisted(int lens1, int lens2) {
-		return (props[lens1] & props[lens2]) != 0;
+	public static boolean isBlacklisted(ItemStack lens1, ItemStack lens2) {
+		ILens item1 = (ILens) lens1.getItem();
+		ILens item2 = (ILens) lens2.getItem();
+		return (item1.getProps(lens1) & item2.getProps(lens2)) != 0;
 	}
 
 	public static Lens getLens(int index) {
@@ -301,13 +303,15 @@ public class ItemLens extends ItemMod implements ILensControl, ITinyPlanetExcemp
 
 	@Override
 	public boolean canCombineLenses(ItemStack sourceLens, ItemStack compositeLens) {
-		if(sourceLens.getItemDamage() == compositeLens.getItemDamage())
+		ILens sourceItem = (ILens) sourceLens.getItem();
+		ILens compositeItem = (ILens) compositeLens.getItem();
+		if(sourceItem == compositeItem && sourceLens.getItemDamage() == compositeLens.getItemDamage())
 			return false;
 
-		if(sourceLens.getItemDamage() == NORMAL || compositeLens.getItemDamage() == NORMAL)
+		if(!sourceItem.isCombinable(sourceLens) || !compositeItem.isCombinable(compositeLens))
 			return false;
 
-		if(isBlacklisted(sourceLens.getItemDamage(), compositeLens.getItemDamage()))
+		if(isBlacklisted(sourceLens, compositeLens))
 			return false;
 
 		return true;
@@ -336,7 +340,7 @@ public class ItemLens extends ItemMod implements ILensControl, ITinyPlanetExcemp
 
 	@Override
 	public boolean isControlLens(ItemStack stack) {
-		return (props[stack.getItemDamage()] & PROP_CONTROL) != 0;
+		return (getProps(stack) & PROP_CONTROL) != 0;
 	}
 
 	@Override
@@ -352,5 +356,15 @@ public class ItemLens extends ItemMod implements ILensControl, ITinyPlanetExcemp
 	@Override
 	public void onControlledSpreaderPulse(ItemStack stack, IManaSpreader spreader, boolean redstone) {
 		lenses[stack.getItemDamage()].onControlledSpreaderPulse(stack, spreader, redstone);
+	}
+
+	@Override
+	public int getProps(ItemStack stack) {
+		return props[stack.getItemDamage()];
+	}
+
+	@Override
+	public boolean isCombinable(ItemStack stack) {
+		return stack.getItemDamage() != NORMAL;
 	}
 }


### PR DESCRIPTION
this will allow ILens instances that aren’t ItemLens to combine with other ILens instances