### PR TITLE
Fix #1726 - Accessories on other players now render in the proper position

### DIFF
--- a/src/main/java/vazkii/botania/api/item/IBaubleRender.java
+++ b/src/main/java/vazkii/botania/api/item/IBaubleRender.java
@@ -53,7 +53,7 @@ public interface IBaubleRender {
 		}
 
 		public static void translateToHeadLevel(EntityPlayer player) {
-			GL11.glTranslated(0, (player != Minecraft.getMinecraft().thePlayer ? 1.62F : 0F) - player.getDefaultEyeHeight() + (player.isSneaking() ? 0.0625 : 0), 0);
+			GL11.glTranslated(0, (player != Minecraft.getMinecraft().thePlayer ? 1.68F : 0F) - player.getDefaultEyeHeight() + (player.isSneaking() ? 0.0625 : 0), 0);
 		}
 
 	}

--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemBaubleCosmetic.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemBaubleCosmetic.java
@@ -213,7 +213,7 @@ public class ItemBaubleCosmetic extends ItemBauble implements ICosmeticBauble {
 				break;
 			case 26:
 				faceTranslate();
-				GL11.glTranslatef(-0.1F, -0.5F, 0F);
+				GL11.glTranslatef(-0.1F, -0.4F, 0F);
 				GL11.glEnable(GL11.GL_BLEND);
 				GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
 				GL11.glColor4f(1F, 1F, 1F, 0.7F);
@@ -222,7 +222,7 @@ public class ItemBaubleCosmetic extends ItemBauble implements ICosmeticBauble {
 			case 27:
 				faceTranslate();
 				scale(0.75F);
-				GL11.glTranslatef(0.04F, -0.5F, 0F);
+				GL11.glTranslatef(0.04F, -0.65F, 0F);
 				renderIcon(27);
 				break;
 			case 28:


### PR DESCRIPTION
This fixes issue #1726, by adjusting the offset for rendering cosmetics from `1.62F` to `1.68F`. It also fixes the rendering of two items (Orange Shades and Groucho Glasses, by modifying their Y-offsets) so they align with the player's eyes properly.

Screenshots:

![2016-01-13_22 34 43](https://cloud.githubusercontent.com/assets/616490/12316134/c86b2eae-ba48-11e5-8743-6e31fcd164e9.png)
![2016-01-13_22 49 50](https://cloud.githubusercontent.com/assets/616490/12316135/c86d655c-ba48-11e5-8dc2-a7e25ffecb6b.png)
![2016-01-13_22 49 58](https://cloud.githubusercontent.com/assets/616490/12316137/c86e8b3a-ba48-11e5-8d4b-bb99d76c21d9.png)
![2016-01-13_22 34 27](https://cloud.githubusercontent.com/assets/616490/12316138/c86f85b2-ba48-11e5-87e7-0b96d6079cf5.png)
![2016-01-13_22 34 34](https://cloud.githubusercontent.com/assets/616490/12316136/c86df832-ba48-11e5-91a1-7511128523ca.png)

Offsets on crouch and head rotation work as they did previously. Comments welcome.