### PR TITLE
Clean up and update wiki providers

### DIFF
--- a/src/main/java/vazkii/botania/api/BotaniaAPI.java
+++ b/src/main/java/vazkii/botania/api/BotaniaAPI.java
@@ -214,33 +214,19 @@ public final class BotaniaAPI {
 		addOreWeightNether("oreOnyx", 500); // SimpleOres 2
 		addOreWeightNether("oreHaditeCoal", 500); // Hadite
 
-		registerModWiki("Minecraft", new SimpleWikiProvider("Minecraft Wiki", "http://minecraft.gamepedia.com/%s"));
+		registerModWiki("minecraft", new SimpleWikiProvider("Minecraft Wiki", "https://minecraft.gamepedia.com/%s"));
 
 		IWikiProvider technicWiki = new SimpleWikiProvider("Technic Wiki", "http://wiki.technicpack.net/%s");
 		IWikiProvider mekanismWiki = new SimpleWikiProvider("Mekanism Wiki", "http://wiki.aidancbrady.com/wiki/%s");
-		IWikiProvider buildcraftWiki = new SimpleWikiProvider("BuildCraft Wiki", "http://www.mod-buildcraft.com/wiki/doku.php?id=%s");
 
-		registerModWiki("Mekanism", mekanismWiki);
-		registerModWiki("MekanismGenerators", mekanismWiki);
-		registerModWiki("MekanismTools", mekanismWiki);
-		registerModWiki("EnderIO", new SimpleWikiProvider("EnderIO Wiki", "http://wiki.enderio.com/%s"));
-		registerModWiki("TropiCraft", new SimpleWikiProvider("Tropicraft Wiki", "http://wiki.tropicraft.net/wiki/%s"));
-		registerModWiki("RandomThings", new SimpleWikiProvider("Random Things Wiki", "http://randomthingsminecraftmod.wikispaces.com/%s"));
-		registerModWiki("Witchery", new SimpleWikiProvider("Witchery Wiki", "https://sites.google.com/site/witcherymod/%s", "-", true));
-		registerModWiki("AppliedEnergistics2", new SimpleWikiProvider("AE2 Wiki", "http://ae-mod.info/%s"));
-		registerModWiki("BigReactors", technicWiki);
-		registerModWiki("BuildCraft|Core", buildcraftWiki);
-		registerModWiki("BuildCraft|Builders", buildcraftWiki);
-		registerModWiki("BuildCraft|Energy", buildcraftWiki);
-		registerModWiki("BuildCraft|Factory", buildcraftWiki);
-		registerModWiki("BuildCraft|Silicon", buildcraftWiki);
-		registerModWiki("BuildCraft|Transport", buildcraftWiki);
-		registerModWiki("ArsMagica2", new SimpleWikiProvider("ArsMagica2 Wiki", "http://wiki.arsmagicamod.com/wiki/%s"));
-		registerModWiki("PneumaticCraft", new SimpleWikiProvider("PneumaticCraft Wiki", "http://www.minemaarten.com/wikis/pneumaticcraft-wiki/pneumaticcraft-wiki-%s"));
-		registerModWiki("StevesCarts2", new SimpleWikiProvider("Steve's Carts Wiki", "http://stevescarts2.wikispaces.com/%s"));
-		registerModWiki("GanysSurface", new SimpleWikiProvider("Gany's Surface Wiki", "http://ganys-surface.wikia.com/wiki/%s"));
-		registerModWiki("GanysNether", new SimpleWikiProvider("Gany's Nether Wiki", "http://ganys-nether.wikia.com/wiki/%s"));
-		registerModWiki("GanysEnd", new SimpleWikiProvider("Gany's End Wiki", "http://ganys-end.wikia.com/wiki/%s"));
+		registerModWiki("mekanism", mekanismWiki);
+		registerModWiki("mekanismgenerators", mekanismWiki);
+		registerModWiki("mekanismtools", mekanismWiki);
+		registerModWiki("enderio", new SimpleWikiProvider("EnderIO Wiki", "http://wiki.enderio.com/%s"));
+		registerModWiki("tropicraft", new SimpleWikiProvider("Tropicraft Wiki", "http://wiki.tropicraft.net/wiki/%s"));
+		registerModWiki("randomthings", new SimpleWikiProvider("Random Things Wiki", "https://lumien.net/rtwiki/blocks/%s/", "-", true));
+		registerModWiki("appliedenergistics2", new SimpleWikiProvider("AE2 Wiki", "http://ae-mod.info/%s"));
+		registerModWiki("bigreactors", technicWiki);
 
 		registerPaintableBlock(Blocks.STAINED_GLASS, BlockStainedGlass.COLOR);
 		registerPaintableBlock(Blocks.STAINED_GLASS_PANE, BlockStainedGlassPane.COLOR);

--- a/src/main/java/vazkii/botania/api/wiki/WikiHooks.java
+++ b/src/main/java/vazkii/botania/api/wiki/WikiHooks.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 public class WikiHooks {
 
-	private static final IWikiProvider FALLBACK_PROVIDER = new SimpleWikiProvider("FTB Wiki", "http://ftb.gamepedia.com/%s");
+	private static final IWikiProvider FALLBACK_PROVIDER = new SimpleWikiProvider("FTB Wiki", "https://ftb.gamepedia.com/%s");
 
 	private static final Map<String, IWikiProvider> modWikis = new HashMap<>();
 


### PR DESCRIPTION
I noticed a lot of outdated links in the wiki provider list, going to sites that are gone or taken over by some shady stuff, and decided to clean that up a bit.

No new wikis were added - basically the main reason I did this was being afraid any users would accidentally use the lexica on a block and land on a bad site.

Summary of changes:
* Gamepedia is now purely on HTTPS
* Lowercased the modids. Didn't change that the providers lowercase the modid as well - what if someone's using the API expecting that? (as if anyone uses this feature).
* Buildcraft's wiki previously used doesn't exist anymore.
* Ars Magica 2, Pneumaticraft - the site was taken over last time I checked.
* Witchery, Gany's mods - those mods seem to be entirely dead. 
* Steve's Carts, Random Things - both were on wikispaces, which stopped being free a while ago... and they are shutting down this year. Random Things migrated, but Steve's Carts doesn't have a wiki anymore.

One thing I didn't address was Big Reactors - the fork Extreme Reactors has a few changes, including appending ` (Legacy)` to the block names, for example. I am not sure if it even uses the same modid as Big Reactors.