### PR TITLE
Fixes the crash when trying to view the recipe for the Band of Aura

### DIFF
--- a/src/main/java/vazkii/botania/common/crafting/ModCraftingRecipes.java
+++ b/src/main/java/vazkii/botania/common/crafting/ModCraftingRecipes.java
@@ -680,7 +680,9 @@ public final class ModCraftingRecipes {
 		recipeTinyPlanet = ModItems.tinyPlanet.getRegistryName();
 		recipeTinyPlanetBlock = ModBlocks.tinyPlanet.getRegistryName();
 		recipeManaRing = ModItems.manaRing.getRegistryName();
+		recipeAuraRing = ModItems.auraRing.getRegistryName();
 		recipeGreaterManaRing = ModItems.manaRingGreater.getRegistryName();
+		recipeGreaterAuraRing = ModItems.auraRingGreater.getRegistryName();
 		recipeTravelBelt = ModItems.travelBelt.getRegistryName();
 		recipeKnockbackBelt = ModItems.knockbackBelt.getRegistryName();
 		recipeIcePendant = ModItems.icePendant.getRegistryName();


### PR DESCRIPTION
Viewing the recipe for the Band of Aura in the Lexicon was failing - it seems this recipe was accidentally missed in `ModCraftingRecipes` when moving recipes to JSON.