### PR TITLE
Add a color function to the RenderTileFloatingFlower

### DIFF
--- a/src/main/java/vazkii/botania/client/render/tile/RenderTileFloatingFlower.java
+++ b/src/main/java/vazkii/botania/client/render/tile/RenderTileFloatingFlower.java
@@ -10,6 +10,7 @@
  */
 package vazkii.botania.client.render.tile;
 
+import java.awt.*;
 import java.util.Random;
 
 import net.minecraft.client.Minecraft;
@@ -52,11 +53,14 @@ public class RenderTileFloatingFlower extends TileEntitySpecialRenderer {
 		}
 
 		Minecraft.getMinecraft().renderEngine.bindTexture(flower.getIslandType().getResource());
+		Color color = new Color(flower.getIslandType().getColor());
+		GL11.glColor3f(color.getRed() / 255f, color.getGreen() / 255f, color.getBlue() / 255f);
 		GL11.glPushMatrix();
 		GL11.glTranslatef(0.5F, 1.4F, 0.5F);
 		GL11.glScalef(1F, -1F, -1F);
 		model.render();
 		GL11.glPopMatrix();
+		GL11.glColor3f(1f, 1f, 1f);
 
 		ItemStack stack = flower.getDisplayStack();
 		IIcon icon = stack.getIconIndex();

--- a/src/main/java/vazkii/botania/common/block/decor/IFloatingFlower.java
+++ b/src/main/java/vazkii/botania/common/block/decor/IFloatingFlower.java
@@ -61,6 +61,10 @@ public interface IFloatingFlower {
 			return res;
 		}
 
+		public int getColor() {
+			return 0xFFFFFF;
+		}
+
 		public String toString() {
 			return this.typeName;
 		}


### PR DESCRIPTION
Derivative classes can use it (allows for rainbow floating flowers)

This is something Botanical Addons requires for one of its Iris Seed variants