### PR TITLE
Added support for StorageDrawers and Deep Storage API

### DIFF
--- a/src/api/java/com/jaquadro/minecraft/storagedrawers/api/inventory/IDrawerInventory.java
+++ b/src/api/java/com/jaquadro/minecraft/storagedrawers/api/inventory/IDrawerInventory.java
@@ -1,0 +1,35 @@
+package com.jaquadro.minecraft.storagedrawers.api.inventory;
+
+import net.minecraft.inventory.ISidedInventory;
+import net.minecraft.item.ItemStack;
+
+public interface IDrawerInventory extends ISidedInventory
+{
+    /**
+     * Gets a drawer's group slot index from an IInventory slot index.
+     *
+     * @param inventorySlot An IInventory slot index returned from getInventorySlot.
+     */
+    int getDrawerSlot (int inventorySlot);
+
+    /**
+     * Gets an IInventory slot index suitable for operations for the given type.
+     *
+     * @param drawerSlot The index of the drawer within its group.
+     * @param type The type of IInventory slot to return an index for.
+     */
+    int getInventorySlot (int drawerSlot, SlotType type);
+
+    /**
+     * Gets the type associated with a given IInventory slot index.
+     *
+     * @param inventorySlot An IInventory slot index returned from getInventorySlot.
+     */
+    SlotType getInventorySlotType (int inventorySlot);
+
+    boolean canInsertItem (int slot, ItemStack stack);
+
+    boolean canExtractItem (int slot, ItemStack stack);
+
+    boolean syncInventoryIfNeeded ();
+}

--- a/src/api/java/com/jaquadro/minecraft/storagedrawers/api/inventory/SlotType.java
+++ b/src/api/java/com/jaquadro/minecraft/storagedrawers/api/inventory/SlotType.java
@@ -1,0 +1,15 @@
+package com.jaquadro.minecraft.storagedrawers.api.inventory;
+
+/**
+ * Classifies different IInventory slots according to how they should be used.
+ */
+public enum SlotType
+{
+    /** An inventory slot for input-only operations; stack sizes artificially held low. */
+    INPUT,
+
+    /** An inventory slot for output-only operations; stack sizes artificially held high. */
+    OUTPUT;
+
+    public static final SlotType[] values = values();
+}

--- a/src/api/java/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawer.java
+++ b/src/api/java/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawer.java
@@ -1,0 +1,110 @@
+package com.jaquadro.minecraft.storagedrawers.api.storage;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+
+public interface IDrawer
+{
+    /**
+     * Gets an ItemStack of size 1 representing the type, metadata, and tags of the stored items.
+     * The returned ItemStack should not be modified for any reason.  Make a copy if you need to store or modify it.
+     */
+    ItemStack getStoredItemPrototype ();
+
+    /**
+     * Gets an ItemStack initialized to the number of items stored in this drawer.
+     * The returned ItemStack is guaranteed to be a new copy and can be used for any purpose.  Does not affect drawer contents.
+     */
+    ItemStack getStoredItemCopy ();
+
+    /**
+     * Sets the type of the stored item and initializes it to the given amount.  Any existing item will be replaced.
+     *
+     * @param itemPrototype An ItemStack representing the type, metadata, and tags of the item to store.
+     * @param amount The amount to initialize the stored item count to.
+     */
+    void setStoredItem (ItemStack itemPrototype, int amount);
+
+    /**
+     * Gets the number of items stored in this drawer.
+     */
+    int getStoredItemCount ();
+
+    /**
+     * Sets the number of items stored in this drawer.  Triggers syncing of inventories and client data.
+     * Setting a drawer's count to 0 may also result in the item type being cleared, depending in implementation.
+     *
+     * @param amount The new amount of items stored in this drawer.
+     */
+    void setStoredItemCount (int amount);
+
+    /**
+     * Gets the maximum number of items that can be stored in this drawer.
+     * This value will vary depending on the max stack size of the stored item type.
+     */
+    int getMaxCapacity ();
+
+    /**
+     * Gets the maximum number of items that could be stored in this drawer if it held the given item.
+     *
+     * @param itemPrototype The item type to query.
+     */
+    int getMaxCapacity (ItemStack itemPrototype);
+
+    /**
+     * Gets the number of items that could still be added to this drawer before it is full.
+     */
+    int getRemainingCapacity ();
+
+    /**
+     * Gets the max stack size of the item type stored in this drawer.  Convenience method.
+     */
+    int getStoredItemStackSize ();
+
+    /**
+     * Gets whether or not an item of the given type and data can be stored in this drawer.
+     *
+     * Stack size and available capacity are not considered.  For drawers that are not empty, this
+     * method can allow ore-dictionary compatible items to be accepted into the drawer, as defined by what
+     * the drawer considers to be an equivalent item.
+     * For drawers that are empty, locking status is considered.
+     *
+     * @param itemPrototype An ItemStack representing the type, metadata, and tags of an item.
+     */
+    boolean canItemBeStored (ItemStack itemPrototype);
+
+    /**
+     * Gets whether or not an item of the given type and data can be extracted from this drawer.
+     *
+     * This is intended to allow outbound ore-dictionary conversions of compatible items, as defined by what
+     * the drawer considers to be an equivalent item.
+     *
+     * @param itemPrototype An ItemStack representing the type, metadata, and tags of an item.
+     */
+    boolean canItemBeExtracted (ItemStack itemPrototype);
+
+    /**
+     * Gets whether or not the drawer has items.
+     * A drawer set with an item type and 0 count is not considered empty.
+     */
+    boolean isEmpty ();
+
+    /**
+     * Gets auxiliary data that has been associated with this drawer.
+     *
+     * @param key The key used to identify the data.
+     * @return An opaque object that was previously stored.
+     */
+    Object getExtendedData (String key);
+
+    /**
+     * Stores auxiliary data with this drawer, mainly for use in integration.
+     * @param key The key to identify the data with.
+     * @param data The data to store.
+     */
+    void setExtendedData (String key, Object data);
+
+    void writeToNBT (NBTTagCompound tag);
+
+    void readFromNBT (NBTTagCompound tag);
+}

--- a/src/api/java/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawerGroup.java
+++ b/src/api/java/com/jaquadro/minecraft/storagedrawers/api/storage/IDrawerGroup.java
@@ -1,0 +1,25 @@
+package com.jaquadro.minecraft.storagedrawers.api.storage;
+
+import com.jaquadro.minecraft.storagedrawers.api.inventory.IDrawerInventory;
+
+public interface IDrawerGroup
+{
+    /**
+     * Gets the number of drawers contained within this group.
+     */
+    int getDrawerCount ();
+
+    /**
+     * Gets the drawer at the given slot within this group.
+     */
+    IDrawer getDrawer (int slot);
+
+    /**
+     * Gets whether the drawer in the given slot is usable.
+     */
+    boolean isDrawerEnabled (int slot);
+
+    IDrawerInventory getDrawerInventory ();
+
+    boolean markDirtyIfNeeded ();
+}

--- a/src/main/java/powercrystals/minefactoryreloaded/api/IDeepStorageUnit.java
+++ b/src/main/java/powercrystals/minefactoryreloaded/api/IDeepStorageUnit.java
@@ -1,0 +1,29 @@
+package powercrystals.minefactoryreloaded.api;
+
+import net.minecraft.item.ItemStack;
+
+public interface IDeepStorageUnit
+{
+	/**
+	 * @return A populated ItemStack with stackSize for the full amount of materials in the DSU.
+	 * May have a stackSize > getMaxStackSize(). May have a stackSize of 0 (indicating locked contents).
+	 */
+	ItemStack getStoredItemType();
+
+	/**
+	 * Sets the total amount of the item currently being stored, or zero if all items are to be removed.
+	 */
+	void setStoredItemCount(int amount);
+
+	/**
+	 * Sets the type of the stored item and initializes the number of stored items to amount.
+	 * Will overwrite any existing stored items.
+	 */
+	void setStoredItemType(ItemStack type, int amount);
+
+	/**
+	 * @return The maximum number of items the DSU can hold.
+	 * May change based on the current type stored.
+	 */
+	int getMaxStoredCount();
+}

--- a/src/main/java/vazkii/botania/api/corporea/CorporeaRequest.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaRequest.java
@@ -1,0 +1,17 @@
+package vazkii.botania.api.corporea;
+
+public class CorporeaRequest {
+	Object matcher;
+	boolean checkNBT;
+	int count;
+	int foundItems = 0;
+	int extractedItems = 0;
+	
+	public CorporeaRequest(Object matcher, boolean checkNBT, int count) {
+		super();
+		this.matcher = matcher;
+		this.checkNBT = checkNBT;
+		this.count = count;
+	}
+
+}

--- a/src/main/java/vazkii/botania/api/corporea/IWrappedInventory.java
+++ b/src/main/java/vazkii/botania/api/corporea/IWrappedInventory.java
@@ -1,0 +1,48 @@
+package vazkii.botania.api.corporea;
+
+import java.util.List;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+
+/**
+ * This interface wraps IInventory corporea works with in order to provide
+ * compatibility with different storage mods.
+ * 
+ */
+public interface IWrappedInventory {
+
+	/**
+	 * Break encapsulation and exposes original inventory.
+	 */
+	IInventory getWrappedObject();
+
+	/**
+	 * Counts items in the inventory matching the request
+	 * 
+	 * @param request
+	 *            - specifies what should be found
+	 * @return List of ItemStack, individual stacks may exceed maxStackSize for
+	 *         purposes of counting huge amounts. To get final count requestor
+	 *         should sum stackSize of all stacks.
+	 */
+	List<ItemStack> countItems(CorporeaRequest request);
+
+	/**
+	 * Convenience method for accessing spark over inventory
+	 */
+	ICorporeaSpark getSpark();
+
+	/**
+	 * Extracts items matching request from the inventory.<br/>
+	 * {@link CorporeaRequest#count} is updated to reflect how many items are
+	 * yet to be extracted.<br/>
+	 * {@link CorporeaRequest#foundItems} and
+	 * {@link CorporeaRequest#extractedItems} are updated to reflect how many
+	 * items were found and extracted.
+	 * 
+	 * @param request
+	 * @return List of ItemStacks to be delivered to the destination.
+	 */
+	List<ItemStack> extractItems(CorporeaRequest request);
+}

--- a/src/main/java/vazkii/botania/api/corporea/WrappedDeepStorage.java
+++ b/src/main/java/vazkii/botania/api/corporea/WrappedDeepStorage.java
@@ -1,0 +1,95 @@
+package vazkii.botania.api.corporea;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import powercrystals.minefactoryreloaded.api.IDeepStorageUnit;
+
+/**
+ * Wrapper for StorageDrawers compatibility.
+ *
+ */
+public class WrappedDeepStorage extends WrappedInvenotryBase implements IWrappedInventory {
+
+	private IDeepStorageUnit inv;
+
+	private WrappedDeepStorage(IDeepStorageUnit inv, ICorporeaSpark spark) {
+		this.inv = inv;
+		this.spark = spark;
+	}
+
+	@Override
+	public IInventory getWrappedObject() {
+		return (IInventory) inv;
+	}
+
+	@Override
+	public List<ItemStack> countItems(CorporeaRequest request) {
+		return iterateOverStacks(request, false);
+	}
+
+	@Override
+	public List<ItemStack> extractItems(CorporeaRequest request) {
+		return iterateOverStacks(request, true);
+	}
+
+	private List<ItemStack> iterateOverStacks(CorporeaRequest request, boolean doit) {
+		List<ItemStack> stacks = new ArrayList<ItemStack>();
+		boolean removedAny = false;
+
+		ItemStack prototype = inv.getStoredItemType();
+		if (prototype == null){
+			//for the case of barrel without contents set
+			return stacks;
+		}
+		int storedCount = prototype.stackSize;
+		
+		//WARNING: this code is very similar in all implementations of IWrappedInventory - keep it synch
+		//this code is also near duplicate to WrappedStorageDrawers - keep it synchronized
+		if (isMatchingItemStack(request.matcher, request.checkNBT, prototype)) {
+			int rem = Math.min(storedCount, request.count == -1 ? storedCount : request.count);
+
+			if (rem > 0) {
+				ItemStack copy = prototype.copy();
+				copy.stackSize = rem;
+				if (doit) {
+					stacks.addAll(breakDownBigStack(copy));
+				} else {
+					stacks.add(copy);
+				}
+			}
+
+			request.foundItems += storedCount;
+			request.extractedItems += rem;
+
+			if (doit && rem > 0) {
+				decreaseStoredCount(inv, rem);
+
+				removedAny = true;
+				if (spark != null)
+					spark.onItemExtracted(prototype);
+			}
+			if (request.count != -1)
+				request.count -= rem;
+		}
+		if (removedAny) {
+			// inv.markDirtyIfNeeded();
+		}
+		return stacks;
+	}
+
+	private void decreaseStoredCount(IDeepStorageUnit inventory, int rem) {
+		inventory.setStoredItemCount(inventory.getStoredItemType().stackSize - rem);
+	}
+
+	/**
+	 * Creates {@link WrappedDeepStorage} if specified inv can be wrapped.
+	 * 
+	 * @return wrapped invenotry or null if it has incompatible type.
+	 */
+	public static IWrappedInventory wrap(IInventory inv, ICorporeaSpark spark) {
+		return inv instanceof IDeepStorageUnit ? new WrappedDeepStorage((IDeepStorageUnit) inv, spark) : null;
+	}
+}

--- a/src/main/java/vazkii/botania/api/corporea/WrappedIInventory.java
+++ b/src/main/java/vazkii/botania/api/corporea/WrappedIInventory.java
@@ -1,0 +1,78 @@
+package vazkii.botania.api.corporea;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+
+public class WrappedIInventory extends WrappedInvenotryBase implements IWrappedInventory {
+
+	private IInventory inv;
+
+	private WrappedIInventory(IInventory inv, ICorporeaSpark spark) {
+		this.inv = inv;
+		this.spark = spark;
+	}
+
+	@Override
+	public IInventory getWrappedObject() {
+		return inv;
+	}
+
+	@Override
+	public List<ItemStack> countItems(CorporeaRequest request) {
+		return iterateOverSlots(request, false);
+	}
+
+	@Override
+	public List<ItemStack> extractItems(CorporeaRequest request) {
+		return iterateOverSlots(request, true);
+	}
+
+	private List<ItemStack> iterateOverSlots(CorporeaRequest request, boolean doit) {
+		List<ItemStack> stacks = new ArrayList<ItemStack>();
+
+		boolean removedAny = false;
+		for (int i = inv.getSizeInventory() - 1; i >= 0; i--) {
+			if (!CorporeaHelper.isValidSlot(inv, i))
+				continue;
+
+			ItemStack stackAt = inv.getStackInSlot(i);
+			//WARNING: this code is very similar in all implementations of IWrappedInventory - keep it synch
+			if (isMatchingItemStack(request.matcher, request.checkNBT, stackAt)) {
+				int rem = Math.min(stackAt.stackSize, request.count == -1 ? stackAt.stackSize : request.count);
+
+				if (rem > 0) {
+					ItemStack copy = stackAt.copy();
+					if (rem < copy.stackSize)
+						copy.stackSize = rem;
+					stacks.add(copy);
+				}
+
+				request.foundItems += stackAt.stackSize;
+				request.extractedItems += rem;
+
+				if (doit && rem > 0) {
+					inv.decrStackSize(i, rem);
+					removedAny = true;
+					if (spark != null)
+						spark.onItemExtracted(stackAt);
+				}
+				if (request.count != -1)
+					request.count -= rem;
+			}
+		}
+
+		if (removedAny) {
+			inv.markDirty();
+		}
+
+		return stacks;
+	}
+
+	public static IWrappedInventory wrap(IInventory inv, ICorporeaSpark spark) {
+		return new WrappedIInventory(inv, spark);
+	}
+
+}

--- a/src/main/java/vazkii/botania/api/corporea/WrappedInvenotryBase.java
+++ b/src/main/java/vazkii/botania/api/corporea/WrappedInvenotryBase.java
@@ -1,0 +1,40 @@
+package vazkii.botania.api.corporea;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import net.minecraft.item.ItemStack;
+
+public abstract class WrappedInvenotryBase implements IWrappedInventory {
+
+	protected ICorporeaSpark spark;
+
+	@Override
+	public ICorporeaSpark getSpark() {
+		return spark;
+	}
+
+	protected boolean isMatchingItemStack(Object matcher, boolean checkNBT, ItemStack stackAt) {
+		return matcher instanceof ItemStack ? CorporeaHelper.stacksMatch((ItemStack) matcher, stackAt, checkNBT)
+				: matcher instanceof String ? CorporeaHelper.stacksMatch(stackAt, (String) matcher) : false;
+	}
+
+	protected Collection<? extends ItemStack> breakDownBigStack(ItemStack stack) {
+		List<ItemStack> stacks = new ArrayList<ItemStack>();
+		int additionalStacks = stack.stackSize / stack.getMaxStackSize();
+		int lastStackSize = stack.stackSize % stack.getMaxStackSize();
+		if (additionalStacks > 0) {
+			ItemStack fullStack = stack.copy();
+			fullStack.stackSize = stack.getMaxStackSize();
+			for (int i = 0; i < additionalStacks; i++) {
+				stacks.add(fullStack.copy());
+			}
+		}
+		ItemStack lastStack = stack.copy();
+		lastStack.stackSize = lastStackSize;
+		stacks.add(lastStack);
+	
+		return stacks;
+	}
+}

--- a/src/main/java/vazkii/botania/api/corporea/WrappedStorageDrawers.java
+++ b/src/main/java/vazkii/botania/api/corporea/WrappedStorageDrawers.java
@@ -1,0 +1,98 @@
+package vazkii.botania.api.corporea;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawer;
+import com.jaquadro.minecraft.storagedrawers.api.storage.IDrawerGroup;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+
+/**
+ * Wrapper for StorageDrawers compatibility. 
+ *
+ */
+public class WrappedStorageDrawers extends WrappedInvenotryBase implements IWrappedInventory {
+
+	private IDrawerGroup inv;
+
+	private WrappedStorageDrawers(IDrawerGroup inv, ICorporeaSpark spark) {
+		this.inv = inv;
+		this.spark = spark;
+	}
+
+	@Override
+	public IInventory getWrappedObject() {
+		return (IInventory) inv;
+	}
+
+	@Override
+	public List<ItemStack> countItems(CorporeaRequest request) {
+		return iterateOverStacks(request, false);
+	}
+
+	@Override
+	public List<ItemStack> extractItems(CorporeaRequest request) {
+		return iterateOverStacks(request, true);
+	}
+
+	private List<ItemStack> iterateOverStacks(CorporeaRequest request, boolean doit) {
+		List<ItemStack> stacks = new ArrayList<ItemStack>();
+		boolean removedAny = false;
+
+		for (int i = 0; i < inv.getDrawerCount(); i++) {
+			IDrawer drawer = inv.getDrawer(i);
+			if (drawer == null) {
+				continue;
+			}
+			ItemStack prototype = drawer.getStoredItemPrototype();
+			int storedCount = drawer.getStoredItemCount();
+			
+			//WARNING: this code is very similar in all implementations of IWrappedInventory - keep it synch
+			//also this code is near duplicate to WrappedDeepStorage - keep it synchronized
+			if (isMatchingItemStack(request.matcher, request.checkNBT, prototype)) {
+				int rem = Math.min(storedCount,	request.count == -1 ? storedCount : request.count);
+
+				if (rem > 0) {
+					ItemStack copy = prototype.copy();
+					copy.stackSize = rem;
+					if (doit) {
+						stacks.addAll(breakDownBigStack(copy));
+					} else {
+						stacks.add(copy);
+					}
+				}
+
+				request.foundItems += storedCount;
+				request.extractedItems += rem;
+
+				if (doit && rem > 0) {
+					decreaseStoredCount(drawer, rem);
+					
+					removedAny = true;
+					if (spark != null)
+						spark.onItemExtracted(prototype);
+				}
+				if (request.count != -1)
+					request.count -= rem;
+			}
+		}
+		if (removedAny) {
+			inv.markDirtyIfNeeded();
+		}
+		return stacks;
+	}
+
+	private void decreaseStoredCount(IDrawer drawer, int rem) {
+		drawer.setStoredItemCount(drawer.getStoredItemCount() - rem);
+	}
+
+	/**
+	 * Creates {@link WrappedStorageDrawers} if specified inv can be wrapped.
+	 * @return wrapped invenotry or null if it has incompatible type.
+	 */
+	public static IWrappedInventory wrap(IInventory inv, ICorporeaSpark spark){
+		return inv instanceof IDrawerGroup ? new WrappedStorageDrawers((IDrawerGroup) inv, spark) : null;
+	}
+}

--- a/src/main/java/vazkii/botania/common/Botania.java
+++ b/src/main/java/vazkii/botania/common/Botania.java
@@ -41,6 +41,7 @@ public class Botania {
 	public static boolean bloodMagicLoaded = false;
 	public static boolean coloredLightsLoaded = false;
 	public static boolean etFuturumLoaded = false;
+	public static boolean storageDrawersLoaded = false;
 
 	public static ILightHelper lightHelper;
 
@@ -59,7 +60,8 @@ public class Botania {
 		bloodMagicLoaded = Loader.isModLoaded("AWWayofTime"); // Psh, noob
 		coloredLightsLoaded = Loader.isModLoaded("easycoloredlights");
 		etFuturumLoaded = Loader.isModLoaded("etfuturum");
-
+		storageDrawersLoaded = Loader.isModLoaded("StorageDrawers");
+		
 		lightHelper = coloredLightsLoaded ? new LightHelperColored() : new LightHelperVanilla();
 
 		proxy.preInit(event);


### PR DESCRIPTION
Added wrapper around IInventory for integration with different storage systems. Used this for Storage Drawers and JABBA (general Deep Storage API).

I had to include Deep Storage API in Botania, which is quite ugly :-( But it will add mass support for all inventories using this API, which is apparently plenty.

TODO:
I don't have correct formatter for Botania - formatting may be off.