### PR TITLE
Fixes the alchemy catalyst eating everything and never working

### DIFF
--- a/src/main/java/vazkii/botania/common/block/ModBlocks.java
+++ b/src/main/java/vazkii/botania/common/block/ModBlocks.java
@@ -299,8 +299,6 @@ public final class ModBlocks {
 
 		RecipeManaInfusion.alchemyState = alchemyCatalyst.getDefaultState();
 		RecipeManaInfusion.conjurationState = conjurationCatalyst.getDefaultState();
-
-		initTileEntities();
 	}
 
 	@SuppressWarnings("ConstantConditions")
@@ -386,6 +384,8 @@ public final class ModBlocks {
 		r.register(new ItemBlockWithMetadataAndName(altGrass).setRegistryName(altGrass.getRegistryName()));
 		r.register(new ItemBlockMod(animatedTorch).setRegistryName(animatedTorch.getRegistryName()));
 		initOreDict();
+
+		initTileEntities();
 	}
 
 	public static void addDispenserBehaviours() {


### PR DESCRIPTION

The issue was that mini flower recipes were being registered before the specialFlower block item was registered, so the recipes for mini flowers were defaulting to having an input and output of Air blocks, breaking all the alchemy recipes.

Fixes #2337.