### PR TITLE
Fix Mana Enchanter only applying one enchanted book

### DIFF
--- a/src/main/java/vazkii/botania/common/block/tile/TileEnchanter.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileEnchanter.java
@@ -375,7 +375,7 @@ public class TileEnchanter extends TileMod implements ISparkAttachable {
 
 		for(EnchantmentData data : enchants) {
 			Enchantment otherEnch = data.enchantmentobj;
-			if (ench.func_191560_c(otherEnch))
+			if (!ench.func_191560_c(otherEnch))
 				return false;
 		}
 


### PR DESCRIPTION
`ench.func_191560_c` returns `true` if the two enchantments are mutually compatible.

Fixes #2188 