### PR TITLE
Corporea retainers use richer signal strength depending on request size (but better)

### DIFF
--- a/src/main/java/vazkii/botania/api/corporea/CorporeaHelper.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaHelper.java
@@ -17,6 +17,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 import vazkii.botania.api.BotaniaAPI;
@@ -301,8 +302,9 @@ public final class CorporeaHelper {
 	/** 
 	 * Returns the comparator strength for a corporea request that corporea crystal cubes and retainers use, following the usual "each step up requires double the items" formula.
 	 */
-	private static final double LOG_2 = Math.log(2);
 	public static int signalStrengthForRequestSize(int requestSize) {
-		return requestSize == 0 ? 0 : Math.min(15, (int) Math.floor(Math.log(requestSize) / LOG_2) + 1);
+		if(requestSize <= 0) return 0;
+		else if (requestSize >= 16384) return 15;
+		else return Math.min(15, MathHelper.log2(requestSize) + 1);
 	}
 }

--- a/src/main/java/vazkii/botania/api/corporea/CorporeaHelper.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaHelper.java
@@ -297,4 +297,12 @@ public final class CorporeaHelper {
 	public static String stripControlCodes(String str) {
 		return patternControlCode.matcher(str).replaceAll("");
 	}
+	
+	/** 
+	 * Returns the comparator strength for a corporea request that corporea crystal cubes and retainers use, following the usual "each step up requires double the items" formula.
+	 */
+	private static final double LOG_2 = Math.log(2);
+	public static int signalStrengthForRequestSize(int requestSize) {
+		return requestSize == 0 ? 0 : Math.min(15, (int) Math.floor(Math.log(requestSize) / LOG_2) + 1);
+	}
 }

--- a/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaCrystalCube.java
+++ b/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaCrystalCube.java
@@ -128,7 +128,7 @@ public class BlockCorporeaCrystalCube extends BlockCorporeaBase implements ILexi
 
 	@Override
 	public int getComparatorInputOverride(IBlockState state, World world, BlockPos pos) {
-		return ((TileCorporeaCrystalCube) world.getTileEntity(pos)).compValue;
+		return ((TileCorporeaCrystalCube) world.getTileEntity(pos)).getComparatorValue();
 	}
 
 	@Nonnull

--- a/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaRetainer.java
+++ b/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaRetainer.java
@@ -75,7 +75,7 @@ public class BlockCorporeaRetainer extends BlockMod implements ILexiconable {
 
 	@Override
 	public int getComparatorInputOverride(IBlockState state, World world, BlockPos pos) {
-		return ((TileCorporeaRetainer) world.getTileEntity(pos)).hasPendingRequest() ? 15 : 0;
+		return ((TileCorporeaRetainer) world.getTileEntity(pos)).getComparatorValue();
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaCrystalCube.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaCrystalCube.java
@@ -111,8 +111,10 @@ public class TileCorporeaCrystalCube extends TileCorporeaBase implements ICorpor
 	}
 
 	private void onUpdateCount() {
+		int oldCompValue = compValue;
 		compValue = CorporeaHelper.signalStrengthForRequestSize(itemCount);
-		world.updateComparatorOutputLevel(pos, world.getBlockState(pos).getBlock());
+		if(compValue != oldCompValue)
+			world.updateComparatorOutputLevel(pos, world.getBlockState(pos).getBlock());
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaCrystalCube.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaCrystalCube.java
@@ -41,7 +41,7 @@ public class TileCorporeaCrystalCube extends TileCorporeaBase implements ICorpor
 	ItemStack requestTarget = ItemStack.EMPTY;
 	int itemCount = 0;
 	int ticks = 0;
-	public int compValue = 0;
+	int compValue = 0;
 
 	private final IAnimationStateMachine asm;
 
@@ -111,7 +111,7 @@ public class TileCorporeaCrystalCube extends TileCorporeaBase implements ICorpor
 	}
 
 	private void onUpdateCount() {
-		compValue = getComparatorValue();
+		compValue = CorporeaHelper.signalStrengthForRequestSize(itemCount);
 		world.updateComparatorOutputLevel(pos, world.getBlockState(pos).getBlock());
 	}
 
@@ -134,9 +134,7 @@ public class TileCorporeaCrystalCube extends TileCorporeaBase implements ICorpor
 	}
 
 	public int getComparatorValue() {
-		if(itemCount == 0)
-			return 0;
-		return Math.min(15, (int) Math.floor(Math.log(itemCount) / LOG_2) + 1);
+		return compValue;
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaRetainer.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaRetainer.java
@@ -38,6 +38,7 @@ public class TileCorporeaRetainer extends TileMod {
 	BlockPos requestPos = BlockPos.ORIGIN;
 	Object request;
 	int requestCount;
+	int compValue;
 
 	public void setPendingRequest(BlockPos pos, Object request, int requestCount) {
 		if(pendingRequest)
@@ -47,9 +48,15 @@ public class TileCorporeaRetainer extends TileMod {
 		this.request = request;
 		this.requestCount = requestCount;
 		pendingRequest = true;
+		
+		compValue = CorporeaHelper.signalStrengthForRequestSize(requestCount);
 		world.updateComparatorOutputLevel(getPos(), world.getBlockState(getPos()).getBlock());
 	}
-
+	
+	public int getComparatorValue() {
+		return compValue;
+	}
+	
 	public boolean hasPendingRequest() {
 		return pendingRequest;
 	}


### PR DESCRIPTION
This PR:
* adds a cute helper function in `CorporeaHelper` to get a signal strength 0-15 from a corporea request size 0-16384, using the usual "each step up needs double the size" method,
* modifies the corporea crystal cube to use that helper function to determine its comparator strength
* modifies the corporea retainer to use that helper function to determine its comparator strength, as opposed to the previous "15 if there is any pending request at all, ever" behavior