### PR TITLE
Fixes Managlass and Elfglass transparencies, Fixes #2272

### DIFF
--- a/src/main/java/vazkii/botania/common/block/decor/BlockElfGlass.java
+++ b/src/main/java/vazkii/botania/common/block/decor/BlockElfGlass.java
@@ -10,7 +10,6 @@
  */
 package vazkii.botania.common.block.decor;
 
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
@@ -29,11 +28,6 @@ public class BlockElfGlass extends BlockManaGlass implements IElvenItem, ILexico
 
 	@Override
 	public boolean isElvenItem(ItemStack stack) {
-		return true;
-	}
-
-	@Override
-	public boolean isFullBlock(IBlockState state) {
 		return true;
 	}
 

--- a/src/main/java/vazkii/botania/common/block/decor/BlockManaGlass.java
+++ b/src/main/java/vazkii/botania/common/block/decor/BlockManaGlass.java
@@ -50,8 +50,8 @@ public class BlockManaGlass extends BlockMod implements ILexiconable {
 	}
 
 	@Override
-	public boolean isFullBlock(IBlockState state) {
-		return true;
+	public boolean isFullCube(IBlockState state) {
+		return false;
 	}
 
 	@SideOnly(Side.CLIENT)


### PR DESCRIPTION
- I saw that BlockGlass was using the method isFullCube and Botania was using isFullBlock, so I switched it and it seems to have fixed the issue, #2272.
- Removed redundant overwrite of isFullBlock in BlockElfGlass.

Before:
![2017-06-14_13 41 27](https://user-images.githubusercontent.com/4359740/27149081-106cf348-5108-11e7-817b-9547c8262d9b.png)
After:
![2017-06-14_13 39 39](https://user-images.githubusercontent.com/4359740/27149086-156384ac-5108-11e7-8211-d68f89d415dc.png)

