### PR TITLE
Fix #2195 - Endoflames eating Mana Infusion products

### DIFF
--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileHopperhock.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileHopperhock.java
@@ -42,6 +42,7 @@ import vazkii.botania.api.subtile.SubTileFunctional;
 import vazkii.botania.common.core.handler.MethodHandles;
 import vazkii.botania.common.core.helper.InventoryHelper;
 import vazkii.botania.common.lexicon.LexiconData;
+import vazkii.botania.common.lib.LibItemAges;
 
 public class SubTileHopperhock extends SubTileFunctional {
 
@@ -77,7 +78,7 @@ public class SubTileHopperhock extends SubTileFunctional {
 				continue;
 			}
 
-			if(age < 60 + slowdown || age >= 105 && age < 110 || item.isDead || item.getEntityItem().isEmpty())
+			if(!LibItemAges.isLegalForFunctional(age, slowdown) || item.isDead || item.getEntityItem().isEmpty())
 				continue;
 
 			ItemStack stack = item.getEntityItem();

--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileHopperhock.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileHopperhock.java
@@ -42,7 +42,7 @@ import vazkii.botania.api.subtile.SubTileFunctional;
 import vazkii.botania.common.core.handler.MethodHandles;
 import vazkii.botania.common.core.helper.InventoryHelper;
 import vazkii.botania.common.lexicon.LexiconData;
-import vazkii.botania.common.lib.LibItemAges;
+import vazkii.botania.common.core.helper.ItemAgeHelper;
 
 public class SubTileHopperhock extends SubTileFunctional {
 
@@ -78,7 +78,7 @@ public class SubTileHopperhock extends SubTileFunctional {
 				continue;
 			}
 
-			if(!LibItemAges.isLegalForFunctional(age, slowdown) || item.isDead || item.getEntityItem().isEmpty())
+			if(!ItemAgeHelper.isLegalForFunctional(age, slowdown) || item.isDead || item.getEntityItem().isEmpty())
 				continue;
 
 			ItemStack stack = item.getEntityItem();

--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTilePollidisiac.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTilePollidisiac.java
@@ -22,6 +22,7 @@ import vazkii.botania.api.subtile.RadiusDescriptor;
 import vazkii.botania.api.subtile.SubTileFunctional;
 import vazkii.botania.common.core.handler.MethodHandles;
 import vazkii.botania.common.lexicon.LexiconData;
+import vazkii.botania.common.lib.LibItemAges;
 import vazkii.botania.common.lib.LibObfuscation;
 
 public class SubTilePollidisiac extends SubTileFunctional {
@@ -52,7 +53,7 @@ public class SubTilePollidisiac extends SubTileFunctional {
 							continue;
 						}
 
-						if(age < 60 + slowdown || item.isDead)
+						if(!LibItemAges.isLegalForFunctional(age, slowdown) || item.isDead)
 							continue;
 
 						ItemStack stack = item.getEntityItem();

--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTilePollidisiac.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTilePollidisiac.java
@@ -22,7 +22,7 @@ import vazkii.botania.api.subtile.RadiusDescriptor;
 import vazkii.botania.api.subtile.SubTileFunctional;
 import vazkii.botania.common.core.handler.MethodHandles;
 import vazkii.botania.common.lexicon.LexiconData;
-import vazkii.botania.common.lib.LibItemAges;
+import vazkii.botania.common.core.helper.ItemAgeHelper;
 import vazkii.botania.common.lib.LibObfuscation;
 
 public class SubTilePollidisiac extends SubTileFunctional {
@@ -53,7 +53,7 @@ public class SubTilePollidisiac extends SubTileFunctional {
 							continue;
 						}
 
-						if(!LibItemAges.isLegalForFunctional(age, slowdown) || item.isDead)
+						if(!ItemAgeHelper.isLegalForFunctional(age, slowdown) || item.isDead)
 							continue;
 
 						ItemStack stack = item.getEntityItem();

--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileRannuncarpus.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileRannuncarpus.java
@@ -46,7 +46,7 @@ import vazkii.botania.common.core.handler.ConfigHandler;
 import vazkii.botania.common.core.handler.MethodHandles;
 import vazkii.botania.common.item.block.ItemBlockSpecialFlower;
 import vazkii.botania.common.lexicon.LexiconData;
-import vazkii.botania.common.lib.LibItemAges;
+import vazkii.botania.common.core.helper.ItemAgeHelper;
 import vazkii.botania.common.lib.LibObfuscation;
 
 public class SubTileRannuncarpus extends SubTileFunctional {
@@ -89,7 +89,7 @@ public class SubTileRannuncarpus extends SubTileFunctional {
 					continue;
 				}
 
-				if(!LibItemAges.isLegalForFunctional(age, slowdown) || item.isDead || item.getEntityItem().isEmpty())
+				if(!ItemAgeHelper.isLegalForFunctional(age, slowdown) || item.isDead || item.getEntityItem().isEmpty())
 					continue;
 
 				ItemStack stack = item.getEntityItem();

--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileRannuncarpus.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileRannuncarpus.java
@@ -46,6 +46,7 @@ import vazkii.botania.common.core.handler.ConfigHandler;
 import vazkii.botania.common.core.handler.MethodHandles;
 import vazkii.botania.common.item.block.ItemBlockSpecialFlower;
 import vazkii.botania.common.lexicon.LexiconData;
+import vazkii.botania.common.lib.LibItemAges;
 import vazkii.botania.common.lib.LibObfuscation;
 
 public class SubTileRannuncarpus extends SubTileFunctional {
@@ -88,7 +89,7 @@ public class SubTileRannuncarpus extends SubTileFunctional {
 					continue;
 				}
 
-				if(age < 60 + slowdown || item.isDead || item.getEntityItem().isEmpty())
+				if(!LibItemAges.isLegalForFunctional(age, slowdown) || item.isDead || item.getEntityItem().isEmpty())
 					continue;
 
 				ItemStack stack = item.getEntityItem();

--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileSpectranthemum.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileSpectranthemum.java
@@ -30,6 +30,7 @@ import vazkii.botania.api.subtile.RadiusDescriptor;
 import vazkii.botania.api.subtile.SubTileFunctional;
 import vazkii.botania.common.core.handler.MethodHandles;
 import vazkii.botania.common.lexicon.LexiconData;
+import vazkii.botania.common.lib.LibItemAges;
 import vazkii.botania.common.network.PacketBotaniaEffect;
 import vazkii.botania.common.network.PacketHandler;
 
@@ -67,7 +68,7 @@ public class SubTileSpectranthemum extends SubTileFunctional {
 					continue;
 				}
 
-				if(age < 60 + slowdown || item.isDead || item.getEntityData().getBoolean(TAG_TELEPORTED))
+				if(!LibItemAges.isLegalForFunctional(age, slowdown) || item.isDead || item.getEntityData().getBoolean(TAG_TELEPORTED))
 					continue;
 
 				ItemStack stack = item.getEntityItem();

--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileSpectranthemum.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileSpectranthemum.java
@@ -30,7 +30,7 @@ import vazkii.botania.api.subtile.RadiusDescriptor;
 import vazkii.botania.api.subtile.SubTileFunctional;
 import vazkii.botania.common.core.handler.MethodHandles;
 import vazkii.botania.common.lexicon.LexiconData;
-import vazkii.botania.common.lib.LibItemAges;
+import vazkii.botania.common.core.helper.ItemAgeHelper;
 import vazkii.botania.common.network.PacketBotaniaEffect;
 import vazkii.botania.common.network.PacketHandler;
 
@@ -68,7 +68,7 @@ public class SubTileSpectranthemum extends SubTileFunctional {
 					continue;
 				}
 
-				if(!LibItemAges.isLegalForFunctional(age, slowdown) || item.isDead || item.getEntityData().getBoolean(TAG_TELEPORTED))
+				if(!ItemAgeHelper.isLegalForFunctional(age, slowdown) || item.isDead || item.getEntityData().getBoolean(TAG_TELEPORTED))
 					continue;
 
 				ItemStack stack = item.getEntityItem();

--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEndoflame.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEndoflame.java
@@ -27,7 +27,7 @@ import vazkii.botania.api.subtile.SubTileGenerating;
 import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.core.handler.MethodHandles;
 import vazkii.botania.common.lexicon.LexiconData;
-import vazkii.botania.common.lib.LibItemAges;
+import vazkii.botania.common.core.helper.ItemAgeHelper;
 
 public class SubTileEndoflame extends SubTileGenerating {
 
@@ -57,7 +57,7 @@ public class SubTileEndoflame extends SubTileGenerating {
 							continue;
 						}
 
-						if(LibItemAges.isLegalForGenerator(age, slowdown) && !item.isDead) {
+						if(ItemAgeHelper.isLegalForGenerator(age, slowdown) && !item.isDead) {
 							ItemStack stack = item.getEntityItem();
 							if(stack.isEmpty() || stack.getItem().hasContainerItem(stack))
 								continue;

--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEndoflame.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEndoflame.java
@@ -27,6 +27,7 @@ import vazkii.botania.api.subtile.SubTileGenerating;
 import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.core.handler.MethodHandles;
 import vazkii.botania.common.lexicon.LexiconData;
+import vazkii.botania.common.lib.LibItemAges;
 
 public class SubTileEndoflame extends SubTileGenerating {
 
@@ -56,7 +57,7 @@ public class SubTileEndoflame extends SubTileGenerating {
 							continue;
 						}
 
-						if(age >= 59 + slowdown && !item.isDead) {
+						if(LibItemAges.isLegalForGenerator(age, slowdown) && !item.isDead) {
 							ItemStack stack = item.getEntityItem();
 							if(stack.isEmpty() || stack.getItem().hasContainerItem(stack))
 								continue;

--- a/src/main/java/vazkii/botania/common/block/tile/TileOpenCrate.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileOpenCrate.java
@@ -23,7 +23,7 @@ import net.minecraft.world.World;
 import vazkii.botania.api.state.BotaniaStateProps;
 import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.core.handler.MethodHandles;
-import vazkii.botania.common.lib.LibItemAges;
+import vazkii.botania.common.core.helper.ItemAgeHelper;
 
 public class TileOpenCrate extends TileSimpleInventory {
 
@@ -76,7 +76,7 @@ public class TileOpenCrate extends TileSimpleInventory {
 
 		if(redstone) {
 			try {
-				MethodHandles.itemAge_setter.invokeExact(item, LibItemAges.OPEN_CRATE_REDSTONE_AGE);
+				MethodHandles.itemAge_setter.invokeExact(item, ItemAgeHelper.OPEN_CRATE_REDSTONE_AGE);
 			} catch (Throwable ignored) {}
 		}
 

--- a/src/main/java/vazkii/botania/common/block/tile/TileOpenCrate.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileOpenCrate.java
@@ -23,6 +23,7 @@ import net.minecraft.world.World;
 import vazkii.botania.api.state.BotaniaStateProps;
 import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.core.handler.MethodHandles;
+import vazkii.botania.common.lib.LibItemAges;
 
 public class TileOpenCrate extends TileSimpleInventory {
 
@@ -75,7 +76,7 @@ public class TileOpenCrate extends TileSimpleInventory {
 
 		if(redstone) {
 			try {
-				MethodHandles.itemAge_setter.invokeExact(item, -200);
+				MethodHandles.itemAge_setter.invokeExact(item, LibItemAges.OPEN_CRATE_REDSTONE_AGE);
 			} catch (Throwable ignored) {}
 		}
 

--- a/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
+++ b/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
@@ -67,6 +67,7 @@ import vazkii.botania.common.core.handler.ManaNetworkHandler;
 import vazkii.botania.common.core.handler.MethodHandles;
 import vazkii.botania.common.item.ItemManaTablet;
 import vazkii.botania.common.item.ModItems;
+import vazkii.botania.common.lib.LibItemAges;
 import vazkii.botania.common.network.PacketBotaniaEffect;
 import vazkii.botania.common.network.PacketHandler;
 
@@ -175,7 +176,7 @@ public class TilePool extends TileMod implements IManaPool, IKeyLocked, ISparkAt
 			age = (int) MethodHandles.itemAge_getter.invokeExact(item);
 		} catch (Throwable throwable) { return false; }
 
-		if(age > 100 && age < 130)
+		if(!LibItemAges.isLegalForInfusion(age))
 			return false;
 
 		RecipeManaInfusion recipe = getMatchingRecipe(stack, world.getBlockState(pos.down()));
@@ -190,7 +191,7 @@ public class TilePool extends TileMod implements IManaPool, IKeyLocked, ISparkAt
 				ItemStack output = recipe.getOutput().copy();
 				EntityItem outputItem = new EntityItem(world, pos.getX() + 0.5, pos.getY() + 1.5, pos.getZ() + 0.5, output);
 				try {
-					MethodHandles.itemAge_setter.invokeExact(outputItem, 105);
+					MethodHandles.itemAge_setter.invokeExact(outputItem, LibItemAges.INFUSION_PRODUCT_AGE);
 				} catch (Throwable ignored) {}
 				world.spawnEntity(outputItem);
 

--- a/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
+++ b/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
@@ -67,7 +67,7 @@ import vazkii.botania.common.core.handler.ManaNetworkHandler;
 import vazkii.botania.common.core.handler.MethodHandles;
 import vazkii.botania.common.item.ItemManaTablet;
 import vazkii.botania.common.item.ModItems;
-import vazkii.botania.common.lib.LibItemAges;
+import vazkii.botania.common.core.helper.ItemAgeHelper;
 import vazkii.botania.common.network.PacketBotaniaEffect;
 import vazkii.botania.common.network.PacketHandler;
 
@@ -176,7 +176,7 @@ public class TilePool extends TileMod implements IManaPool, IKeyLocked, ISparkAt
 			age = (int) MethodHandles.itemAge_getter.invokeExact(item);
 		} catch (Throwable throwable) { return false; }
 
-		if(!LibItemAges.isLegalForInfusion(age))
+		if(!ItemAgeHelper.isLegalForInfusion(age))
 			return false;
 
 		RecipeManaInfusion recipe = getMatchingRecipe(stack, world.getBlockState(pos.down()));
@@ -191,7 +191,7 @@ public class TilePool extends TileMod implements IManaPool, IKeyLocked, ISparkAt
 				ItemStack output = recipe.getOutput().copy();
 				EntityItem outputItem = new EntityItem(world, pos.getX() + 0.5, pos.getY() + 1.5, pos.getZ() + 0.5, output);
 				try {
-					MethodHandles.itemAge_setter.invokeExact(outputItem, LibItemAges.INFUSION_PRODUCT_AGE);
+					MethodHandles.itemAge_setter.invokeExact(outputItem, ItemAgeHelper.INFUSION_PRODUCT_AGE);
 				} catch (Throwable ignored) {}
 				world.spawnEntity(outputItem);
 

--- a/src/main/java/vazkii/botania/common/core/helper/ItemAgeHelper.java
+++ b/src/main/java/vazkii/botania/common/core/helper/ItemAgeHelper.java
@@ -8,9 +8,9 @@
  *
  */
 
-package vazkii.botania.common.lib;
+package vazkii.botania.common.core.helper;
 
-public class LibItemAges {
+public class ItemAgeHelper {
 
     // Items dropped by an Open Crate start at this age, if the Crate has a Redstone signal applied
     public static final int OPEN_CRATE_REDSTONE_AGE = -200;

--- a/src/main/java/vazkii/botania/common/lib/LibItemAges.java
+++ b/src/main/java/vazkii/botania/common/lib/LibItemAges.java
@@ -1,0 +1,47 @@
+/**
+ * This class was created by <codewarrior0>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ *
+ */
+
+package vazkii.botania.common.lib;
+
+public class LibItemAges {
+
+    // Items dropped by an Open Crate start at this age, if the Crate has a Redstone signal applied
+    public static final int OPEN_CRATE_REDSTONE_AGE = -200;
+
+    // Items created by a Mana Pool start at this age
+    public static final int INFUSION_PRODUCT_AGE = 105;
+
+    // Items created by a Mana Pool may not be used by a flower until they are this age or higher.
+    private static final int INFUSION_PRODUCT_USABLE = 110;
+
+    // Items created by a Mana Pool may not be used by any Mana Pool until they are this age or higher.
+    private static final int INFUSION_PRODUCT_RECRAFTABLE = 130;
+
+    // Items of this age or higher may be used by a generating flower
+    private static final int LEGAL_FOR_GENERATOR = 59;
+
+    // Items of this age or higher may be used by a functional flower
+    private static final int LEGAL_FOR_FUNCTIONAL = 60;
+
+
+    public static boolean isLegalForGenerator(int age, int slowdown) {
+        return ((age >= LEGAL_FOR_GENERATOR + slowdown) &&
+                (age < INFUSION_PRODUCT_AGE || age >= INFUSION_PRODUCT_USABLE));
+    }
+
+    public static boolean isLegalForFunctional(int age, int slowdown) {
+        return ((age >= LEGAL_FOR_FUNCTIONAL + slowdown) &&
+                (age < INFUSION_PRODUCT_AGE || age >= INFUSION_PRODUCT_USABLE));
+    }
+
+    public static boolean isLegalForInfusion(int age) {
+        return age < INFUSION_PRODUCT_AGE || age >= INFUSION_PRODUCT_RECRAFTABLE;
+    }
+}


### PR DESCRIPTION
Consolidate all age checks done by functional and generating flowers
(and the Open Crate) into a new class, ItemAgeHelper. These age checks
ensure generating flowers act on dropped items before functional ones,
ensure that items newly created by Mana Infusion are not acted upon
immediately by either flower type, and conveniently move all of the
magic age numbers into a single place.

This also changes the Pollidisiac, Rannuncarpus, and Spectranthemum to
delay acting upon items newly crafted by Mana Infusion.

Fixes #2195