### PR TITLE
Fix incorrect step assist height

### DIFF
--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemTravelBelt.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemTravelBelt.java
@@ -91,7 +91,7 @@ public class ItemTravelBelt extends ItemBauble implements IBaubleRender, IManaUs
 
 					if(player.isSneaking())
 						player.stepHeight = 0.60001F; // Not 0.6F because that is the default
-						else player.stepHeight = 1F;
+						else player.stepHeight = 1.1875F;
 
 				} else {
 					player.stepHeight = 0.6F;
@@ -99,7 +99,7 @@ public class ItemTravelBelt extends ItemBauble implements IBaubleRender, IManaUs
 				}
 			} else if(shouldPlayerHaveStepup(player)) {
 				playersWithStepup.add(s);
-				player.stepHeight = 1F;
+				player.stepHeight = 1.1875F;
 			}
 		}
 	}

--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemTravelBelt.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemTravelBelt.java
@@ -91,7 +91,7 @@ public class ItemTravelBelt extends ItemBauble implements IBaubleRender, IManaUs
 
 					if(player.isSneaking())
 						player.stepHeight = 0.60001F; // Not 0.6F because that is the default
-						else player.stepHeight = 1.1875F;
+						else player.stepHeight = 1.25F;
 
 				} else {
 					player.stepHeight = 0.6F;
@@ -99,7 +99,7 @@ public class ItemTravelBelt extends ItemBauble implements IBaubleRender, IManaUs
 				}
 			} else if(shouldPlayerHaveStepup(player)) {
 				playersWithStepup.add(s);
-				player.stepHeight = 1.1875F;
+				player.stepHeight = 1.25F;
 			}
 		}
 	}


### PR DESCRIPTION
1.25F is player jump height, which is what should ideally be used for step assist. This allows a player to step up to places where they would otherwise be able to jump to, such as a block with 2 layers of snow on top of it.

If there are other places in the code where this needs changing, feel free to close this PR and I'll open an issue for it to be dealt with later.