### PR TITLE
Added ManaItemsEvent

### DIFF
--- a/src/main/java/vazkii/botania/api/mana/ManaItemHandler.java
+++ b/src/main/java/vazkii/botania/api/mana/ManaItemHandler.java
@@ -30,8 +30,7 @@ public final class ManaItemHandler {
 	 * their player-associated inventories.
 	 * @return The list of items
 	 */
-	public static List<ItemStack> getManaItems(EntityPlayer player)
-	{
+	public static List<ItemStack> getManaItems(EntityPlayer player) {
 		if (player == null)
 			return new ArrayList<ItemStack>();
 		
@@ -58,8 +57,7 @@ public final class ManaItemHandler {
 	 * Gets a list containing all mana-holding items in a player's baubles inventory.
 	 * @return The list of items
 	 */
-	public static Map<Integer, ItemStack> getManaBaubles(EntityPlayer player)
-	{
+	public static Map<Integer, ItemStack> getManaBaubles(EntityPlayer player) {
 		if (player == null)
 			return new HashMap<Integer, ItemStack>();
 		
@@ -94,8 +92,7 @@ public final class ManaItemHandler {
 			return 0;
 
 		List<ItemStack> items = getManaItems(player);
-		for (ItemStack stackInSlot : items)
-		{
+		for (ItemStack stackInSlot : items) {
 			if(stackInSlot == stack)
 				continue;
 			IManaItem manaItem = (IManaItem) stackInSlot.getItem();
@@ -113,8 +110,7 @@ public final class ManaItemHandler {
 		}
 		
 		Map<Integer, ItemStack> baubles = getManaBaubles(player);
-		for (Entry<Integer, ItemStack> entry : baubles.entrySet())
-		{
+		for (Entry<Integer, ItemStack> entry : baubles.entrySet()) {
 			ItemStack stackInSlot = entry.getValue();
 			if(stackInSlot == stack)
 				continue;
@@ -149,8 +145,7 @@ public final class ManaItemHandler {
 			return false;
 
 		List<ItemStack> items = getManaItems(player);
-		for (ItemStack stackInSlot : items)
-		{
+		for (ItemStack stackInSlot : items) {
 			if(stackInSlot == stack)
 				continue;
 			IManaItem manaItemSlot = (IManaItem) stackInSlot.getItem();
@@ -166,8 +161,7 @@ public final class ManaItemHandler {
 		}
 		
 		Map<Integer, ItemStack> baubles = getManaBaubles(player);
-		for (Entry<Integer, ItemStack> entry : baubles.entrySet())
-		{
+		for (Entry<Integer, ItemStack> entry : baubles.entrySet()) {
 			ItemStack stackInSlot = entry.getValue();
 			if(stackInSlot == stack)
 				continue;
@@ -199,8 +193,7 @@ public final class ManaItemHandler {
 			return 0;
 
 		List<ItemStack> items = getManaItems(player);
-		for (ItemStack stackInSlot : items)
-		{
+		for (ItemStack stackInSlot : items) {
 			if(stackInSlot == stack)
 				continue;
 			IManaItem manaItemSlot = (IManaItem) stackInSlot.getItem();
@@ -222,8 +215,7 @@ public final class ManaItemHandler {
 		}
 		
 		Map<Integer, ItemStack> baubles = getManaBaubles(player);
-		for (Entry<Integer, ItemStack> entry : baubles.entrySet())
-		{
+		for (Entry<Integer, ItemStack> entry : baubles.entrySet()) {
 			ItemStack stackInSlot = entry.getValue();
 			if(stackInSlot == stack)
 				continue;
@@ -261,8 +253,7 @@ public final class ManaItemHandler {
 			return false;
 
 		List<ItemStack> items = getManaItems(player);
-		for (ItemStack stackInSlot : items)
-		{
+		for (ItemStack stackInSlot : items) {
 			if(stackInSlot == stack)
 				continue;
 			IManaItem manaItemSlot = (IManaItem) stackInSlot.getItem();
@@ -278,8 +269,7 @@ public final class ManaItemHandler {
 		}
 		
 		Map<Integer, ItemStack> baubles = getManaBaubles(player);
-		for (Entry<Integer, ItemStack> entry : baubles.entrySet())
-		{
+		for (Entry<Integer, ItemStack> entry : baubles.entrySet()) {
 			ItemStack stackInSlot = entry.getValue();
 			if(stackInSlot == stack)
 				continue;

--- a/src/main/java/vazkii/botania/api/mana/ManaItemHandler.java
+++ b/src/main/java/vazkii/botania/api/mana/ManaItemHandler.java
@@ -10,6 +10,12 @@
  */
 package vazkii.botania.api.mana;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
@@ -18,6 +24,64 @@ import vazkii.botania.api.BotaniaAPI;
 
 public final class ManaItemHandler {
 
+	/**
+	 * Gets a list containing all mana-holding items in a player's inventory.
+	 * Also includes a call to ManaItemsEvent, so other mods can add items from
+	 * their player-associated inventories.
+	 * @return The list of items
+	 */
+	public static List<ItemStack> getManaItems(EntityPlayer player)
+	{
+		if (player == null)
+			return new ArrayList<ItemStack>();
+		
+		IInventory mainInv = player.inventory;
+		
+		List<ItemStack> toReturn = new ArrayList<ItemStack>();
+		int size = mainInv.getSizeInventory();
+
+		for(int slot = 0; slot < size; slot++) {
+			ItemStack stackInSlot = mainInv.getStackInSlot(slot);
+
+			if(stackInSlot != null && stackInSlot.getItem() instanceof IManaItem) {
+				toReturn.add(stackInSlot);
+			}
+		}
+		
+		ManaItemsEvent event = new ManaItemsEvent(player, toReturn);
+		MinecraftForge.EVENT_BUS.post(event);
+		toReturn = event.getItems();
+		return toReturn;
+	}
+	
+	/**
+	 * Gets a list containing all mana-holding items in a player's baubles inventory.
+	 * @return The list of items
+	 */
+	public static Map<Integer, ItemStack> getManaBaubles(EntityPlayer player)
+	{
+		if (player == null)
+			return new HashMap<Integer, ItemStack>();
+		
+		IInventory baublesInv = BotaniaAPI.internalHandler.getBaublesInventory(player);
+		if (baublesInv == null)
+			return new HashMap<Integer, ItemStack>();
+		
+		
+		Map<Integer, ItemStack> toReturn = new HashMap<Integer, ItemStack>();
+		int size = baublesInv.getSizeInventory();
+
+		for(int slot = 0; slot < size; slot++) {
+			ItemStack stackInSlot = baublesInv.getStackInSlot(slot);
+
+			if(stackInSlot != null && stackInSlot.getItem() instanceof IManaItem) {
+				toReturn.put(slot, stackInSlot);
+			}
+		}
+		
+		return toReturn;
+	}
+	
 	/**
 	 * Requests mana from items in a given player's inventory.
 	 * @param manaToGet How much mana is to be requested, if less mana exists than this amount,
@@ -29,37 +93,44 @@ public final class ManaItemHandler {
 		if(stack == null)
 			return 0;
 
-		IInventory mainInv = player.inventory;
-		IInventory baublesInv = BotaniaAPI.internalHandler.getBaublesInventory(player);
-
-		int invSize = mainInv.getSizeInventory();
-		int size = invSize;
-		if(baublesInv != null)
-			size += baublesInv.getSizeInventory();
-
-		for(int i = 0; i < size; i++) {
-			boolean useBaubles = i >= invSize;
-			IInventory inv = useBaubles ? baublesInv : mainInv;
-			int slot = i - (useBaubles ? invSize : 0);
-			ItemStack stackInSlot = inv.getStackInSlot(slot);
+		List<ItemStack> items = getManaItems(player);
+		for (ItemStack stackInSlot : items)
+		{
 			if(stackInSlot == stack)
 				continue;
+			IManaItem manaItem = (IManaItem) stackInSlot.getItem();
+			if(manaItem.canExportManaToItem(stackInSlot, stack) && manaItem.getMana(stackInSlot) > 0) {
+				if(stack.getItem() instanceof IManaItem && !((IManaItem) stack.getItem()).canReceiveManaFromItem(stack, stackInSlot))
+					continue;
 
-			if(stackInSlot != null && stackInSlot.getItem() instanceof IManaItem) {
-				IManaItem manaItem = (IManaItem) stackInSlot.getItem();
-				if(manaItem.canExportManaToItem(stackInSlot, stack) && manaItem.getMana(stackInSlot) > 0) {
-					if(stack.getItem() instanceof IManaItem && !((IManaItem) stack.getItem()).canReceiveManaFromItem(stack, stackInSlot))
-						continue;
+				int mana = Math.min(manaToGet, manaItem.getMana(stackInSlot));
 
-					int mana = Math.min(manaToGet, manaItem.getMana(stackInSlot));
+				if(remove)
+					manaItem.addMana(stackInSlot, -mana);
 
-					if(remove)
-						manaItem.addMana(stackInSlot, -mana);
-					if(useBaubles)
-						BotaniaAPI.internalHandler.sendBaubleUpdatePacket(player, slot);
+				return mana;
+			}
+		}
+		
+		Map<Integer, ItemStack> baubles = getManaBaubles(player);
+		for (Entry<Integer, ItemStack> entry : baubles.entrySet())
+		{
+			ItemStack stackInSlot = entry.getValue();
+			if(stackInSlot == stack)
+				continue;
+			IManaItem manaItem = (IManaItem) stackInSlot.getItem();
+			if(manaItem.canExportManaToItem(stackInSlot, stack) && manaItem.getMana(stackInSlot) > 0) {
+				if(stack.getItem() instanceof IManaItem && !((IManaItem) stack.getItem()).canReceiveManaFromItem(stack, stackInSlot))
+					continue;
 
-					return mana;
-				}
+				int mana = Math.min(manaToGet, manaItem.getMana(stackInSlot));
+
+				if(remove)
+					manaItem.addMana(stackInSlot, -mana);
+				
+				BotaniaAPI.internalHandler.sendBaubleUpdatePacket(player, entry.getKey());
+
+				return mana;
 			}
 		}
 
@@ -77,35 +148,39 @@ public final class ManaItemHandler {
 		if(stack == null)
 			return false;
 
-		IInventory mainInv = player.inventory;
-		IInventory baublesInv = BotaniaAPI.internalHandler.getBaublesInventory(player);
-
-		int invSize = mainInv.getSizeInventory();
-		int size = invSize;
-		if(baublesInv != null)
-			size += baublesInv.getSizeInventory();
-
-		for(int i = 0; i < size; i++) {
-			boolean useBaubles = i >= invSize;
-			IInventory inv = useBaubles ? baublesInv : mainInv;
-			int slot = i - (useBaubles ? invSize : 0);
-			ItemStack stackInSlot = inv.getStackInSlot(slot);
+		List<ItemStack> items = getManaItems(player);
+		for (ItemStack stackInSlot : items)
+		{
 			if(stackInSlot == stack)
 				continue;
+			IManaItem manaItemSlot = (IManaItem) stackInSlot.getItem();
+			if(manaItemSlot.canExportManaToItem(stackInSlot, stack) && manaItemSlot.getMana(stackInSlot) > manaToGet) {
+				if(stack.getItem() instanceof IManaItem && !((IManaItem) stack.getItem()).canReceiveManaFromItem(stack, stackInSlot))
+					continue;
 
-			if(stackInSlot != null && stackInSlot.getItem() instanceof IManaItem) {
-				IManaItem manaItemSlot = (IManaItem) stackInSlot.getItem();
-				if(manaItemSlot.canExportManaToItem(stackInSlot, stack) && manaItemSlot.getMana(stackInSlot) > manaToGet) {
-					if(stack.getItem() instanceof IManaItem && !((IManaItem) stack.getItem()).canReceiveManaFromItem(stack, stackInSlot))
-						continue;
+				if(remove)
+					manaItemSlot.addMana(stackInSlot, -manaToGet);
 
-					if(remove)
-						manaItemSlot.addMana(stackInSlot, -manaToGet);
-					if(useBaubles)
-						BotaniaAPI.internalHandler.sendBaubleUpdatePacket(player, slot);
+				return true;
+			}
+		}
+		
+		Map<Integer, ItemStack> baubles = getManaBaubles(player);
+		for (Entry<Integer, ItemStack> entry : baubles.entrySet())
+		{
+			ItemStack stackInSlot = entry.getValue();
+			if(stackInSlot == stack)
+				continue;
+			IManaItem manaItemSlot = (IManaItem) stackInSlot.getItem();
+			if(manaItemSlot.canExportManaToItem(stackInSlot, stack) && manaItemSlot.getMana(stackInSlot) > manaToGet) {
+				if(stack.getItem() instanceof IManaItem && !((IManaItem) stack.getItem()).canReceiveManaFromItem(stack, stackInSlot))
+					continue;
 
-					return true;
-				}
+				if(remove)
+					manaItemSlot.addMana(stackInSlot, -manaToGet);
+				BotaniaAPI.internalHandler.sendBaubleUpdatePacket(player, entry.getKey());
+
+				return true;
 			}
 		}
 
@@ -123,42 +198,51 @@ public final class ManaItemHandler {
 		if(stack == null)
 			return 0;
 
-		IInventory mainInv = player.inventory;
-		IInventory baublesInv = BotaniaAPI.internalHandler.getBaublesInventory(player);
-
-		int invSize = mainInv.getSizeInventory();
-		int size = invSize;
-		if(baublesInv != null)
-			size += baublesInv.getSizeInventory();
-
-		for(int i = 0; i < size; i++) {
-			boolean useBaubles = i >= invSize;
-			IInventory inv = useBaubles ? baublesInv : mainInv;
-			int slot = i - (useBaubles ? invSize : 0);
-			ItemStack stackInSlot = inv.getStackInSlot(slot);
+		List<ItemStack> items = getManaItems(player);
+		for (ItemStack stackInSlot : items)
+		{
 			if(stackInSlot == stack)
 				continue;
+			IManaItem manaItemSlot = (IManaItem) stackInSlot.getItem();
+			if(manaItemSlot.canReceiveManaFromItem(stackInSlot, stack)) {
+				if(stack.getItem() instanceof IManaItem && !((IManaItem) stack.getItem()).canExportManaToItem(stack, stackInSlot))
+					continue;
 
-			if(stackInSlot != null && stackInSlot.getItem() instanceof IManaItem) {
-				IManaItem manaItemSlot = (IManaItem) stackInSlot.getItem();
-
-				if(manaItemSlot.canReceiveManaFromItem(stackInSlot, stack)) {
-					if(stack.getItem() instanceof IManaItem && !((IManaItem) stack.getItem()).canExportManaToItem(stack, stackInSlot))
-						continue;
-
-					int received;
-					if(manaItemSlot.getMana(stackInSlot) + manaToSend <= manaItemSlot.getMaxMana(stackInSlot))
-						received = manaToSend;
-					else received = manaToSend - (manaItemSlot.getMana(stackInSlot) + manaToSend - manaItemSlot.getMaxMana(stackInSlot));
+				int received;
+				if(manaItemSlot.getMana(stackInSlot) + manaToSend <= manaItemSlot.getMaxMana(stackInSlot))
+					received = manaToSend;
+				else received = manaToSend - (manaItemSlot.getMana(stackInSlot) + manaToSend - manaItemSlot.getMaxMana(stackInSlot));
 
 
-					if(add)
-						manaItemSlot.addMana(stackInSlot, manaToSend);
-					if(useBaubles)
-						BotaniaAPI.internalHandler.sendBaubleUpdatePacket(player, slot);
+				if(add)
+					manaItemSlot.addMana(stackInSlot, manaToSend);
 
-					return received;
-				}
+				return received;
+			}
+		}
+		
+		Map<Integer, ItemStack> baubles = getManaBaubles(player);
+		for (Entry<Integer, ItemStack> entry : baubles.entrySet())
+		{
+			ItemStack stackInSlot = entry.getValue();
+			if(stackInSlot == stack)
+				continue;
+			IManaItem manaItemSlot = (IManaItem) stackInSlot.getItem();
+			if(manaItemSlot.canReceiveManaFromItem(stackInSlot, stack)) {
+				if(stack.getItem() instanceof IManaItem && !((IManaItem) stack.getItem()).canExportManaToItem(stack, stackInSlot))
+					continue;
+
+				int received;
+				if(manaItemSlot.getMana(stackInSlot) + manaToSend <= manaItemSlot.getMaxMana(stackInSlot))
+					received = manaToSend;
+				else received = manaToSend - (manaItemSlot.getMana(stackInSlot) + manaToSend - manaItemSlot.getMaxMana(stackInSlot));
+
+
+				if(add)
+					manaItemSlot.addMana(stackInSlot, manaToSend);
+				BotaniaAPI.internalHandler.sendBaubleUpdatePacket(player, entry.getKey());
+
+				return received;
 			}
 		}
 
@@ -176,35 +260,39 @@ public final class ManaItemHandler {
 		if(stack == null)
 			return false;
 
-		IInventory mainInv = player.inventory;
-		IInventory baublesInv = BotaniaAPI.internalHandler.getBaublesInventory(player);
-
-		int invSize = mainInv.getSizeInventory();
-		int size = invSize;
-		if(baublesInv != null)
-			size += baublesInv.getSizeInventory();
-
-		for(int i = 0; i < size; i++) {
-			boolean useBaubles = i >= invSize;
-			IInventory inv = useBaubles ? baublesInv : mainInv;
-			int slot = i - (useBaubles ? invSize : 0);
-			ItemStack stackInSlot = inv.getStackInSlot(slot);
+		List<ItemStack> items = getManaItems(player);
+		for (ItemStack stackInSlot : items)
+		{
 			if(stackInSlot == stack)
 				continue;
+			IManaItem manaItemSlot = (IManaItem) stackInSlot.getItem();
+			if(manaItemSlot.getMana(stackInSlot) + manaToSend <= manaItemSlot.getMaxMana(stackInSlot) && manaItemSlot.canReceiveManaFromItem(stackInSlot, stack)) {
+				if(stack.getItem() instanceof IManaItem && !((IManaItem) stack.getItem()).canExportManaToItem(stack, stackInSlot))
+					continue;
 
-			if(stackInSlot != null && stackInSlot.getItem() instanceof IManaItem) {
-				IManaItem manaItemSlot = (IManaItem) stackInSlot.getItem();
-				if(manaItemSlot.getMana(stackInSlot) + manaToSend <= manaItemSlot.getMaxMana(stackInSlot) && manaItemSlot.canReceiveManaFromItem(stackInSlot, stack)) {
-					if(stack.getItem() instanceof IManaItem && !((IManaItem) stack.getItem()).canExportManaToItem(stack, stackInSlot))
-						continue;
+				if(add)
+					manaItemSlot.addMana(stackInSlot, manaToSend);
+					
+				return true;
+			}
+		}
+		
+		Map<Integer, ItemStack> baubles = getManaBaubles(player);
+		for (Entry<Integer, ItemStack> entry : baubles.entrySet())
+		{
+			ItemStack stackInSlot = entry.getValue();
+			if(stackInSlot == stack)
+				continue;
+			IManaItem manaItemSlot = (IManaItem) stackInSlot.getItem();
+			if(manaItemSlot.getMana(stackInSlot) + manaToSend <= manaItemSlot.getMaxMana(stackInSlot) && manaItemSlot.canReceiveManaFromItem(stackInSlot, stack)) {
+				if(stack.getItem() instanceof IManaItem && !((IManaItem) stack.getItem()).canExportManaToItem(stack, stackInSlot))
+					continue;
 
-					if(add)
-						manaItemSlot.addMana(stackInSlot, manaToSend);
-					if(useBaubles)
-						BotaniaAPI.internalHandler.sendBaubleUpdatePacket(player, slot);
+				if(add)
+					manaItemSlot.addMana(stackInSlot, manaToSend);
+				BotaniaAPI.internalHandler.sendBaubleUpdatePacket(player, entry.getKey());
 
-					return true;
-				}
+				return true;
 			}
 		}
 

--- a/src/main/java/vazkii/botania/api/mana/ManaItemsEvent.java
+++ b/src/main/java/vazkii/botania/api/mana/ManaItemsEvent.java
@@ -1,0 +1,40 @@
+/**
+ * This class was created by <Flaxbeard>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ * 
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ * 
+ * File Created @ [Sep 23, 2016, 11:59:12 PM (GMT)]
+ */
+package vazkii.botania.api.mana;
+
+import java.util.List;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fml.common.eventhandler.Event;
+
+public class ManaItemsEvent extends Event {
+
+	private final EntityPlayer entityPlayer;
+	private List<ItemStack> items;
+
+	public ManaItemsEvent(EntityPlayer entityPlayer, List<ItemStack> items) {
+		this.entityPlayer = entityPlayer;
+		this.items = items;
+	}
+	
+	public EntityPlayer getEntityPlayer() {
+		return entityPlayer;
+	}
+	
+	public List<ItemStack> getItems() {
+		return items;
+	}
+
+	public void add(ItemStack item) {
+		items.add(item);
+	}
+}

--- a/src/main/java/vazkii/botania/api/package-info.java
+++ b/src/main/java/vazkii/botania/api/package-info.java
@@ -1,4 +1,4 @@
-@API(owner = "Botania", apiVersion = "80", provides = "BotaniaAPI")
+@API(owner = "Botania", apiVersion = "81", provides = "BotaniaAPI")
 package vazkii.botania.api;
 import net.minecraftforge.fml.common.API;
 

--- a/src/main/java/vazkii/botania/client/core/handler/HUDHandler.java
+++ b/src/main/java/vazkii/botania/client/core/handler/HUDHandler.java
@@ -223,8 +223,7 @@ public final class HUDHandler {
 				}
 				
 				List<ItemStack> items = ManaItemHandler.getManaItems(player);
-				for (ItemStack stack : items)
-				{
+				for (ItemStack stack : items) {
 					Item item = stack.getItem();
 					if(!((IManaItem) item).isNoExport(stack)) {
 						totalMana += ((IManaItem) item).getMana(stack);
@@ -235,8 +234,7 @@ public final class HUDHandler {
 				}
 				
 				Map<Integer, ItemStack> baubles = ManaItemHandler.getManaBaubles(player);
-				for (Entry<Integer, ItemStack> entry : baubles.entrySet())
-				{
+				for (Entry<Integer, ItemStack> entry : baubles.entrySet()) {
 					ItemStack stack = entry.getValue();
 					Item item = stack.getItem();
 					if(!((IManaItem) item).isNoExport(stack)) {

--- a/src/main/java/vazkii/botania/client/core/handler/HUDHandler.java
+++ b/src/main/java/vazkii/botania/client/core/handler/HUDHandler.java
@@ -10,7 +10,11 @@
  */
 package vazkii.botania.client.core.handler;
 
-import baubles.common.lib.PlayerHandler;
+import java.awt.Color;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.state.IBlockState;
@@ -36,13 +40,16 @@ import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
+
 import org.lwjgl.opengl.GL11;
+
 import vazkii.botania.api.lexicon.ILexicon;
 import vazkii.botania.api.lexicon.ILexiconable;
 import vazkii.botania.api.lexicon.LexiconEntry;
 import vazkii.botania.api.mana.ICreativeManaProvider;
 import vazkii.botania.api.mana.IManaItem;
 import vazkii.botania.api.mana.IManaUsingItem;
+import vazkii.botania.api.mana.ManaItemHandler;
 import vazkii.botania.api.recipe.RecipeManaInfusion;
 import vazkii.botania.api.wand.IWandHUD;
 import vazkii.botania.api.wiki.IWikiProvider;
@@ -66,8 +73,7 @@ import vazkii.botania.common.item.equipment.bauble.ItemDodgeRing;
 import vazkii.botania.common.item.equipment.bauble.ItemFlightTiara;
 import vazkii.botania.common.item.equipment.bauble.ItemMonocle;
 import vazkii.botania.common.lib.LibObfuscation;
-
-import java.awt.*;
+import baubles.common.lib.PlayerHandler;
 
 public final class HUDHandler {
 
@@ -213,17 +219,32 @@ public final class HUDHandler {
 						Item item = stack.getItem();
 						if(item instanceof IManaUsingItem)
 							anyRequest = anyRequest || ((IManaUsingItem) item).usesMana(stack);
-
-						if(item instanceof IManaItem) {
-							if(!((IManaItem) item).isNoExport(stack)) {
-								totalMana += ((IManaItem) item).getMana(stack);
-								totalMaxMana += ((IManaItem) item).getMaxMana(stack);
-							}
-						}
-
-						if(item instanceof ICreativeManaProvider && ((ICreativeManaProvider) item).isCreative(stack))
-							creative = true;
 					}
+				}
+				
+				List<ItemStack> items = ManaItemHandler.getManaItems(player);
+				for (ItemStack stack : items)
+				{
+					Item item = stack.getItem();
+					if(!((IManaItem) item).isNoExport(stack)) {
+						totalMana += ((IManaItem) item).getMana(stack);
+						totalMaxMana += ((IManaItem) item).getMaxMana(stack);
+					}
+					if(item instanceof ICreativeManaProvider && ((ICreativeManaProvider) item).isCreative(stack))
+						creative = true;
+				}
+				
+				Map<Integer, ItemStack> baubles = ManaItemHandler.getManaBaubles(player);
+				for (Entry<Integer, ItemStack> entry : baubles.entrySet())
+				{
+					ItemStack stack = entry.getValue();
+					Item item = stack.getItem();
+					if(!((IManaItem) item).isNoExport(stack)) {
+						totalMana += ((IManaItem) item).getMana(stack);
+						totalMaxMana += ((IManaItem) item).getMaxMana(stack);
+					}
+					if(item instanceof ICreativeManaProvider && ((ICreativeManaProvider) item).isCreative(stack))
+						creative = true;
 				}
 
 				if(anyRequest)


### PR DESCRIPTION
**Changes:**
Adds two helper functions, getManaItems() and getManaBaubles(), in ManaItemHandler so that the code for gathering mana-storing items no longer needs to be repeated in ManaItemHandler and HUDHandler and to enable ManaItemsEvent to function.

getManaItems() gathers mana-storing items from the player's base inventory, as base Botania does. The new code here calls ManaItemsEvent to enable mods to pass (or remove) mana-storing items from their own inventories.

getManaBaubles() gathers mana-storing items from the player's baubles inventory. The reason this function is separate from getManaItems() is because Botania code requires sendBaubleUpdatePacket to be called when a mana-storing bauble is accessed. sendBaubleUpdatePacket needs a slot number as a param, so I had to make this.

**Potential uses:**
Locations in which mana-storing items can be accessed is no longer fixed to just the base inventory and baubles inventory. This enables a variety of scenarios:

- Mana-storing items placed in additional inventory or equipment slots added by other mods can now be accessed by Botania items
- Cyberware items can be used to store mana
- Mods can selectively disable certain mana-storing items by removing them from the list passed in ManaItemsEvent. Not sure how this could be used - maybe a potion effect that disables mana tablets or something.