### PR TITLE
Fix #1588: chordata ring stops player from drowning with no mana.

### DIFF
--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemWaterRing.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemWaterRing.java
@@ -58,7 +58,8 @@ public class ItemWaterRing extends ItemBauble implements IManaUsingItem {
 
 			if(player.getAir() <= 1 && player instanceof EntityPlayer) {
 				int mana = ManaItemHandler.requestMana(stack, (EntityPlayer) player, 300, true);
-				player.setAir(mana);
+				if(mana > 0) // If zero gets in the player has no air but won't drown.
+					player.setAir(mana);
 			}
 		} else onUnequipped(stack, player);
 	}


### PR DESCRIPTION
Setting the player's air to zero stops them from drowning until next tick, where it gets reset again. Added line (and indentation, never forget the indentation :wink:) to fix.