### PR TITLE
Fixes the shaking mouse-over elements in the Lexicon.

### DIFF
--- a/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexicon.java
+++ b/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexicon.java
@@ -259,7 +259,7 @@ public class GuiLexicon extends GuiScreen {
 	
 	public void drawScreenAfterScale(int par1, int par2, float par3) {
 		float time = ClientTickHandler.ticksInGame + par3;
-		timeDelta = time - lastTime;
+		timeDelta = time - lastTime + partialTicks;
 		lastTime = time;
 		partialTicks = par3;
 

--- a/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexicon.java
+++ b/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexicon.java
@@ -257,15 +257,15 @@ public class GuiLexicon extends GuiScreen {
 		}
 	}
 	
-	public void drawScreenAfterScale(int par1, int par2, float par3) {
-		float time = ClientTickHandler.ticksInGame + par3;
-		timeDelta = time - lastTime + partialTicks;
+	public void drawScreenAfterScale(int xCoord, int yCoord, float newPartialTicks) {
+		float time = ClientTickHandler.ticksInGame + newPartialTicks;
+		timeDelta = time - lastTime + newPartialTicks;
 		lastTime = time;
-		partialTicks = par3;
+		partialTicks = newPartialTicks;
 
 		GlStateManager.color(1F, 1F, 1F, 1F);
 		mc.renderEngine.bindTexture(texture);
-		drawNotes(par3);
+		drawNotes(newPartialTicks);
 
 		GlStateManager.color(1F, 1F, 1F, 1F);
 		mc.renderEngine.bindTexture(texture);
@@ -292,7 +292,7 @@ public class GuiLexicon extends GuiScreen {
 			GlStateManager.color(1F, 1F, 1F, 1F);
 			mc.renderEngine.bindTexture(texture);
 			drawTexturedModalRect(left - 19, top + 42, 67, 180, 19, 26);
-			if(par1 >= left - 19 && par1 < left && par2 >= top + 62 && par2 < top + 88) {
+			if(xCoord >= left - 19 && xCoord < left && yCoord >= top + 62 && yCoord < top + 88) {
 				mc.renderEngine.bindTexture(textureToff);
 				GlStateManager.pushMatrix();
 				GlStateManager.scale(0.5F, 0.5F, 0.5F);
@@ -302,24 +302,24 @@ public class GuiLexicon extends GuiScreen {
 
 				int w = 256;
 				int h = 152;
-				int x = (int) ((ClientTickHandler.ticksInGame + par3) * 6) % (width + w) - w;
-				int y = (int) (top + guiHeight / 2 - h / 4 + Math.sin((ClientTickHandler.ticksInGame + par3) / 6.0) * 40);
+				int x = (int) ((ClientTickHandler.ticksInGame + newPartialTicks) * 6) % (width + w) - w;
+				int y = (int) (top + guiHeight / 2 - h / 4 + Math.sin((ClientTickHandler.ticksInGame + newPartialTicks) / 6.0) * 40);
 
 				drawTexturedModalRect(x * 2, y * 2, 0, 0, w, h);
 				GlStateManager.disableBlend();
 				GlStateManager.popMatrix();
 
-				RenderHelper.renderTooltip(par1, par2, Arrays.asList(TextFormatting.GOLD + "#goldfishchris", TextFormatting.AQUA + "IT SAYS MANUAL"));
+				RenderHelper.renderTooltip(xCoord, yCoord, Arrays.asList(TextFormatting.GOLD + "#goldfishchris", TextFormatting.AQUA + "IT SAYS MANUAL"));
 			}
 		}
 
-		super.drawScreen(par1, par2, par3);
+		super.drawScreen(xCoord, yCoord, newPartialTicks);
 
 		if(hasTutorialArrow) {
 			mc.renderEngine.bindTexture(texture);
 			GlStateManager.enableBlend();
 			GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-			GlStateManager.color(1F, 1F, 1F, 0.7F + (float) (Math.sin((ClientTickHandler.ticksInGame + par3) * 0.3F) + 1) * 0.15F);
+			GlStateManager.color(1F, 1F, 1F, 0.7F + (float) (Math.sin((ClientTickHandler.ticksInGame + newPartialTicks) * 0.3F) + 1) * 0.15F);
 			drawTexturedModalRect(tutorialArrowX, tutorialArrowY, 20, 200, TUTORIAL_ARROW_WIDTH, TUTORIAL_ARROW_HEIGHT);
 			GlStateManager.disableBlend();
 		}

--- a/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexiconChallenge.java
+++ b/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexiconChallenge.java
@@ -54,8 +54,8 @@ public class GuiLexiconChallenge extends GuiLexicon implements IParented {
 	}
 
 	@Override
-	public void drawScreenAfterScale(int par1, int par2, float par3) {
-		super.drawScreenAfterScale(par1, par2, par3);
+	public void drawScreenAfterScale(int xCoord, int yCoord, float newPartialTicks) {
+		super.drawScreenAfterScale(xCoord, yCoord, newPartialTicks);
 
 		RenderHelper.enableGUIStandardItemLighting();
 		GlStateManager.enableRescaleNormal();

--- a/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexiconChallengesList.java
+++ b/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexiconChallengesList.java
@@ -55,8 +55,8 @@ public class GuiLexiconChallengesList extends GuiLexicon implements IParented {
 	}
 
 	@Override
-	public void drawScreenAfterScale(int par1, int par2, float par3) {
-		super.drawScreenAfterScale(par1, par2, par3);
+	public void drawScreenAfterScale(int xCoord, int yCoord, float newPartialTicks) {
+		super.drawScreenAfterScale(xCoord, yCoord, newPartialTicks);
 
 		boolean unicode = fontRenderer.getUnicodeFlag();
 		fontRenderer.setUnicodeFlag(true);

--- a/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexiconEntry.java
+++ b/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexiconEntry.java
@@ -192,11 +192,11 @@ public class GuiLexiconEntry extends GuiLexicon implements IGuiLexiconEntry, IPa
 	}
 
 	@Override
-	public void drawScreenAfterScale(int par1, int par2, float par3) {
-		super.drawScreenAfterScale(par1, par2, par3);
+	public void drawScreenAfterScale(int xCoord, int yCoord, float newPartialTicks) {
+		super.drawScreenAfterScale(xCoord, yCoord, newPartialTicks);
 
 		LexiconPage page = entry.pages.get(this.page);
-		page.renderScreen(this, par1, par2);
+		page.renderScreen(this, xCoord, yCoord);
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexiconIndex.java
+++ b/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexiconIndex.java
@@ -28,7 +28,6 @@ import vazkii.botania.client.core.handler.ClientTickHandler;
 import vazkii.botania.client.gui.lexicon.button.GuiButtonBack;
 import vazkii.botania.client.gui.lexicon.button.GuiButtonInvisible;
 import vazkii.botania.client.gui.lexicon.button.GuiButtonPage;
-import vazkii.botania.common.Botania;
 import vazkii.botania.common.lexicon.DogLexiconEntry;
 
 import java.io.IOException;
@@ -171,8 +170,8 @@ public class GuiLexiconIndex extends GuiLexicon implements IParented {
 	}
 
 	@Override
-	public void drawScreenAfterScale(int par1, int par2, float par3) {
-		super.drawScreenAfterScale(par1, par2, par3);
+	public void drawScreenAfterScale(int xCoord, int yCoord, float newPartialTicks) {
+		super.drawScreenAfterScale(xCoord, yCoord, newPartialTicks);
 
 		if(!searchField.getText().isEmpty()) {
 			drawBookmark(left + 138, top + guiHeight - 24, "  " + searchField.getText(), false);


### PR DESCRIPTION
This should fix the following weird shaking when using the Lexicon:

- The tooltip that indicates that you can hold Shift to get more information about an entry should no longer flash in and out of view.
- The tooltip that is displayed when you hold Shift should no longer pop into and out of existence, and it should stay at a fixed width instead of shaking.
- The shadow placed behind entries in the Lexicon when you mouse over them should no longer shake on the right edge of the Lexicon.