### PR TITLE
Add oredict support 1.8 stone recipes, closes #1660

### DIFF
--- a/src/main/java/vazkii/botania/common/crafting/ModCraftingRecipes.java
+++ b/src/main/java/vazkii/botania/common/crafting/ModCraftingRecipes.java
@@ -2223,8 +2223,31 @@ public final class ModCraftingRecipes {
 
 		// 1.8 Block Stone Stairs & Slabs
 		for(int i = 0; i < 4; i++) {
-			addStairsAndSlabs(ModFluffBlocks.stone, i, ModFluffBlocks.stoneStairs[i], ModFluffBlocks.stoneSlabs[i]);
-			addStairsAndSlabs(ModFluffBlocks.stone, i + 8, ModFluffBlocks.stoneStairs[i + 4], ModFluffBlocks.stoneSlabs[i + 4]);
+			addOreDictRecipe(new ItemStack(ModFluffBlocks.stoneSlabs[i], 6),
+					"QQQ",
+					'Q', LibOreDict.STONE_18_VARIANTS[i]);
+			addOreDictRecipe(new ItemStack(ModFluffBlocks.stoneStairs[i], 4),
+					"  Q", " QQ", "QQQ",
+					'Q', LibOreDict.STONE_18_VARIANTS[i]);
+			addOreDictRecipe(new ItemStack(ModFluffBlocks.stoneStairs[i], 4),
+					"Q  ", "QQ ", "QQQ",
+					'Q', LibOreDict.STONE_18_VARIANTS[i]);
+			addOreDictRecipe(new ItemStack(ModFluffBlocks.stone, 1, i),
+					"Q", "Q",
+					'Q', new ItemStack(ModFluffBlocks.stoneSlabs[i]));
+			
+			addOreDictRecipe(new ItemStack(ModFluffBlocks.stoneSlabs[i + 4], 6),
+					"QQQ",
+					'Q', LibOreDict.STONE_18_VARIANTS[i + 8]);
+			addOreDictRecipe(new ItemStack(ModFluffBlocks.stoneStairs[i + 4], 4),
+					"  Q", " QQ", "QQQ",
+					'Q', LibOreDict.STONE_18_VARIANTS[i + 8]);
+			addOreDictRecipe(new ItemStack(ModFluffBlocks.stoneStairs[i + 4], 4),
+					"Q  ", "QQ ", "QQQ",
+					'Q', LibOreDict.STONE_18_VARIANTS[i + 8]);
+			addOreDictRecipe(new ItemStack(ModFluffBlocks.stone, 1, i + 8),	//VERY 		VERY
+					"Q", "Q",												//BIG		BIG
+					'Q', new ItemStack(ModFluffBlocks.stoneSlabs[i + 4]));	//PROBLEM	PROBLEM
 		}
 
 		// Pavement Stairsm & Stairs


### PR DESCRIPTION
the code was copy-pastaed from the addStairsAndSlabs helper function to
hack in oredict support, feel free to just add it to the helper function
if you want though. Looking at other Botania code, this is what comes to
mind though.

see #1703
There is also a very big problem that I marked with a comment that says
"very big problem", where on many many different stone types (end,
metamorph, 1.8) the recipe for stone bricks and for chisled is the same,
so usually you can't craft chisled.

sorry for long commit message