### PR TITLE
Fix #1999

### DIFF
--- a/src/main/java/vazkii/botania/common/block/BlockAltar.java
+++ b/src/main/java/vazkii/botania/common/block/BlockAltar.java
@@ -31,8 +31,10 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.ChunkCache;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
@@ -103,7 +105,7 @@ public class BlockAltar extends BlockMod implements ILexiconable {
 	@Nonnull
 	@Override
 	public IBlockState getActualState(@Nonnull IBlockState state, IBlockAccess worldIn, BlockPos pos) {
-		TileEntity te = worldIn.getTileEntity(pos);
+		TileEntity te = worldIn instanceof ChunkCache ? ((ChunkCache)worldIn).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : worldIn.getTileEntity(pos);;
 		if (te instanceof TileAltar) {
 			TileAltar altar = (TileAltar) te;
 

--- a/src/main/java/vazkii/botania/common/block/BlockAltar.java
+++ b/src/main/java/vazkii/botania/common/block/BlockAltar.java
@@ -105,7 +105,7 @@ public class BlockAltar extends BlockMod implements ILexiconable {
 	@Nonnull
 	@Override
 	public IBlockState getActualState(@Nonnull IBlockState state, IBlockAccess worldIn, BlockPos pos) {
-		TileEntity te = worldIn instanceof ChunkCache ? ((ChunkCache)worldIn).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : worldIn.getTileEntity(pos);;
+		TileEntity te = worldIn instanceof ChunkCache ? ((ChunkCache)worldIn).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : worldIn.getTileEntity(pos);
 		if (te instanceof TileAltar) {
 			TileAltar altar = (TileAltar) te;
 

--- a/src/main/java/vazkii/botania/common/block/BlockFloatingSpecialFlower.java
+++ b/src/main/java/vazkii/botania/common/block/BlockFloatingSpecialFlower.java
@@ -31,8 +31,10 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.world.ChunkCache;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.common.property.ExtendedBlockState;
 import net.minecraftforge.common.property.IExtendedBlockState;
 import net.minecraftforge.common.property.IUnlistedProperty;
@@ -75,7 +77,7 @@ public class BlockFloatingSpecialFlower extends BlockFloatingFlower implements I
 	@Override
 	public IBlockState getExtendedState(@Nonnull IBlockState state, IBlockAccess world, BlockPos pos) {
 		state = super.getExtendedState(state, world, pos);
-		TileEntity te = world.getTileEntity(pos);
+		TileEntity te = world instanceof ChunkCache ? ((ChunkCache)world).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : world.getTileEntity(pos);
 		if (te instanceof TileFloatingSpecialFlower) {
 			state = ((IExtendedBlockState) state).withProperty(BotaniaStateProps.SUBTILE_ID, ((TileFloatingSpecialFlower) te).subTileName);
 		}

--- a/src/main/java/vazkii/botania/common/block/BlockOpenCrate.java
+++ b/src/main/java/vazkii/botania/common/block/BlockOpenCrate.java
@@ -90,7 +90,7 @@ public class BlockOpenCrate extends BlockMod implements ILexiconable, IWandable,
 	@Nonnull
 	@Override
 	public IBlockState getActualState(@Nonnull IBlockState state, IBlockAccess world, BlockPos pos) {
-		TileEntity te = world instanceof ChunkCache ? ((ChunkCache)world).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : world.getTileEntity(pos);;
+		TileEntity te = world instanceof ChunkCache ? ((ChunkCache)world).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : world.getTileEntity(pos);
 		if (te instanceof TileCraftCrate) {
 			TileCraftCrate tile = (TileCraftCrate) te;
 			state = state.withProperty(BotaniaStateProps.CRATE_PATTERN, CratePattern.values()[tile.pattern + 1]);

--- a/src/main/java/vazkii/botania/common/block/BlockOpenCrate.java
+++ b/src/main/java/vazkii/botania/common/block/BlockOpenCrate.java
@@ -29,8 +29,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.ChunkCache;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -88,8 +90,9 @@ public class BlockOpenCrate extends BlockMod implements ILexiconable, IWandable,
 	@Nonnull
 	@Override
 	public IBlockState getActualState(@Nonnull IBlockState state, IBlockAccess world, BlockPos pos) {
-		if (world.getTileEntity(pos) instanceof TileCraftCrate) {
-			TileCraftCrate tile = (TileCraftCrate) world.getTileEntity(pos);
+		TileEntity te = world instanceof ChunkCache ? ((ChunkCache)world).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : world.getTileEntity(pos);;
+		if (te instanceof TileCraftCrate) {
+			TileCraftCrate tile = (TileCraftCrate) te;
 			state = state.withProperty(BotaniaStateProps.CRATE_PATTERN, CratePattern.values()[tile.pattern + 1]);
 		} else {
 			state = state.withProperty(BotaniaStateProps.CRATE_PATTERN, CratePattern.NONE);

--- a/src/main/java/vazkii/botania/common/block/BlockPlatform.java
+++ b/src/main/java/vazkii/botania/common/block/BlockPlatform.java
@@ -30,9 +30,11 @@ import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.ChunkCache;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.common.property.ExtendedBlockState;
 import net.minecraftforge.common.property.IExtendedBlockState;
@@ -95,8 +97,9 @@ public class BlockPlatform extends BlockCamo implements ILexiconable, IWandable,
 		state = ((IExtendedBlockState) state).withProperty(BotaniaStateProps.HELD_WORLD, world)
 				.withProperty(BotaniaStateProps.HELD_POS, pos);
 
-		if (world.getTileEntity(pos) instanceof TileCamo) {
-			TileCamo tile = (TileCamo) world.getTileEntity(pos);
+		TileEntity te = world instanceof ChunkCache ? ((ChunkCache)world).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : world.getTileEntity(pos);
+		if (te instanceof TileCamo) {
+			TileCamo tile = (TileCamo) te;
 			return ((IExtendedBlockState) state).withProperty(BotaniaStateProps.HELD_STATE, tile.camoState);
 		} else {
 			return state;

--- a/src/main/java/vazkii/botania/common/block/BlockSpecialFlower.java
+++ b/src/main/java/vazkii/botania/common/block/BlockSpecialFlower.java
@@ -39,8 +39,10 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.world.ChunkCache;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.common.property.ExtendedBlockState;
 import net.minecraftforge.common.property.IExtendedBlockState;
@@ -145,7 +147,7 @@ public class BlockSpecialFlower extends BlockFlower implements ISpecialFlower, I
 	@Nonnull
 	@Override
 	public IExtendedBlockState getExtendedState(@Nonnull IBlockState state, IBlockAccess world, BlockPos pos) {
-		TileEntity te = world.getTileEntity(pos);
+		TileEntity te = world instanceof ChunkCache ? ((ChunkCache)world).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : world.getTileEntity(pos);
 		if (te instanceof TileSpecialFlower && ((TileSpecialFlower) te).getSubTile() != null) {
 			Class<? extends SubTileEntity> clazz = ((TileSpecialFlower) te).getSubTile().getClass();
 			String id = BotaniaAPI.getSubTileStringMapping(clazz);

--- a/src/main/java/vazkii/botania/common/block/decor/BlockFloatingFlower.java
+++ b/src/main/java/vazkii/botania/common/block/decor/BlockFloatingFlower.java
@@ -34,8 +34,10 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.ChunkCache;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.common.property.ExtendedBlockState;
 import net.minecraftforge.common.property.IExtendedBlockState;
@@ -125,7 +127,7 @@ public class BlockFloatingFlower extends BlockMod implements ILexiconable, IInfu
 	@Override
 	public IBlockState getExtendedState(@Nonnull IBlockState state, IBlockAccess world, BlockPos pos) {
 		state = getActualState(state, world, pos);
-		TileEntity te = world.getTileEntity(pos);
+		TileEntity te = world instanceof ChunkCache ? ((ChunkCache)world).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : world.getTileEntity(pos);
 		if (te instanceof TileFloatingFlower) {
 			state = ((IExtendedBlockState) state).withProperty(BotaniaStateProps.ISLAND_TYPE, ((TileFloatingFlower) te).getIslandType());
 		} else if (te instanceof TileFloatingSpecialFlower) {

--- a/src/main/java/vazkii/botania/common/block/mana/BlockPool.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockPool.java
@@ -105,7 +105,7 @@ public class BlockPool extends BlockMod implements IWandHUD, IWandable, ILexicon
 	@Nonnull
 	@Override
 	public IBlockState getActualState(@Nonnull IBlockState state, IBlockAccess world, BlockPos pos) {
-		TileEntity te = world instanceof ChunkCache ? ((ChunkCache)world).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : world.getTileEntity(pos);;
+		TileEntity te = world instanceof ChunkCache ? ((ChunkCache)world).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : world.getTileEntity(pos);
 		if (te instanceof TilePool) {
 			return state.withProperty(BotaniaStateProps.COLOR, ((TilePool) te).color);
 		} else {

--- a/src/main/java/vazkii/botania/common/block/mana/BlockPool.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockPool.java
@@ -36,8 +36,10 @@ import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.ChunkCache;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
@@ -103,7 +105,7 @@ public class BlockPool extends BlockMod implements IWandHUD, IWandable, ILexicon
 	@Nonnull
 	@Override
 	public IBlockState getActualState(@Nonnull IBlockState state, IBlockAccess world, BlockPos pos) {
-		TileEntity te = world.getTileEntity(pos);
+		TileEntity te = world instanceof ChunkCache ? ((ChunkCache)world).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : world.getTileEntity(pos);;
 		if (te instanceof TilePool) {
 			return state.withProperty(BotaniaStateProps.COLOR, ((TilePool) te).color);
 		} else {


### PR DESCRIPTION
Make getTileEntity safe from getActualState and getExtendedState, closes #1999

The problem:

* getActualState and getExtendedState can be called from other threads
* getTileEntity by default tries to create the TE if it doesn't exist (??? vanilla)
* this creation can CME the main thread

The solution:

* Insert special case to use a version of getTileEntity that doesn't try to create if it doesn't exist. The code for this special case is basically straight out of `BlockFlowerPot.getActualState`, so I trust that mojang knows that that works :P 