### PR TITLE
Allow inserting elven lexica into the portal

### DIFF
--- a/src/main/java/vazkii/botania/common/block/tile/TileAlfPortal.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileAlfPortal.java
@@ -128,7 +128,18 @@ public class TileAlfPortal extends TileMod {
 						continue;
 
 					ItemStack stack = item.getEntityItem();
-					if((!(stack.getItem() instanceof IElvenItem) || !((IElvenItem) stack.getItem()).isElvenItem(stack)) && !item.getEntityData().hasKey(TAG_PORTAL_FLAG)) {
+					boolean consume;
+					if (item.getEntityData().hasKey(TAG_PORTAL_FLAG)) {
+						consume = false;
+					} else if (stack.getItem() instanceof ItemLexicon) {
+						consume = true;
+					} else if ((!(stack.getItem() instanceof IElvenItem) || !((IElvenItem) stack.getItem()).isElvenItem(stack))) {
+						consume = true;
+					} else {
+						consume = false;
+					}
+
+					if (consume) {
 						item.setDead();
 						addItem(stack);
 						ticksSinceLastItem = 0;
@@ -198,11 +209,14 @@ public class TileAlfPortal extends TileMod {
 		int i = 0;
 		for(ItemStack stack : stacksIn) {
 			if(stack != null && stack.getItem() instanceof ILexicon) {
-				((ILexicon) stack.getItem()).unlockKnowledge(stack, BotaniaAPI.elvenKnowledge);
-				ItemLexicon.setForcedPage(stack, LexiconData.elvenMessage.getUnlocalizedName());
-				spawnItem(stack);
-				stacksIn.remove(i);
-				return;
+				ILexicon lexicon = (ILexicon) stack.getItem();
+				if (!lexicon.isKnowledgeUnlocked(stack, BotaniaAPI.elvenKnowledge)) {
+					lexicon.unlockKnowledge(stack, BotaniaAPI.elvenKnowledge);
+					ItemLexicon.setForcedPage(stack, LexiconData.elvenMessage.getUnlocalizedName());
+					spawnItem(stack);
+					stacksIn.remove(i);
+					return;
+				}
 			}
 			i++;
 		}


### PR DESCRIPTION
Allows using a Lexica as an ingredient in Alfheim Portal recipes.

This is required for my Elven Charter addon which uses the Lexica to track who's used the current trade and who hasn't.

To address willie's concerns on my original PR for this (williewillus/Botania#421), `isElvenItem` doesn't work for this without modifying and changing the meaning of the method. Currently `ItemLexicon.isElvenItem` return `true` if the elven knowledge has been unlocked, so the Lexica can't be thrown back into the portal. This would require special casing in the Portal or changing the fundamental meaning of `isElvenItem`, potentially breaking anything else that uses it.