### PR TITLE
Fixed usages of deprecated getFullDiscountForTools method

### DIFF
--- a/src/main/java/vazkii/botania/api/mana/ManaItemHandler.java
+++ b/src/main/java/vazkii/botania/api/mana/ManaItemHandler.java
@@ -299,7 +299,7 @@ public final class ManaItemHandler {
 	 * @return The amount of mana received from the request.
 	 */
 	public static int requestManaForTool(ItemStack stack, EntityPlayer player, int manaToGet, boolean remove) {
-		float multiplier = Math.max(0F, 1F - getFullDiscountForTools(player));
+		float multiplier = Math.max(0F, 1F - getFullDiscountForTools(player, stack));
 		int cost = (int) (manaToGet * multiplier);
 		return (int) (requestMana(stack, player, cost, remove) / multiplier);
 	}
@@ -313,7 +313,7 @@ public final class ManaItemHandler {
 	 * @return If the request was succesful.
 	 */
 	public static boolean requestManaExactForTool(ItemStack stack, EntityPlayer player, int manaToGet, boolean remove) {
-		float multiplier = Math.max(0F, 1F - getFullDiscountForTools(player));
+		float multiplier = Math.max(0F, 1F - getFullDiscountForTools(player, stack));
 		int cost = (int) (manaToGet * multiplier);
 		return requestManaExact(stack, player, cost, remove);
 	}


### PR DESCRIPTION
This commit changes the two calls to the deprecated getFullDiscountForTools method in requestManaForTool and requestManaForToolExact to the newer ItemStack-sensitive one. Otherwise, the stack is always null.