### PR TITLE
Clean up common/item/ItemGaiaHead.java

### DIFF
--- a/src/main/java/vazkii/botania/common/item/ItemGaiaHead.java
+++ b/src/main/java/vazkii/botania/common/item/ItemGaiaHead.java
@@ -2,10 +2,10 @@
  * This class was created by <Vazkii>. It's distributed as
  * part of the Botania Mod. Get the Source Code in github:
  * https://github.com/Vazkii/Botania
- * 
+ *
  * Botania is Open Source and distributed under the
  * Botania License: http://botaniamod.net/license.php
- * 
+ *
  * File Created @ [Sep 23, 2015, 11:40:51 PM (GMT)]
  */
 package vazkii.botania.common.item;
@@ -18,6 +18,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntitySkull;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.lib.LibItemNames;
 
@@ -27,103 +28,68 @@ public class ItemGaiaHead extends ItemMod {
 		setUnlocalizedName(LibItemNames.GAIA_HEAD);
 	}
 
-	// Copypasta from ItemSkull and I'm not even going to bother to clean it up
-	//
-	// Deal with it.
+	// I couldn't deal with it.
 	@Override
-	public boolean onItemUse(ItemStack p_77648_1_, EntityPlayer p_77648_2_, World p_77648_3_, int p_77648_4_, int p_77648_5_, int p_77648_6_, int p_77648_7_, float p_77648_8_, float p_77648_9_, float p_77648_10_)
-	{
-		if(p_77648_3_.getBlock(p_77648_4_, p_77648_5_, p_77648_6_).isReplaceable(p_77648_3_, p_77648_4_, p_77648_5_, p_77648_6_) && p_77648_7_ != 0)
-		{
-			p_77648_7_ = 1;
-			p_77648_5_--;
+	public boolean onItemUse(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, float sideX, float sideY, float sideZ) {
+		// The side of the wall the head is being used on.
+		ForgeDirection sideDir = ForgeDirection.getOrientation(side);
+
+		// If we can replace the block we're clicking on, then we'll go ahead
+		// and replace it (eg, snow).
+		if (world.getBlock(x, y, z).isReplaceable(world, x, y, z) && sideDir != ForgeDirection.DOWN) {
+			sideDir = ForgeDirection.UP;
+			y--;
 		}
-		if (p_77648_7_ == 0)
-		{
+
+		// Skulls can't be placed on the bottom side of a block.
+		if (sideDir == ForgeDirection.DOWN)
 			return false;
-		}
-		else if (!p_77648_3_.isSideSolid(p_77648_4_, p_77648_5_, p_77648_6_, net.minecraftforge.common.util.ForgeDirection.getOrientation(p_77648_7_)))
-		{
+
+		// If the side we're trying to place the skull on isn't solid, then
+		// we can't place it either.
+		if (!world.isSideSolid(x, y, z, sideDir))
 			return false;
+
+		// Figure out where the skull actually goes based on the side we're placing it against.
+		switch(sideDir) {
+		case UP: y++; break; // If we're placing it on the top, then the skull goes 1 block above.
+		case NORTH: z--; break; // Placing it on the north side (Z- axis).
+		case SOUTH: z++; break; // Placing it on the south side (Z+ axis).
+		case WEST: x--; break; // Placing it on the west side (X- axis).
+		case EAST: x++; break; // Placing it on the east side (X+ axis).
+		default: return false; // Oops, this shouldn't happen.
 		}
-		else
-		{
-			if (p_77648_7_ == 1)
-			{
-				++p_77648_5_;
-			}
 
-			if (p_77648_7_ == 2)
-			{
-				--p_77648_6_;
-			}
-
-			if (p_77648_7_ == 3)
-			{
-				++p_77648_6_;
-			}
-
-			if (p_77648_7_ == 4)
-			{
-				--p_77648_4_;
-			}
-
-			if (p_77648_7_ == 5)
-			{
-				++p_77648_4_;
-			}
-
-		}
-		{
-			if (!p_77648_3_.isRemote)
-			{
-				if (!Blocks.skull.canPlaceBlockOnSide(p_77648_3_, p_77648_4_, p_77648_5_, p_77648_6_, p_77648_7_)) return false;
-				p_77648_3_.setBlock(p_77648_4_, p_77648_5_, p_77648_6_, ModBlocks.gaiaHead, p_77648_7_, 2); // Gaia head instead of skull
-				int i1 = 0;
-
-				if (p_77648_7_ == 1)
-				{
-					i1 = MathHelper.floor_double(p_77648_2_.rotationYaw * 16.0F / 360.0F + 0.5D) & 15;
-				}
-
-				TileEntity tileentity = p_77648_3_.getTileEntity(p_77648_4_, p_77648_5_, p_77648_6_);
-
-				if (tileentity != null && tileentity instanceof TileEntitySkull)
-				{
-					/*if (p_77648_1_.getItemDamage() == 3)
-					{
-						GameProfile gameprofile = null;
-
-						if (p_77648_1_.hasTagCompound())
-						{
-							NBTTagCompound nbttagcompound = p_77648_1_.getTagCompound();
-
-							if (nbttagcompound.hasKey("SkullOwner", 10))
-							{
-								gameprofile = NBTUtil.func_152459_a(nbttagcompound.getCompoundTag("SkullOwner"));
-							}
-							else if (nbttagcompound.hasKey("SkullOwner", 8) && nbttagcompound.getString("SkullOwner").length() > 0)
-							{
-								gameprofile = new GameProfile((UUID)null, nbttagcompound.getString("SkullOwner"));
-							}
-						}
-
-						((TileEntitySkull)tileentity).func_152106_a(gameprofile);
-					}
-					else
-					{
-						((TileEntitySkull)tileentity).func_152107_a(p_77648_1_.getItemDamage());
-					}*/
-
-					((TileEntitySkull)tileentity).func_145903_a(i1);
-					((BlockSkull)Blocks.skull).func_149965_a(p_77648_3_, p_77648_4_, p_77648_5_, p_77648_6_, (TileEntitySkull)tileentity);
-				}
-
-				--p_77648_1_.stackSize;
-			}
-
+		// We can't place blocks as a measly client.
+		if(world.isRemote)
 			return true;
+
+		// If the skull says no, who are we to argue?
+		if (!ModBlocks.gaiaHead.canPlaceBlockOnSide(world, x, y, z, side))
+			return false;
+
+		// Gaia head, instead of skull
+		world.setBlock(x, y, z, ModBlocks.gaiaHead, sideDir.ordinal(), 2);
+		int headAngle = 0;
+
+		// If we place the skull on top of a block, we should also make it
+		// face the player by rotating it.
+		if (sideDir == ForgeDirection.UP)
+			headAngle = MathHelper.floor_double(player.rotationYaw * 16.0F / 360.0F + 0.5D) & 15;
+
+		// Update the skull's orientation if it lets us.
+		TileEntity tileentity = world.getTileEntity(x, y, z);
+
+		if (tileentity != null && tileentity instanceof TileEntitySkull) {
+			((TileEntitySkull) tileentity).func_145903_a(headAngle);
+			((BlockSkull) Blocks.skull).func_149965_a(world, x, y, z, (TileEntitySkull) tileentity);
 		}
+
+		// Remove a head from the stack.
+		--stack.stackSize;
+
+		// Call it a success and leave.
+		return true;
 	}
 
 }


### PR DESCRIPTION
Replaces the lovely copypasta in `common/item/ItemGaiaHead.java` with more idiomatic Forge code, and with comments, too! The code is functionally identical, but uses `ForgeDirection` and looks prettier.

As usual, a lovely few pictures to show that you can still place Gaia Skulls just fine:

![2016-01-13_16 18 35](https://cloud.githubusercontent.com/assets/616490/12309800/31794b56-ba12-11e5-82df-16a54bc4e823.png)

![2016-01-13_16 18 40](https://cloud.githubusercontent.com/assets/616490/12309802/343d6aca-ba12-11e5-833e-b3bc5ba9eec2.png)

You can't place Gaia Skulls on the ceiling as well, maintaining previous functionality.

(Also, the code was properly cleaned up this time and extra whitespace removed).