### PR TITLE
Modified the hopperhock to check for ticksExisted instead of age.

### DIFF
--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileHopperhock.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileHopperhock.java
@@ -70,15 +70,11 @@ public class SubTileHopperhock extends SubTileFunctional {
 		int slowdown = getSlowdownFactor();
 
 		for(EntityItem item : items) {
-			int age;
-			try {
-				age = (int) MethodHandles.itemAge_getter.invokeExact(item);
-			} catch (Throwable t) {
+			int age = item.ticksExisted;
+
+			if(age < 60 + slowdown || age >= 105 && age < 110 || item.isDead) {
 				continue;
 			}
-
-			if(age < 60 + slowdown || age >= 105 && age < 110 || item.isDead)
-				continue;
 
 			ItemStack stack = item.getEntityItem();
 			IItemHandler invToPutItemIn = null;


### PR DESCRIPTION
They both represent the amount of ticks the EntityItem existed except that the EntityItem class has some magic numbers for age to represent certain item states.

Fixes #2018