### PR TITLE
Fix #1749 - Mana Tablets no longer lose durability in storage drawer

### DIFF
--- a/src/main/java/vazkii/botania/common/item/ItemManaTablet.java
+++ b/src/main/java/vazkii/botania/common/item/ItemManaTablet.java
@@ -49,13 +49,16 @@ public class ItemManaTablet extends ItemMod implements IManaItem, ICreativeManaP
 
 	@Override
 	public void getSubItems(Item par1, CreativeTabs par2CreativeTabs, List par3List) {
-		par3List.add(new ItemStack(par1, 1, 10000));
+		// Empty tablet
+		par3List.add(new ItemStack(par1, 1));
 
-		ItemStack fullPower = new ItemStack(par1, 1, 1);
+		// Full tablet
+		ItemStack fullPower = new ItemStack(par1, 1);
 		setMana(fullPower, MAX_MANA);
 		par3List.add(fullPower);
 
-		ItemStack creative = new ItemStack(par1, 1, 0);
+		// Creative Tablet
+		ItemStack creative = new ItemStack(par1, 1);
 		setMana(creative, MAX_MANA);
 		setStackCreative(creative);
 		par3List.add(creative);
@@ -69,13 +72,12 @@ public class ItemManaTablet extends ItemMod implements IManaItem, ICreativeManaP
 
 	@Override
 	public int getDamage(ItemStack stack) {
-		float mana = getMana(stack);
-		return 1000 - (int) (mana / MAX_MANA * 1000);
-	}
+		// Compatibility shim, so tablets from previous versions of botania
+		// stack right in barrels and so forth
+		if(super.getDamage(stack) != 0)
+			super.setDamage(stack, 0);
 
-	@Override
-	public int getDisplayDamage(ItemStack stack) {
-		return getDamage(stack);
+		return 0;
 	}
 
 	@Override
@@ -167,5 +169,19 @@ public class ItemManaTablet extends ItemMod implements IManaItem, ICreativeManaP
 	@Override
 	public float getManaFractionForDisplay(ItemStack stack) {
 		return (float) getMana(stack) / (float) getMaxMana(stack);
+	}
+	
+
+	@Override
+	public boolean showDurabilityBar(ItemStack stack) {
+		// If the stack is not creative, show the durability bar.
+		return !isStackCreative(stack);
+	}
+
+	@Override
+	public double getDurabilityForDisplay(ItemStack stack) {
+		// I believe Forge has their durability values swapped, hence the (1.0 -).
+		// This will probably be fixed soon.
+		return 1.0 - getManaFractionForDisplay(stack);
 	}
 }


### PR DESCRIPTION
Makes Mana Tablet durability bar actually use `showDurabilityBar` and `getDurabilityForDisplay` instead of the deprecated `getDisplayDamage`; as `getDisplayDamage` is no longer used, damage differences can be removed entirely (so no more item stack damage 1 to 1000).

In order to ensure compatibility with previous releases, `getDamage` is overridden to ensure that all mana tablets have a damage value of 0.

Some examples of it working with storage drawers:

Before placing in drawer:
![2016-01-15_02 36 38](https://cloud.githubusercontent.com/assets/616490/12349826/39dd0fae-bb38-11e5-9d53-6b20363423a6.png)

In drawer:
![2016-01-15_02 37 06](https://cloud.githubusercontent.com/assets/616490/12349824/39a51518-bb38-11e5-8a25-6766cde174d4.png)

After:
![2016-01-15_02 37 17](https://cloud.githubusercontent.com/assets/616490/12349825/39da6362-bb38-11e5-909a-31841f2d7c07.png)

(From left to right: empty, semi-full, full, and creative)
