### PR TITLE
In skyblock, use horizon height and void fade as in Void biome.

### DIFF
--- a/src/main/java/vazkii/botania/common/world/WorldTypeSkyblock.java
+++ b/src/main/java/vazkii/botania/common/world/WorldTypeSkyblock.java
@@ -61,4 +61,16 @@ public class WorldTypeSkyblock extends WorldType {
 		return flat;
 	}
 
+	/* In skyblock worlds, do not darken the sky until player hits y=0 */
+	@Override
+	public double getHorizon(World world)
+	{
+		return 0.0D;
+	}
+
+	@Override
+	public double voidFadeMagnitude() {
+		return 1.0D;
+	}
+
 }


### PR DESCRIPTION
In Garden of Glass, dipping below y=63 or so makes the sky go dark. I looked into why that is, given that in the "Void" superflat preset in Minecraft this does not happen. This is because that preset uses the "Void" biome everywhere. Using any other biome causes the same dark sky problem below where the ocean should be.

This takes the settings from the "Void" biome and hopefully applies them to all biomes when in Garden of Glass, i.e. using the "botania-skyblock" world type. Not sure whether sea level should be changed as well.