### PR TITLE
Implement getCreatorModId on the flower item

### DIFF
--- a/src/main/java/vazkii/botania/common/item/block/ItemBlockSpecialFlower.java
+++ b/src/main/java/vazkii/botania/common/item/block/ItemBlockSpecialFlower.java
@@ -104,10 +104,14 @@ public class ItemBlockSpecialFlower extends ItemBlockMod implements IRecipeKeyPr
 			if(!refLocalized.equals(refUnlocalized))
 				stacks.add(TextFormatting.ITALIC + refLocalized);
 		}
+	}
 
-		String mod = BotaniaAPI.subTileMods.get(type);
-		if(mod != null && !mod.equals(LibMisc.MOD_ID))
-			stacks.add(TextFormatting.ITALIC + "[" + mod + "]");
+	@Override
+	public String getCreatorModId(ItemStack itemStack) {
+		String mod = BotaniaAPI.subTileMods.get(getType(itemStack));
+		if(mod != null)
+			return mod;
+		return LibMisc.MOD_ID;
 	}
 
 	public static String getType(ItemStack stack) {


### PR DESCRIPTION
Replaces the tooltip containing the creator mod's modid with an override for the method returning it,  allowing mods like JEI to show the mod that actually added the flower and return it in mod searches, like
Forge's universal bucket already does with mod fluids.

Example, using a flower from Incorporeal: 

![alexa play despacito](https://user-images.githubusercontent.com/26120076/44173291-ca7ad980-a0df-11e8-9750-926b7a1b20a2.png)
