### PR TITLE
Make Pure Daisy recognize metadata

### DIFF
--- a/src/main/java/vazkii/botania/api/BotaniaAPI.java
+++ b/src/main/java/vazkii/botania/api/BotaniaAPI.java
@@ -353,13 +353,44 @@ public final class BotaniaAPI {
 
 	/**
 	 * Registers a Pure Daisy Recipe.
+	 * 
+	 * @deprecated Use {@link #registerPureDaisyRecipe(String, Block, int)} or
+	 * {@link #registerPureDaisyRecipe(Block, Integer, Block, int)} instead.
 	 * @param input The block that works as an input for the recipe. Can be a Block or an oredict String.
 	 * @param output The block to be placed upon recipe completion.
 	 * @param outputMeta The metadata to be placed upon recipe completion.
 	 * @return The recipe created.
 	 */
+	@Deprecated
 	public static RecipePureDaisy registerPureDaisyRecipe(Object input, Block output, int outputMeta) {
 		RecipePureDaisy recipe = new RecipePureDaisy(input, output, outputMeta);
+		pureDaisyRecipes.add(recipe);
+		return recipe;
+	}
+
+	/**
+	 * Registers a Pure Daisy Recipe.
+	 * @param input The block that works as an input for the recipe as on oredict String.
+	 * @param output The block to be placed upon recipe completion.
+	 * @param outputMeta The metadata to be placed upon recipe completion.
+	 * @return The recipe created.
+	 */
+	public static RecipePureDaisy registerPureDaisyRecipe(String input, Block output, int outputMeta) {
+		RecipePureDaisy recipe = new RecipePureDaisy(input, output, outputMeta);
+		pureDaisyRecipes.add(recipe);
+		return recipe;
+	}
+
+	/**
+	 * Registers a Pure Daisy Recipe.
+	 * @param input The block that works as an input for the recipe as a Block
+	 * @param inputMeta The metadata of the input, or <code>null</code> to match all.
+	 * @param output The block to be placed upon recipe completion.
+	 * @param outputMeta The metadata to be placed upon recipe completion.
+	 * @return The recipe created.
+	 */
+	public static RecipePureDaisy registerPureDaisyRecipe(Block input, Integer inputMeta, Block output, int outputMeta) {
+		RecipePureDaisy recipe = new RecipePureDaisy(input, inputMeta, output, outputMeta);
 		pureDaisyRecipes.add(recipe);
 		return recipe;
 	}

--- a/src/main/java/vazkii/botania/api/recipe/RecipePureDaisy.java
+++ b/src/main/java/vazkii/botania/api/recipe/RecipePureDaisy.java
@@ -25,16 +25,44 @@ public class RecipePureDaisy {
 	private static final Map<String, List<ItemStack>> oreMap = new HashMap();
 
 	Object input;
+	Integer inputMeta;
 	Block output;
 	int outputMeta;
 
-	public RecipePureDaisy(Object input, Block output, int outputMeta) {
+	/**
+	 * @param input Oredict <code>String</code> to match
+	 */
+	public RecipePureDaisy(String inputOreDict, Block output, int outputMeta) {
+		this((Object)inputOreDict, null, output, outputMeta);
+	}
+
+	/**
+	 * @param inputMeta metadata of input, or null for any.
+	 */
+	public RecipePureDaisy(Block input, Integer inputMeta, Block output, int outputMeta) {
+		this((Object)input, inputMeta, output, outputMeta);
+	}
+
+	private RecipePureDaisy(Object input, Integer inputMeta, Block output, int outputMeta) {
 		this.input = input;
+		this.inputMeta = inputMeta;
 		this.output = output;
 		this.outputMeta = outputMeta;
 
 		if(input != null && !(input instanceof String || input instanceof Block))
 			throw new IllegalArgumentException("input must be an oredict String or a Block.");
+		else if(input instanceof String && inputMeta != null)
+			throw new IllegalArgumentException("inputMeta must be null if input is an oredict String.");
+	}
+
+	/**
+	 * Equivalent to <code>RecipePureDaisy(input, null, output, outputMeta)</code>
+	 * 
+	 * @deprecated Use the other two instead.
+	 */
+	@Deprecated
+	public RecipePureDaisy(Object input, Block output, int outputMeta) {
+		this(input, null, output, outputMeta);
 	}
 
 	/**
@@ -42,7 +70,7 @@ public class RecipePureDaisy {
 	 */
 	public boolean matches(World world, int x, int y, int z, SubTileEntity pureDaisy, Block block, int meta) {
 		if(input instanceof Block)
-			return block == input;
+			return block == input && (inputMeta == null || (int)inputMeta == meta);
 
 		ItemStack stack = new ItemStack(block, 1, meta);
 		String oredict = (String) input;
@@ -86,6 +114,10 @@ public class RecipePureDaisy {
 
 	public Object getInput() {
 		return input;
+	}
+
+	public Integer getInputMeta() {
+		return inputMeta;
 	}
 
 	public Block getOutput() {

--- a/src/main/java/vazkii/botania/client/integration/nei/RecipeHandlerPureDaisy.java
+++ b/src/main/java/vazkii/botania/client/integration/nei/RecipeHandlerPureDaisy.java
@@ -37,7 +37,12 @@ public class RecipeHandlerPureDaisy extends TemplateRecipeHandler {
 
 			if(recipe.getInput() instanceof String)
 				inputs.add(new PositionedStack(OreDictionary.getOres((String) recipe.getInput()), 42, 23));
-			else inputs.add(new PositionedStack(new ItemStack((Block) recipe.getInput()), 42, 23));
+			else {
+				if(recipe.getInputMeta() != null)
+					inputs.add(new PositionedStack(new ItemStack((Block) recipe.getInput(), 1, (int)recipe.getInputMeta()), 42, 23));
+				else
+					inputs.add(new PositionedStack(new ItemStack((Block) recipe.getInput()), 42, 23));
+			}
 
 			output = new PositionedStack(new ItemStack(recipe.getOutput()), 101, 23);
 		}

--- a/src/main/java/vazkii/botania/common/crafting/ModPureDaisyRecipes.java
+++ b/src/main/java/vazkii/botania/common/crafting/ModPureDaisyRecipes.java
@@ -25,7 +25,7 @@ public final class ModPureDaisyRecipes {
 		BotaniaAPI.registerPureDaisyRecipe("soulSand", Blocks.sand, 0);
 		BotaniaAPI.registerPureDaisyRecipe("ice", Blocks.packed_ice, 0);
 		BotaniaAPI.registerPureDaisyRecipe(LibOreDict.BLAZE_BLOCK, Blocks.obsidian, 0);
-		BotaniaAPI.registerPureDaisyRecipe(Blocks.water, Blocks.snow, 0);
+		BotaniaAPI.registerPureDaisyRecipe(Blocks.water, null, Blocks.snow, 0);
 	}
 
 }


### PR DESCRIPTION
Add inputMeta field to RecipePureDaisy, two new constructors, a getter,
and two new API methods to account for it. Also deprecate the old
constructor and API method and alter NEI recipes. Fix #1645.