### PR TITLE
Elementium Tools now repair with Elementium

### DIFF
--- a/src/main/java/vazkii/botania/common/item/equipment/armor/elementium/ItemElementiumArmor.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/armor/elementium/ItemElementiumArmor.java
@@ -37,8 +37,8 @@ public abstract class ItemElementiumArmor extends ItemManasteelArmor implements 
 	}
 
 	@Override
-	public boolean getIsRepairable(ItemStack par1ItemStack, @Nonnull ItemStack par2ItemStack) {
-		return par2ItemStack.getItem() == ModItems.manaResource && par2ItemStack.getItemDamage() == 7 ? true : super.getIsRepairable(par1ItemStack, par2ItemStack);
+	public boolean getIsRepairable(ItemStack toRepair, @Nonnull ItemStack repairBy) {
+		return repairBy.getItem() == ModItems.manaResource && repairBy.getItemDamage() == 7 ? true : super.getIsRepairable(toRepair, repairBy);
 	}
 
 	static ItemStack[] armorset;

--- a/src/main/java/vazkii/botania/common/item/equipment/armor/elementium/ItemElementiumArmor.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/armor/elementium/ItemElementiumArmor.java
@@ -37,8 +37,8 @@ public abstract class ItemElementiumArmor extends ItemManasteelArmor implements 
 	}
 
 	@Override
-	public boolean getIsRepairable(ItemStack toRepair, @Nonnull ItemStack repairBy) {
-		return repairBy.getItem() == ModItems.manaResource && repairBy.getItemDamage() == 7 ? true : super.getIsRepairable(toRepair, repairBy);
+	public boolean getIsRepairable(ItemStack par1ItemStack, @Nonnull ItemStack par2ItemStack) {
+		return par2ItemStack.getItem() == ModItems.manaResource && par2ItemStack.getItemDamage() == 7 ? true : super.getIsRepairable(par1ItemStack, par2ItemStack);
 	}
 
 	static ItemStack[] armorset;

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumAxe.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumAxe.java
@@ -65,8 +65,8 @@ public class ItemElementiumAxe extends ItemManasteelAxe {
 	}
 
 	@Override
-	public boolean getIsRepairable(ItemStack par1ItemStack, @Nonnull ItemStack par2ItemStack) {
-		return par2ItemStack.getItem() == ModItems.manaResource && par2ItemStack.getItemDamage() == 7 ? true : super.getIsRepairable(par1ItemStack, par2ItemStack);
+	public boolean getIsRepairable(ItemStack toRepair, @Nonnull ItemStack repairBy) {
+		return repairBy.getItem() == ModItems.manaResource && repairBy.getItemDamage() == 7 ? true : super.getIsRepairable(toRepair, repairBy);
 	}
 
 }

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumAxe.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumAxe.java
@@ -21,6 +21,7 @@ import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.equipment.tool.manasteel.ItemManasteelAxe;
 import vazkii.botania.common.lib.LibItemNames;
 
+import javax.annotation.Nonnull;
 import java.util.Random;
 
 public class ItemElementiumAxe extends ItemManasteelAxe {
@@ -61,6 +62,11 @@ public class ItemElementiumAxe extends ItemManasteelAxe {
 		EntityItem entityitem = new EntityItem(event.getEntityLiving().world, event.getEntityLiving().posX, event.getEntityLiving().posY, event.getEntityLiving().posZ, drop);
 		entityitem.setPickupDelay(10);
 		event.getDrops().add(entityitem);
+	}
+
+	@Override
+	public boolean getIsRepairable(ItemStack par1ItemStack, @Nonnull ItemStack par2ItemStack) {
+		return par2ItemStack.getItem() == ModItems.manaResource && par2ItemStack.getItemDamage() == 7 ? true : super.getIsRepairable(par1ItemStack, par2ItemStack);
 	}
 
 }

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumPick.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumPick.java
@@ -12,6 +12,8 @@ import vazkii.botania.common.item.equipment.tool.manasteel.ItemManasteelPick;
 import vazkii.botania.common.item.equipment.tool.terrasteel.ItemTerraPick;
 import vazkii.botania.common.lib.LibItemNames;
 
+import javax.annotation.Nonnull;
+
 public class ItemElementiumPick extends ItemManasteelPick {
 
 	public ItemElementiumPick() {
@@ -53,5 +55,10 @@ public class ItemElementiumPick extends ItemManasteelPick {
 				return true;
 		}
 		return false;
+	}
+
+	@Override
+	public boolean getIsRepairable(ItemStack par1ItemStack, @Nonnull ItemStack par2ItemStack) {
+		return par2ItemStack.getItem() == ModItems.manaResource && par2ItemStack.getItemDamage() == 7 ? true : super.getIsRepairable(par1ItemStack, par2ItemStack);
 	}
 }

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumPick.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumPick.java
@@ -58,7 +58,7 @@ public class ItemElementiumPick extends ItemManasteelPick {
 	}
 
 	@Override
-	public boolean getIsRepairable(ItemStack par1ItemStack, @Nonnull ItemStack par2ItemStack) {
-		return par2ItemStack.getItem() == ModItems.manaResource && par2ItemStack.getItemDamage() == 7 ? true : super.getIsRepairable(par1ItemStack, par2ItemStack);
+	public boolean getIsRepairable(ItemStack toRepair, @Nonnull ItemStack repairBy) {
+		return repairBy.getItem() == ModItems.manaResource && repairBy.getItemDamage() == 7 ? true : super.getIsRepairable(toRepair, repairBy);
 	}
 }

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumShears.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumShears.java
@@ -16,6 +16,7 @@ import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.IShearable;
+import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.equipment.tool.ToolCommons;
 import vazkii.botania.common.item.equipment.tool.manasteel.ItemManasteelShears;
 import vazkii.botania.common.lib.LibItemNames;
@@ -74,6 +75,11 @@ public class ItemElementiumShears extends ItemManasteelShears {
 				}
 			}
 		}
+	}
+
+	@Override
+	public boolean getIsRepairable(ItemStack par1ItemStack, @Nonnull ItemStack par2ItemStack) {
+		return par2ItemStack.getItem() == ModItems.manaResource && par2ItemStack.getItemDamage() == 7 ? true : super.getIsRepairable(par1ItemStack, par2ItemStack);
 	}
 
 }

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumShears.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumShears.java
@@ -78,8 +78,8 @@ public class ItemElementiumShears extends ItemManasteelShears {
 	}
 
 	@Override
-	public boolean getIsRepairable(ItemStack par1ItemStack, @Nonnull ItemStack par2ItemStack) {
-		return par2ItemStack.getItem() == ModItems.manaResource && par2ItemStack.getItemDamage() == 7 ? true : super.getIsRepairable(par1ItemStack, par2ItemStack);
+	public boolean getIsRepairable(ItemStack toRepair, @Nonnull ItemStack repairBy) {
+		return repairBy.getItem() == ModItems.manaResource && repairBy.getItemDamage() == 7 ? true : super.getIsRepairable(toRepair, repairBy);
 	}
 
 }

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumShovel.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumShovel.java
@@ -51,8 +51,8 @@ public class ItemElementiumShovel extends ItemManasteelShovel {
 	}
 
 	@Override
-	public boolean getIsRepairable(ItemStack par1ItemStack, @Nonnull ItemStack par2ItemStack) {
-		return par2ItemStack.getItem() == ModItems.manaResource && par2ItemStack.getItemDamage() == 7 ? true : super.getIsRepairable(par1ItemStack, par2ItemStack);
+	public boolean getIsRepairable(ItemStack toRepair, @Nonnull ItemStack repairBy) {
+		return repairBy.getItem() == ModItems.manaResource && repairBy.getItemDamage() == 7 ? true : super.getIsRepairable(toRepair, repairBy);
 	}
 
 }

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumShovel.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumShovel.java
@@ -12,10 +12,12 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3i;
 import net.minecraft.world.World;
 import vazkii.botania.api.BotaniaAPI;
+import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.equipment.tool.ToolCommons;
 import vazkii.botania.common.item.equipment.tool.manasteel.ItemManasteelShovel;
 import vazkii.botania.common.lib.LibItemNames;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
 
@@ -46,6 +48,11 @@ public class ItemElementiumShovel extends ItemManasteelShovel {
 			ToolCommons.removeBlocksInIteration(player, stack, world, pos, new Vec3i(0, -12, 0), new Vec3i(1, 12, 1), blk, materialsShovel, silk, fortune, false);
 
 		return false;
+	}
+
+	@Override
+	public boolean getIsRepairable(ItemStack par1ItemStack, @Nonnull ItemStack par2ItemStack) {
+		return par2ItemStack.getItem() == ModItems.manaResource && par2ItemStack.getItemDamage() == 7 ? true : super.getIsRepairable(par1ItemStack, par2ItemStack);
 	}
 
 }

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumSword.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumSword.java
@@ -3,8 +3,11 @@ package vazkii.botania.common.item.equipment.tool.elementium;
 import net.minecraft.item.ItemStack;
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.item.IPixieSpawner;
+import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.equipment.tool.manasteel.ItemManasteelSword;
 import vazkii.botania.common.lib.LibItemNames;
+
+import javax.annotation.Nonnull;
 
 public class ItemElementiumSword extends ItemManasteelSword implements IPixieSpawner {
 
@@ -15,6 +18,11 @@ public class ItemElementiumSword extends ItemManasteelSword implements IPixieSpa
 	@Override
 	public float getPixieChance(ItemStack stack) {
 		return 0.05F;
+	}
+
+	@Override
+	public boolean getIsRepairable(ItemStack par1ItemStack, @Nonnull ItemStack par2ItemStack) {
+		return par2ItemStack.getItem() == ModItems.manaResource && par2ItemStack.getItemDamage() == 7 ? true : super.getIsRepairable(par1ItemStack, par2ItemStack);
 	}
 
 }

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumSword.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ItemElementiumSword.java
@@ -21,8 +21,8 @@ public class ItemElementiumSword extends ItemManasteelSword implements IPixieSpa
 	}
 
 	@Override
-	public boolean getIsRepairable(ItemStack par1ItemStack, @Nonnull ItemStack par2ItemStack) {
-		return par2ItemStack.getItem() == ModItems.manaResource && par2ItemStack.getItemDamage() == 7 ? true : super.getIsRepairable(par1ItemStack, par2ItemStack);
+	public boolean getIsRepairable(ItemStack toRepair, @Nonnull ItemStack repairBy) {
+		return repairBy.getItem() == ModItems.manaResource && repairBy.getItemDamage() == 7 ? true : super.getIsRepairable(toRepair, repairBy);
 	}
 
 }


### PR DESCRIPTION
This fixes https://github.com/Vazkii/Botania/issues/2646 
I assumed that Elementium was the correct material to repair the tools instead of manasteel because the tools were made from Elementium, also Elementium is used to repair the armor instead of manasteel.