### PR TITLE
UUID for relics

### DIFF
--- a/src/main/java/vazkii/botania/api/item/IRelic.java
+++ b/src/main/java/vazkii/botania/api/item/IRelic.java
@@ -10,6 +10,8 @@
  */
 package vazkii.botania.api.item;
 
+import java.util.UUID;
+
 import net.minecraft.item.ItemStack;
 import net.minecraft.stats.Achievement;
 
@@ -22,12 +24,28 @@ public interface IRelic {
 	/**
 	 * Binds to the player name passed in.
 	 */
+	@Deprecated
 	public void bindToUsername(String playerName, ItemStack stack);
 
 	/**
 	 * Gets the username of the person this relic is bound to.
 	 */
 	public String getSoulbindUsername(ItemStack stack);
+
+	/**
+	 * Binds to the UUID passed in.
+	 */
+	public void bindToUUID(UUID uuid, ItemStack stack);
+
+	/**
+	 * Gets the UUID of the person this relic is bound to.
+	 */
+	public UUID getSoulbindUUID(ItemStack stack);
+
+	/**
+	 * Checks if the relic is using UUIDs.
+	 */
+	public boolean hasUUID(ItemStack stack);
 
 	/**
 	 * Sets the achievement that this relic binds to.

--- a/src/main/java/vazkii/botania/common/crafting/recipe/AesirRingRecipe.java
+++ b/src/main/java/vazkii/botania/common/crafting/recipe/AesirRingRecipe.java
@@ -10,6 +10,8 @@
  */
 package vazkii.botania.common.crafting.recipe;
 
+import java.util.UUID;
+
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
@@ -44,22 +46,37 @@ public class AesirRingRecipe implements IRecipe {
 	@Override
 	public ItemStack getCraftingResult(InventoryCrafting var1) {
 		String soulbind = null;
+		UUID soulbindUUID = null;
+		boolean hasUUID = false;
 
 		for(int i = 0; i < var1.getSizeInventory(); i++) {
 			ItemStack stack = var1.getStackInSlot(i);
 			if(stack != null) {
 				if(stack.getItem() instanceof IRelic) {
-					String bind = ((IRelic) stack.getItem()).getSoulbindUsername(stack);
-					if(soulbind == null)
-						soulbind = bind;
-					else if(!soulbind.equals(bind))
-						return null;
+					if(((IRelic) stack.getItem()).hasUUID(stack)) {
+						hasUUID = true;
+						UUID bindUUID = ((IRelic) stack.getItem()).getSoulbindUUID(stack);
+						if(soulbindUUID == null)
+							soulbindUUID = bindUUID;
+						else if(!soulbindUUID.equals(bindUUID))
+							return null;
+					}
+					else {
+						String bind = ((IRelic) stack.getItem()).getSoulbindUsername(stack);
+						if(soulbind == null)
+							soulbind = bind;
+						else if(!soulbind.equals(bind))
+							return null;
+					}
 				} else return null;
 			}
 		}
 
 		ItemStack stack = new ItemStack(ModItems.aesirRing);
-		((IRelic) ModItems.aesirRing).bindToUsername(soulbind, stack);
+		if(hasUUID)
+			((IRelic) ModItems.aesirRing).bindToUUID(soulbindUUID, stack);
+		else
+			((IRelic) ModItems.aesirRing).bindToUsername(soulbind, stack);
 		return stack;
 	}
 

--- a/src/main/java/vazkii/botania/common/entity/EntityDoppleganger.java
+++ b/src/main/java/vazkii/botania/common/entity/EntityDoppleganger.java
@@ -14,6 +14,7 @@ import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 import net.minecraft.block.Block;
@@ -110,7 +111,7 @@ public class EntityDoppleganger extends EntityCreature implements IBotaniaBossWi
 	boolean spawnPixies = false;
 	boolean anyWithArmor = false;
 
-	List<String> playersWhoAttacked = new ArrayList();
+	List<UUID> playersWhoAttacked = new ArrayList();
 
 	private static boolean isPlayingMusic = false;
 
@@ -364,8 +365,8 @@ public class EntityDoppleganger extends EntityCreature implements IBotaniaBossWi
 		Entity e = par1DamageSource.getEntity();
 		if((par1DamageSource.damageType.equals("player") || e instanceof EntityPixie) && e != null && isTruePlayer(e) && getInvulTime() == 0) {
 			EntityPlayer player = (EntityPlayer) e;
-			if(!playersWhoAttacked.contains(player.getCommandSenderName()))
-				playersWhoAttacked.add(player.getCommandSenderName());
+			if(!playersWhoAttacked.contains(player.getUniqueID()))
+				playersWhoAttacked.add(player.getUniqueID());
 
 			float dmg = par2;
 			boolean crit = false;
@@ -452,7 +453,7 @@ public class EntityDoppleganger extends EntityCreature implements IBotaniaBossWi
 					entityDropItem(new ItemStack(ModItems.ancientWill, 1, rand.nextInt(6)), 1F);
 					if(ConfigHandler.relicsEnabled) {
 						ItemStack dice = new ItemStack(ModItems.dice);
-						ItemRelic.bindToUsernameS(playersWhoAttacked.get(pl), dice);
+						ItemRelic.bindToUUIDS(playersWhoAttacked.get(pl), dice);
 						entityDropItem(dice, 1F);
 					}
 

--- a/src/main/java/vazkii/botania/common/item/relic/ItemRelicBauble.java
+++ b/src/main/java/vazkii/botania/common/item/relic/ItemRelicBauble.java
@@ -11,6 +11,7 @@
 package vazkii.botania.common.item.relic;
 
 import java.util.List;
+import java.util.UUID;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -71,6 +72,21 @@ public abstract class ItemRelicBauble extends ItemBauble implements IRelic {
 	@Override
 	public String getSoulbindUsername(ItemStack stack) {
 		return ItemRelic.getSoulbindUsernameS(stack);
+	}
+
+	@Override
+	public void bindToUUID(UUID uuid, ItemStack stack) {
+		ItemRelic.bindToUUIDS(uuid, stack);
+	}
+
+	@Override
+	public UUID getSoulbindUUID(ItemStack stack) {
+		return ItemRelic.getSoulbindUUIDS(stack);
+	}
+
+	@Override
+	public boolean hasUUID(ItemStack stack) {
+		return ItemRelic.hasUUIDS(stack);
 	}
 
 	@Override


### PR DESCRIPTION
Adds UUID support for relics. 

Everything should work fine, both with items that have UUID and for those that doesn't. If an item has both UUID and username information, it will prefer the UUID, if not it will fall back to using the username. Username will be converted to UUID when the owner has the item in his inventory.

I've tested that this works fine with previous builds of Botania.

I was a bit unsure about what to call the static methods in the ItemRelics file though. UUIDS sounds wierd, but I didn't want to break away from what you already had.