### PR TITLE
Hotfix #1722 - Allow client to control sash speedup and slowdown

### DIFF
--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemSpeedUpBelt.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemSpeedUpBelt.java
@@ -55,9 +55,6 @@ public class ItemSpeedUpBelt extends ItemTravelBelt {
 	}
 
 	public boolean commitPositionAndCompare(ItemStack stack, EntityPlayer player) {
-		if(player.worldObj.isRemote)
-			return true;
-
 		double oldX = ItemNBTHelper.getDouble(stack, TAG_OLD_X, 0);
 		double oldY = ItemNBTHelper.getDouble(stack, TAG_OLD_Y, 0);
 		double oldZ = ItemNBTHelper.getDouble(stack, TAG_OLD_Z, 0);


### PR DESCRIPTION
This provides the straightforward solution as outlined in #1722, by allowing the client to also handle slowdowns. The existing code allowed the client to handle the actual speedup, but prevented it from reseting the speed as well due to a remote server check. The actual origin of the bug is related to `Entity.moveForward` always being `0.0F` on the server, but the fix for it is nontrivial and this will work as a working solution in the meanwhile.

With this patch, the sash properly resets it's speed both on the client and the server if the user stops for a few moments. The sash speeds up properly as it already has been.

Comments welcome.