### PR TITLE
make ItemLens combination checking more generic (ICompositableLens)

### DIFF
--- a/src/main/java/vazkii/botania/api/mana/ICompositableLens.java
+++ b/src/main/java/vazkii/botania/api/mana/ICompositableLens.java
@@ -1,0 +1,32 @@
+/**
+ * This class was created by <WireSegal>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ * 
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ * 
+ * File Created @ [Nov 23, 2015, 10:30:34 AM (GMT)]
+ */
+package vazkii.botania.api.mana;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * Have an Item implement this to be counted as a lens that can be combined with an ItemLens.
+ */
+public interface ICompositableLens extends ILens {
+
+	/**
+	* Returns the properties of the itemstack, used to check if two lenses can combine.
+	*/
+	public int getProps(ItemStack stack);
+
+	/**
+	* Checks if the lens is combinable.
+	*/
+	public boolean isCombinable(ItemStack stack);
+
+}
+
+

--- a/src/main/java/vazkii/botania/common/crafting/recipe/CompositeLensRecipe.java
+++ b/src/main/java/vazkii/botania/common/crafting/recipe/CompositeLensRecipe.java
@@ -15,7 +15,7 @@ import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.world.World;
-import vazkii.botania.api.mana.ILens;
+import vazkii.botania.api.mana.ICompositableLens;
 import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.lens.ItemLens;
 
@@ -30,7 +30,7 @@ public class CompositeLensRecipe implements IRecipe {
 		for(int i = 0; i < var1.getSizeInventory(); i++) {
 			ItemStack stack = var1.getStackInSlot(i);
 			if(stack != null) {
-				if(stack.getItem() instanceof ILens && !foundSecondLens) {
+				if(stack.getItem() instanceof ICompositableLens && !foundSecondLens) {
 					if(foundLens)
 						foundSecondLens = true;
 					else foundLens = true;
@@ -51,15 +51,15 @@ public class CompositeLensRecipe implements IRecipe {
 		for(int i = 0; i < var1.getSizeInventory(); i++) {
 			ItemStack stack = var1.getStackInSlot(i);
 			if(stack != null) {
-				if(stack.getItem() instanceof ILens)
+				if(stack.getItem() instanceof ICompositableLens)
 					if(lens == null)
 						lens = stack;
 					else secondLens = stack;
 			}
 		}
 
-		if(lens.getItem() instanceof ILens) {
-			ILens lensItem = (ILens) lens.getItem();
+		if(lens.getItem() instanceof ICompositableLens) {
+			ICompositableLens lensItem = (ICompositableLens) lens.getItem();
 			if(secondLens == null || !lensItem.canCombineLenses(lens, secondLens) || lensItem.getCompositeLens(lens) != null || lensItem.getCompositeLens(secondLens) != null)
 				return null;
 

--- a/src/main/java/vazkii/botania/common/item/lens/ItemLens.java
+++ b/src/main/java/vazkii/botania/common/item/lens/ItemLens.java
@@ -28,6 +28,7 @@ import net.minecraftforge.oredict.RecipeSorter;
 import net.minecraftforge.oredict.RecipeSorter.Category;
 import vazkii.botania.api.internal.IManaBurst;
 import vazkii.botania.api.mana.BurstProperties;
+import vazkii.botania.api.mana.ICompositableLens;
 import vazkii.botania.api.mana.ILens;
 import vazkii.botania.api.mana.ILensControl;
 import vazkii.botania.api.mana.IManaSpreader;
@@ -41,7 +42,7 @@ import vazkii.botania.common.item.ItemMod;
 import vazkii.botania.common.lib.LibItemNames;
 import cpw.mods.fml.common.registry.GameRegistry;
 
-public class ItemLens extends ItemMod implements ILensControl, ITinyPlanetExcempt {
+public class ItemLens extends ItemMod implements ILensControl, ICompositableLens, ITinyPlanetExcempt {
 
 	public static final int SUBTYPES = 22;
 
@@ -287,8 +288,10 @@ public class ItemLens extends ItemMod implements ILensControl, ITinyPlanetExcemp
 		lenses[index] = lens;
 	}
 
-	public static boolean isBlacklisted(int lens1, int lens2) {
-		return (props[lens1] & props[lens2]) != 0;
+	public static boolean isBlacklisted(ItemStack lens1, ItemStack lens2) {
+		ICompositableLens item1 = (ICompositableLens) lens1.getItem();
+		ICompositableLens item2 = (ICompositableLens) lens2.getItem();
+		return (item1.getProps(lens1) & item2.getProps(lens2)) != 0;
 	}
 
 	public static Lens getLens(int index) {
@@ -301,13 +304,15 @@ public class ItemLens extends ItemMod implements ILensControl, ITinyPlanetExcemp
 
 	@Override
 	public boolean canCombineLenses(ItemStack sourceLens, ItemStack compositeLens) {
-		if(sourceLens.getItemDamage() == compositeLens.getItemDamage())
+		ICompositableLens sourceItem = (ICompositableLens) sourceLens.getItem();
+		ICompositableLens compositeItem = (ICompositableLens) compositeLens.getItem();
+		if(sourceItem == compositeItem && sourceLens.getItemDamage() == compositeLens.getItemDamage())
 			return false;
 
-		if(sourceLens.getItemDamage() == NORMAL || compositeLens.getItemDamage() == NORMAL)
+		if(!sourceItem.isCombinable(sourceLens) || !compositeItem.isCombinable(compositeLens))
 			return false;
 
-		if(isBlacklisted(sourceLens.getItemDamage(), compositeLens.getItemDamage()))
+		if(isBlacklisted(sourceLens, compositeLens))
 			return false;
 
 		return true;
@@ -336,7 +341,7 @@ public class ItemLens extends ItemMod implements ILensControl, ITinyPlanetExcemp
 
 	@Override
 	public boolean isControlLens(ItemStack stack) {
-		return (props[stack.getItemDamage()] & PROP_CONTROL) != 0;
+		return (getProps(stack) & PROP_CONTROL) != 0;
 	}
 
 	@Override
@@ -352,5 +357,15 @@ public class ItemLens extends ItemMod implements ILensControl, ITinyPlanetExcemp
 	@Override
 	public void onControlledSpreaderPulse(ItemStack stack, IManaSpreader spreader, boolean redstone) {
 		lenses[stack.getItemDamage()].onControlledSpreaderPulse(stack, spreader, redstone);
+	}
+
+	@Override
+	public int getProps(ItemStack stack) {
+		return props[stack.getItemDamage()];
+	}
+
+	@Override
+	public boolean isCombinable(ItemStack stack) {
+		return stack.getItemDamage() != NORMAL;
 	}
 }


### PR DESCRIPTION
this will allow ILens instances that aren’t ItemLens to combine with other ILens instances

I squashed it... >.>