### PR TITLE
Daffomills and anime torches face away from the player when placed

### DIFF
--- a/src/main/java/vazkii/botania/common/block/BlockAnimatedTorch.java
+++ b/src/main/java/vazkii/botania/common/block/BlockAnimatedTorch.java
@@ -15,6 +15,7 @@ import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -58,6 +59,11 @@ public class BlockAnimatedTorch extends BlockMod implements IWandable, IManaTrig
 		}
 
 		return false;
+	}
+	
+	@Override
+	public void onBlockPlacedBy(World world, BlockPos pos, IBlockState state, EntityLivingBase entity, ItemStack stack) {
+		((TileAnimatedTorch) world.getTileEntity(pos)).onPlace(entity);
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileDaffomill.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileDaffomill.java
@@ -10,12 +10,16 @@
  */
 package vazkii.botania.common.block.subtile.functional;
 
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import vazkii.botania.api.lexicon.LexiconEntry;
 import vazkii.botania.api.subtile.RadiusDescriptor;
 import vazkii.botania.api.subtile.SubTileFunctional;
@@ -107,6 +111,13 @@ public class SubTileDaffomill extends SubTileFunctional {
 
 			return true;
 		} else return super.onWanded(player, wand);
+	}
+	
+	@Override
+	public void onBlockPlacedBy(World world, BlockPos pos, IBlockState state, EntityLivingBase entity, ItemStack stack) {
+		if(entity != null)
+			orientation = entity.getHorizontalFacing();
+		super.onBlockPlacedBy(world, pos, state, entity, stack);
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/tile/TileAnimatedTorch.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileAnimatedTorch.java
@@ -12,6 +12,7 @@ package vazkii.botania.common.block.tile;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -22,6 +23,8 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.common.block.ModBlocks;
+
+import java.util.Arrays;
 
 public class TileAnimatedTorch extends TileMod {
 
@@ -60,6 +63,12 @@ public class TileAnimatedTorch extends TileMod {
 	public void handRotate() {
 		if(!world.isRemote)
 			world.addBlockEvent(getPos(), ModBlocks.animatedTorch, 0, (side + 1) % 4);
+	}
+	
+	public void onPlace(EntityLivingBase entity) {
+		if(entity != null) {
+			side = Arrays.asList(SIDES).indexOf(entity.getHorizontalFacing().getOpposite());
+		}
 	}
 
 	public void toggle() {


### PR DESCRIPTION
Just a small usability and convenience tweak. They used to always face north when you placed them, now they face away from the player, like a repeater.

This is my first PR ever so please nitpick. I hope I'm doing this right.