### PR TITLE
Fix Munchdew going from one cooldown straight into another

### DIFF
--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileMunchdew.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileMunchdew.java
@@ -98,7 +98,10 @@ public class SubTileMunchdew extends SubTileGenerating {
 		if(ateOnce) {
 			ticksWithoutEating++;
 			if(ticksWithoutEating >= 5)
+			{
 				cooldown = 1600;
+				ateOnce = false;
+			}
 		}
 	}
 


### PR DESCRIPTION
When the Munchdew is done eating leaves, it goes on cooldown for 80 seconds, then is supposed to return to an idle state and wait for more leaves to appear.  Instead, if it comes off cooldown and finds no leaves for 5 ticks, it goes back on cooldown.

This PR fixes this issue by setting the ateOnce field, which controls whether the Munchdew goes on cooldown when there are no leaves to eat, to false when the flower enters its cooldown.  Alternately, this could be done inside the `if (cooldown > 0) {...}` block.