### PR TITLE
Refactor client.challenge.* - Add comments and fix whitespace

### DIFF
--- a/src/main/java/vazkii/botania/client/challenge/Challenge.java
+++ b/src/main/java/vazkii/botania/client/challenge/Challenge.java
@@ -13,23 +13,58 @@ package vazkii.botania.client.challenge;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 
+/**
+ * A in-game challenge as found in the Lexica Botania challenge sections -
+ * contains a simple name for the challenge, the display icon, the difficulty,
+ * and a marker for completion.
+ */
 public class Challenge {
 
+	/**
+	 * The unlocalized name of this challenge.
+	 */
 	public final String unlocalizedName;
+
+	/**
+	 * The icon to display in the visuals for this challenge.
+	 */
 	public final ItemStack icon;
+
+	/**
+	 * The percieved difficulty of this challenge.
+	 */
 	public final EnumChallengeLevel level;
+
+	/**
+	 * Whether or not this challenge is considered complete
+	 * (true if it is, false otherwise).
+	 */
 	public boolean complete = false;
 
+	/**
+	 * Creates a new challenge with the specified arguments.
+	 * @param unlocalizedName The unlocalized name of the challenge.
+	 * @param icon The icon of the challenge, represented by the icon of the provided item stack.
+	 * @param level The difficulty level of the challenge.
+	 */
 	public Challenge(String unlocalizedName, ItemStack icon, EnumChallengeLevel level) {
 		this.unlocalizedName = unlocalizedName;
 		this.icon = icon;
 		this.level = level;
 	}
 
+	/**
+	 * Write this challenge to the provided NBT tag.
+	 * @param cmp The tag to write this challenge to.
+	 */
 	public void writeToNBT(NBTTagCompound cmp) {
 		cmp.setBoolean(unlocalizedName, complete);
 	}
 
+	/**
+	 * Read this challenge from the provided NBT tag.
+	 * @param cmp The tag to read this challenge from.
+	 */
 	public void readFromNBT(NBTTagCompound cmp) {
 		complete = cmp.getBoolean(unlocalizedName);
 	}

--- a/src/main/java/vazkii/botania/client/challenge/EnumChallengeLevel.java
+++ b/src/main/java/vazkii/botania/client/challenge/EnumChallengeLevel.java
@@ -10,19 +10,49 @@
  */
 package vazkii.botania.client.challenge;
 
+/**
+ * An enumeration representing the possible difficulty levels of a challenge.
+ */
 public enum EnumChallengeLevel {
 
+	/**
+	 * An "easy" challenge - something with a few moving parts which automates a mundane task.
+	 */
 	EASY("botania.challengelevel.easy"),
+
+	/**
+	 * A normal challenge for sane people who like to automate things.
+	 */
 	NORMAL("botania.challengelevel.normal"),
+
+	/**
+	 * A difficult challenge which requires complex interaction between flowers, blocks,
+	 * and game mechanics.
+	 */
 	HARD("botania.challengelevel.hard"),
+
+	/**
+	 * A challenge for those with too much time and too little sanity.
+	 */
 	LUNATIC("botania.challengelevel.lunatic");
 
-	String name;
+	/**
+	 * The name of the challenge.
+	 */
+	private String name;
 
+	/**
+	 * Constructs a new challenge level with the provided, unlocalized name.
+	 * @param name The unlocalized name of the challenge level.
+	 */
 	private EnumChallengeLevel(String name) {
 		this.name = name;
 	}
 
+	/**
+	 * Returns the unlocalized name of the challenge level.
+	 * @return The unlocalized name of the challenge level.
+	 */
 	public String getName() {
 		return name;
 	}

--- a/src/main/java/vazkii/botania/client/challenge/ModChallenges.java
+++ b/src/main/java/vazkii/botania/client/challenge/ModChallenges.java
@@ -25,13 +25,26 @@ import vazkii.botania.common.lib.LibBlockNames;
 
 public final class ModChallenges {
 
-	public static final EnumMap<EnumChallengeLevel, List<Challenge>> challenges = new EnumMap(EnumChallengeLevel.class);
-	public static final HashMap<String, Challenge> challengeLookup = new HashMap();
+	/**
+	 * A map of challenge levels to a list of the challenges of that level.
+	 */
+	public static final EnumMap<EnumChallengeLevel, List<Challenge>> challenges =
+			new EnumMap<EnumChallengeLevel, List<Challenge>>(EnumChallengeLevel.class);
 
+	/**
+	 * A map of challenge names to their corresponding challenge objects.
+	 */
+	public static final HashMap<String, Challenge> challengeLookup = new HashMap<String, Challenge>();
+
+	/**
+	 * Initializes the default challenges in Botania, adding them to the lookup tables.
+	 */
 	public static void init() {
-		for(EnumChallengeLevel level : EnumChallengeLevel.class.getEnumConstants())
-			challenges.put(level, new ArrayList());
+		// Fill the challenge map with empty lists
+		for(EnumChallengeLevel level : EnumChallengeLevel.values())
+			challenges.put(level, new ArrayList<Challenge>());
 
+		// Easy Challenges
 		addChallenge(EnumChallengeLevel.EASY, "flowerFarm", new ItemStack(ModBlocks.flower, 1, 6));
 		addChallenge(EnumChallengeLevel.EASY, "recordFarm", new ItemStack(Items.record_13));
 		addChallenge(EnumChallengeLevel.EASY, "reedFarm", new ItemStack(Items.reeds));
@@ -39,6 +52,7 @@ public final class ModChallenges {
 		addChallenge(EnumChallengeLevel.EASY, "pureDaisy", ItemBlockSpecialFlower.ofType(LibBlockNames.SUBTILE_PUREDAISY));
 		addChallenge(EnumChallengeLevel.EASY, "battery", new ItemStack(ModBlocks.pool));
 
+		// Normal Challenges
 		addChallenge(EnumChallengeLevel.NORMAL, "apothecaryRefill", new ItemStack(ModBlocks.altar));
 		addChallenge(EnumChallengeLevel.NORMAL, "treeFarm", new ItemStack(Blocks.sapling));
 		addChallenge(EnumChallengeLevel.NORMAL, "fullCropFarm", new ItemStack(Items.wheat_seeds));
@@ -46,18 +60,29 @@ public final class ModChallenges {
 		addChallenge(EnumChallengeLevel.NORMAL, "boneMealFarm", new ItemStack(Items.dye, 1, 15));
 		addChallenge(EnumChallengeLevel.NORMAL, "orechid", ItemBlockSpecialFlower.ofType(LibBlockNames.SUBTILE_ORECHID));
 
+		// Hard Challenges
 		addChallenge(EnumChallengeLevel.HARD, "mobTower", new ItemStack(Items.bone));
 		addChallenge(EnumChallengeLevel.HARD, "entropinnyumSetup", ItemBlockSpecialFlower.ofType(LibBlockNames.SUBTILE_ENTROPINNYUM));
 		addChallenge(EnumChallengeLevel.HARD, "spectrolusSetup", ItemBlockSpecialFlower.ofType(LibBlockNames.SUBTILE_SPECTROLUS));
 		addChallenge(EnumChallengeLevel.HARD, "potionBrewer", new ItemStack(ModBlocks.brewery));
 
+		// You have a problem
 		addChallenge(EnumChallengeLevel.LUNATIC, "kekimurusSetup", ItemBlockSpecialFlower.ofType(LibBlockNames.SUBTILE_KEKIMURUS));
 		addChallenge(EnumChallengeLevel.LUNATIC, "autoQuarry", new ItemStack(Items.diamond_pickaxe));
 		addChallenge(EnumChallengeLevel.LUNATIC, "runeCrafter", new ItemStack(ModItems.rune));
 	}
 
+	/**
+	 * Adds a challenge to the Botania challenge registry, so that it will show up in the
+	 * Lexica Botania as a challenge.
+	 * @param level The difficulty level of this challenge.
+	 * @param name The name of this challenge.
+	 * @param icon The icon of this challenge, represented as the icon of the provided item stack.
+	 */
 	public static void addChallenge(EnumChallengeLevel level, String name, ItemStack icon) {
 		Challenge c = new Challenge("botania.challenge." + name, icon, level);
+
+		// Insert the challenge
 		challenges.get(level).add(c);
 		challengeLookup.put(c.unlocalizedName, c);
 	}


### PR DESCRIPTION
Refactors the three classes in `client.challenge` by adding comments and removing warnings. Not too much to say, really, other than check over the diff. There may be several of these types of PRs over the next few days, as they are a lot less about coding and a lot more about documentation.

(Adding comments makes me feel better).

Also, challenges still work, of course:

![2016-01-15_19 35 04](https://cloud.githubusercontent.com/assets/616490/12369605/52f87aae-bbc0-11e5-9ea7-d92671a8aa82.png)
