### PR TITLE
Add JEI handlers for Orechid and Orechid Ignem

### DIFF
--- a/src/main/java/vazkii/botania/client/integration/jei/JEIBotaniaPlugin.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/JEIBotaniaPlugin.java
@@ -15,7 +15,9 @@ import mezz.jei.api.JEIPlugin;
 import mezz.jei.api.recipe.IRecipeCategoryRegistration;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.recipe.RecipeBrew;
 import vazkii.botania.api.recipe.RecipeElvenTrade;
@@ -33,6 +35,10 @@ import vazkii.botania.client.integration.jei.elventrade.ElvenTradeRecipeCategory
 import vazkii.botania.client.integration.jei.elventrade.ElvenTradeRecipeWrapper;
 import vazkii.botania.client.integration.jei.manapool.ManaPoolRecipeCategory;
 import vazkii.botania.client.integration.jei.manapool.ManaPoolRecipeWrapper;
+import vazkii.botania.client.integration.jei.orechid.OrechidIgnemRecipeCategory;
+import vazkii.botania.client.integration.jei.orechid.OrechidIgnemRecipeWrapper;
+import vazkii.botania.client.integration.jei.orechid.OrechidRecipeCategory;
+import vazkii.botania.client.integration.jei.orechid.OrechidRecipeWrapper;
 import vazkii.botania.client.integration.jei.petalapothecary.PetalApothecaryRecipeCategory;
 import vazkii.botania.client.integration.jei.petalapothecary.PetalApothecaryRecipeWrapper;
 import vazkii.botania.client.integration.jei.puredaisy.PureDaisyRecipeCategory;
@@ -45,6 +51,12 @@ import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.block.ItemBlockSpecialFlower;
 
 import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static vazkii.botania.common.lib.LibBlockNames.SUBTILE_ORECHID;
+import static vazkii.botania.common.lib.LibBlockNames.SUBTILE_ORECHID_IGNEM;
+import static vazkii.botania.common.lib.LibBlockNames.SUBTILE_PUREDAISY;
 
 @JEIPlugin
 public class JEIBotaniaPlugin implements IModPlugin {
@@ -63,8 +75,16 @@ public class JEIBotaniaPlugin implements IModPlugin {
 				new RunicAltarRecipeCategory(registry.getJeiHelpers().getGuiHelper()), // Runic must come before petals. See williewillus/Botania#172
 				new PetalApothecaryRecipeCategory(registry.getJeiHelpers().getGuiHelper()),
 				new ElvenTradeRecipeCategory(registry.getJeiHelpers().getGuiHelper()),
-				new ManaPoolRecipeCategory(registry.getJeiHelpers().getGuiHelper())
-				);
+				new ManaPoolRecipeCategory(registry.getJeiHelpers().getGuiHelper()),
+				new OrechidRecipeCategory(registry.getJeiHelpers().getGuiHelper()),
+				new OrechidIgnemRecipeCategory(registry.getJeiHelpers().getGuiHelper())
+		);
+	}
+
+	public static boolean doesOreExist(Map.Entry<String, Integer> entry) {
+		return OreDictionary.doesOreNameExist(entry.getKey())
+				&& OreDictionary.getOres(entry.getKey()).stream()
+				.anyMatch(s -> s.getItem() instanceof ItemBlock);
 	}
 
 	@Override
@@ -84,6 +104,23 @@ public class JEIBotaniaPlugin implements IModPlugin {
 		registry.addRecipes(BotaniaAPI.runeAltarRecipes, RunicAltarRecipeCategory.UID);
 		registry.addRecipes(BotaniaAPI.manaInfusionRecipes, ManaPoolRecipeCategory.UID);
 
+		registry.addRecipes(
+				BotaniaAPI.oreWeights.entrySet().stream()
+						.filter(JEIBotaniaPlugin::doesOreExist)
+						.map(OrechidRecipeWrapper::new)
+						.sorted()
+						.collect(Collectors.toList()),
+				OrechidRecipeCategory.UID);
+
+		registry.addRecipes(
+				BotaniaAPI.oreWeightsNether.entrySet().stream()
+						.filter(JEIBotaniaPlugin::doesOreExist)
+						.map(OrechidIgnemRecipeWrapper::new)
+						.sorted()
+						.collect(Collectors.toList()),
+				OrechidIgnemRecipeCategory.UID);
+
+
 		registry.addRecipeCatalyst(new ItemStack(ModBlocks.brewery), BreweryRecipeCategory.UID);
 		registry.addRecipeCatalyst(new ItemStack(ModBlocks.alfPortal), ElvenTradeRecipeCategory.UID);
 
@@ -96,8 +133,12 @@ public class JEIBotaniaPlugin implements IModPlugin {
 			registry.addRecipeCatalyst(new ItemStack(ModBlocks.altar, 1, v.ordinal()), PetalApothecaryRecipeCategory.UID);
 		}
 
-		registry.addRecipeCatalyst(ItemBlockSpecialFlower.ofType("puredaisy"), PureDaisyRecipeCategory.UID);
-		registry.addRecipeCatalyst(ItemBlockSpecialFlower.ofType(new ItemStack(ModBlocks.floatingSpecialFlower), "puredaisy"), PureDaisyRecipeCategory.UID);
+		registry.addRecipeCatalyst(ItemBlockSpecialFlower.ofType(SUBTILE_ORECHID), OrechidRecipeCategory.UID);
+		registry.addRecipeCatalyst(ItemBlockSpecialFlower.ofType(new ItemStack(ModBlocks.floatingSpecialFlower), SUBTILE_ORECHID), OrechidRecipeCategory.UID);
+		registry.addRecipeCatalyst(ItemBlockSpecialFlower.ofType(SUBTILE_ORECHID_IGNEM), OrechidIgnemRecipeCategory.UID);
+		registry.addRecipeCatalyst(ItemBlockSpecialFlower.ofType(new ItemStack(ModBlocks.floatingSpecialFlower), SUBTILE_ORECHID_IGNEM), OrechidIgnemRecipeCategory.UID);
+		registry.addRecipeCatalyst(ItemBlockSpecialFlower.ofType(SUBTILE_PUREDAISY), PureDaisyRecipeCategory.UID);
+		registry.addRecipeCatalyst(ItemBlockSpecialFlower.ofType(new ItemStack(ModBlocks.floatingSpecialFlower), SUBTILE_PUREDAISY), PureDaisyRecipeCategory.UID);
 
 
 		registry.addRecipeCatalyst(new ItemStack(ModBlocks.runeAltar), RunicAltarRecipeCategory.UID);

--- a/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidIgnemRecipeCategory.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidIgnemRecipeCategory.java
@@ -1,0 +1,95 @@
+/**
+ * This class was created by <codewarrior0>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ * <p/>
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ */
+package vazkii.botania.client.integration.jei.orechid;
+
+import mezz.jei.api.IGuiHelper;
+import mezz.jei.api.gui.IDrawable;
+import mezz.jei.api.gui.IDrawableStatic;
+import mezz.jei.api.gui.IGuiItemStackGroup;
+import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IRecipeCategory;
+import mezz.jei.api.recipe.IRecipeWrapper;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import vazkii.botania.common.item.block.ItemBlockSpecialFlower;
+import vazkii.botania.common.lib.LibBlockNames;
+import vazkii.botania.common.lib.LibMisc;
+
+import javax.annotation.Nonnull;
+
+public class OrechidIgnemRecipeCategory implements IRecipeCategory {
+
+    public static final String UID = "botania.orechid_ignem";
+    private final IDrawableStatic background;
+    private final String localizedName;
+    private final IDrawableStatic overlay;
+
+    public OrechidIgnemRecipeCategory(IGuiHelper guiHelper) {
+        background = guiHelper.createBlankDrawable(168, 64);
+        localizedName = I18n.format("botania.nei.orechidIgnem");
+        overlay = guiHelper.createDrawable(new ResourceLocation("botania", "textures/gui/pureDaisyOverlay.png"),
+                0, 0, 64, 46);
+    }
+
+    @Nonnull
+    @Override
+    public String getUid() {
+        return UID;
+    }
+
+    @Nonnull
+    @Override
+    public String getTitle() {
+        return localizedName;
+    }
+
+    @Nonnull
+    @Override
+    public IDrawable getBackground() {
+        return background;
+    }
+
+
+    @Override
+    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
+        final IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+
+        itemStacks.init(0, true, 40, 12);
+
+        itemStacks.set(0, ingredients.getInputs(ItemStack.class).get(0));
+
+        itemStacks.init(1, true, 70, 12);
+        itemStacks.set(1, ItemBlockSpecialFlower.ofType(LibBlockNames.SUBTILE_ORECHID_IGNEM));
+
+        itemStacks.init(2, true, 99, 12);
+
+        itemStacks.set(2, ingredients.getOutputs(ItemStack.class).get(0));
+
+    }
+
+    @Override
+    public void drawExtras(@Nonnull Minecraft minecraft) {
+        GlStateManager.enableAlpha();
+        GlStateManager.enableBlend();
+        overlay.draw(minecraft, 48, 0);
+        GlStateManager.disableBlend();
+        GlStateManager.disableAlpha();
+    }
+
+    @Nonnull
+    @Override
+    public String getModName() {
+        return LibMisc.MOD_NAME;
+    }
+
+}

--- a/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidIgnemRecipeWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidIgnemRecipeWrapper.java
@@ -1,0 +1,32 @@
+/**
+ * This class was created by <codewarrior0>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ * <p/>
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ */
+package vazkii.botania.client.integration.jei.orechid;
+
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import vazkii.botania.api.BotaniaAPI;
+
+import java.util.Map;
+
+public class OrechidIgnemRecipeWrapper extends OrechidRecipeWrapper {
+
+    public OrechidIgnemRecipeWrapper(Map.Entry<String, Integer> entry) {
+        super(entry);
+    }
+
+    public Map<String, Integer> getOreWeights() {
+        return BotaniaAPI.oreWeightsNether;
+    }
+    static ItemStack inputStack;
+
+    public ItemStack getInputStack() {
+        if (inputStack == null) inputStack = new ItemStack(Blocks.NETHERRACK, 64);
+        return inputStack;
+    }
+}

--- a/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidRecipeCategory.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidRecipeCategory.java
@@ -1,0 +1,95 @@
+/**
+ * This class was created by <codewarrior0>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ * <p/>
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ */
+package vazkii.botania.client.integration.jei.orechid;
+
+import mezz.jei.api.IGuiHelper;
+import mezz.jei.api.gui.IDrawable;
+import mezz.jei.api.gui.IDrawableStatic;
+import mezz.jei.api.gui.IGuiItemStackGroup;
+import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IRecipeCategory;
+import mezz.jei.api.recipe.IRecipeWrapper;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import vazkii.botania.common.item.block.ItemBlockSpecialFlower;
+import vazkii.botania.common.lib.LibBlockNames;
+import vazkii.botania.common.lib.LibMisc;
+
+import javax.annotation.Nonnull;
+
+public class OrechidRecipeCategory implements IRecipeCategory {
+
+    public static final String UID = "botania.orechid";
+    private final IDrawableStatic background;
+    private final String localizedName;
+    private final IDrawableStatic overlay;
+
+    public OrechidRecipeCategory(IGuiHelper guiHelper) {
+        background = guiHelper.createBlankDrawable(168, 64);
+        localizedName = I18n.format("botania.nei.orechid");
+        overlay = guiHelper.createDrawable(new ResourceLocation("botania", "textures/gui/pureDaisyOverlay.png"),
+                0, 0, 64, 46);
+    }
+
+    @Nonnull
+    @Override
+    public String getUid() {
+        return UID;
+    }
+
+    @Nonnull
+    @Override
+    public String getTitle() {
+        return localizedName;
+    }
+
+    @Nonnull
+    @Override
+    public IDrawable getBackground() {
+        return background;
+    }
+
+
+    @Override
+    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
+        final IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+
+        itemStacks.init(0, true, 40, 12);
+
+        itemStacks.set(0, ingredients.getInputs(ItemStack.class).get(0));
+
+        itemStacks.init(1, true, 70, 12);
+        itemStacks.set(1, ItemBlockSpecialFlower.ofType(LibBlockNames.SUBTILE_ORECHID));
+
+        itemStacks.init(2, true, 99, 12);
+
+        itemStacks.set(2, ingredients.getOutputs(ItemStack.class).get(0));
+
+    }
+
+    @Override
+    public void drawExtras(@Nonnull Minecraft minecraft) {
+        GlStateManager.enableAlpha();
+        GlStateManager.enableBlend();
+        overlay.draw(minecraft, 48, 0);
+        GlStateManager.disableBlend();
+        GlStateManager.disableAlpha();
+    }
+
+    @Nonnull
+    @Override
+    public String getModName() {
+        return LibMisc.MOD_NAME;
+    }
+
+}

--- a/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidRecipeWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidRecipeWrapper.java
@@ -1,0 +1,82 @@
+/**
+ * This class was created by <codewarrior0>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ * <p/>
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ */
+package vazkii.botania.client.integration.jei.orechid;
+
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IRecipeWrapper;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+import vazkii.botania.api.BotaniaAPI;
+import vazkii.botania.client.integration.jei.JEIBotaniaPlugin;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class OrechidRecipeWrapper implements IRecipeWrapper, Comparable<OrechidRecipeWrapper> {
+    public String oreDictKey;
+    public int weight;
+
+    static ItemStack inputStack;
+    List<List<ItemStack>> outputStacks;
+
+    public ItemStack getInputStack() {
+        if (inputStack == null) inputStack = new ItemStack(Blocks.STONE, 64);
+        return inputStack;
+    }
+
+    public List<List<ItemStack>> getOutputStacks() {
+        if (outputStacks == null) {
+            final int amount = Math.max(1, Math.round((float) weight * 64 / getTotalOreWeight()));
+
+            // Shouldn't ever return an empty list since the ore weight
+            // list is filtered to only have ores with ItemBlocks
+            List<ItemStack> stackList = OreDictionary.getOres(oreDictKey).stream()
+                    .filter(s -> s.getItem() instanceof ItemBlock)
+                    .map(ItemStack::copy)
+                    .collect(Collectors.toList());
+
+            stackList.forEach(s -> s.setCount(amount));
+
+            outputStacks = Collections.singletonList(stackList);
+        }
+        return outputStacks;
+    }
+
+    public OrechidRecipeWrapper(Map.Entry<String, Integer> entry) {
+        this.oreDictKey = entry.getKey();
+        this.weight = entry.getValue();
+    }
+
+    public Map<String, Integer> getOreWeights() {
+        return BotaniaAPI.oreWeights;
+    }
+
+    public float getTotalOreWeight() {
+        return (getOreWeights().entrySet().stream()
+                .filter(JEIBotaniaPlugin::doesOreExist)
+                .map(Map.Entry::getValue)
+                .reduce(Integer::sum)).orElse(weight * 64 * 64);
+    }
+
+    @Override
+    public void getIngredients(IIngredients ingredients) {
+
+        ingredients.setInput(ItemStack.class, getInputStack());
+        ingredients.setOutputLists(ItemStack.class, getOutputStacks());
+    }
+
+    @Override
+    public int compareTo(OrechidRecipeWrapper o) {
+        return Integer.compare(o.weight, weight);
+    }
+}

--- a/src/main/resources/assets/botania/lang/en_us.lang
+++ b/src/main/resources/assets/botania/lang/en_us.lang
@@ -168,6 +168,9 @@ botania.nei.petalApothecary=Petal Apothecary
 botania.nei.runicAltar=Runic Altar
 botania.nei.pureDaisy=Pure Daisy
 botania.nei.lexica=Lexica Botania
+botania.nei.orechid=Orechid
+botania.nei.orechidIgnem=Orechid Ignem
+
 nei.options.keys.gui.botania_corporea_request=Corporea Request
 
 botania.nei.lexicaSeparator=Extra Info:


### PR DESCRIPTION
Adds two JEI pages that show the expected number of ores when a stack of stone is processed by the Orechid. Entries are sorted by weight. Shows a single ore when the expected chance is less than 1/64. Output ores rotate through the oredict to allow the player to look up any variety of e.g. Tin Ore to see the Orechid entry. Skips any ores that don't exist as ItemBlocks, and skips any oredict keys that don't contain any ItemBlocks at all.

![image](https://user-images.githubusercontent.com/307683/39971402-0cdc5806-5696-11e8-9a1f-1e44516f4ee9.png)
