### PR TITLE
Use ore dictionary ingredients in more recipes

### DIFF
--- a/src/main/resources/assets/botania/recipes/_constants.json
+++ b/src/main/resources/assets/botania/recipes/_constants.json
@@ -149,6 +149,13 @@
   {
     "ingredient": {
       "type": "forge:ore_dict",
+      "ore": "feather"
+    },
+    "name": "FEATHER"
+  },
+  {
+    "ingredient": {
+      "type": "forge:ore_dict",
       "ore": "gemEmerald"
     },
     "name": "GEMEMERALD"
@@ -229,6 +236,13 @@
       "ore": "ingotTerrasteel"
     },
     "name": "INGOTTERRASTEEL"
+  },
+  {
+    "ingredient": {
+      "type": "forge:ore_dict",
+      "ore": "leather"
+    },
+    "name": "LEATHER"
   },
   {
     "ingredient": {
@@ -534,9 +548,23 @@
   {
     "ingredient": {
       "type": "forge:ore_dict",
+      "ore": "obsidian"
+    },
+    "name": "OBSIDIAN"
+  },
+  {
+    "ingredient": {
+      "type": "forge:ore_dict",
       "ore": "paneGlassColorless"
     },
     "name": "PANEGLASSCOLORLESS"
+  },
+  {
+    "ingredient": {
+      "type": "forge:ore_dict",
+      "ore": "paper"
+    },
+    "name": "PAPER"
   },
   {
     "ingredient": {
@@ -873,6 +901,13 @@
       "ore": "treeSapling"
     },
     "name": "TREESAPLING"
+  },
+  {
+    "ingredient": {
+      "type": "forge:ore_dict",
+      "ore": "vine"
+    },
+    "name": "VINE"
   },
   {
     "ingredient": {

--- a/src/main/resources/assets/botania/recipes/bellows.json
+++ b/src/main/resources/assets/botania/recipes/bellows.json
@@ -17,7 +17,7 @@
       "data": 0
     },
     "L": {
-      "item": "minecraft:leather"
+      "item": "#LEATHER"
     }
   }
 }

--- a/src/main/resources/assets/botania/recipes/corporeaindex.json
+++ b/src/main/resources/assets/botania/recipes/corporeaindex.json
@@ -20,7 +20,7 @@
       "item": "#ELVENDRAGONSTONE"
     },
     "O": {
-      "item": "minecraft:obsidian"
+      "item": "#OBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/botania/recipes/endereyeblock.json
+++ b/src/main/resources/assets/botania/recipes/endereyeblock.json
@@ -16,7 +16,7 @@
       "item": "minecraft:ender_eye"
     },
     "O": {
-      "item": "minecraft:obsidian"
+      "item": "#OBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/botania/recipes/enderhand.json
+++ b/src/main/resources/assets/botania/recipes/enderhand.json
@@ -16,10 +16,10 @@
       "item": "minecraft:ender_chest"
     },
     "L": {
-      "item": "minecraft:leather"
+      "item": "#LEATHER"
     },
     "O": {
-      "item": "minecraft:obsidian"
+      "item": "#OBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/botania/recipes/flighttiara_0.json
+++ b/src/main/resources/assets/botania/recipes/flighttiara_0.json
@@ -14,7 +14,7 @@
       "item": "#BENDERAIRBOTTLE"
     },
     "F": {
-      "item": "minecraft:feather"
+      "item": "#FEATHER"
     },
     "I": {
       "item": "#INGOTELVENELEMENTIUM"

--- a/src/main/resources/assets/botania/recipes/forestdrum_0.json
+++ b/src/main/resources/assets/botania/recipes/forestdrum_0.json
@@ -18,7 +18,7 @@
       "data": 0
     },
     "L": {
-      "item": "minecraft:leather"
+      "item": "#LEATHER"
     }
   }
 }

--- a/src/main/resources/assets/botania/recipes/forestdrum_1.json
+++ b/src/main/resources/assets/botania/recipes/forestdrum_1.json
@@ -17,7 +17,7 @@
       "item": "#DREAMWOOD"
     },
     "L": {
-      "item": "minecraft:leather"
+      "item": "#LEATHER"
     }
   }
 }

--- a/src/main/resources/assets/botania/recipes/forestdrum_2.json
+++ b/src/main/resources/assets/botania/recipes/forestdrum_2.json
@@ -18,7 +18,7 @@
       "data": 1
     },
     "L": {
-      "item": "minecraft:leather"
+      "item": "#LEATHER"
     }
   }
 }

--- a/src/main/resources/assets/botania/recipes/garden_of_glass/end_portal_frame.json
+++ b/src/main/resources/assets/botania/recipes/garden_of_glass/end_portal_frame.json
@@ -17,7 +17,7 @@
       "item": "#ETERNALLIFEESSENCE"
     },
     "O": {
-      "item": "minecraft:obsidian"
+      "item": "#OBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/botania/recipes/keepivy.json
+++ b/src/main/resources/assets/botania/recipes/keepivy.json
@@ -7,7 +7,7 @@
       "item": "#ELVENPIXIEDUST"
     },
     {
-      "item": "minecraft:vine"
+      "item": "#VINE"
     },
     {
       "item": "#BENDERAIRBOTTLE"

--- a/src/main/resources/assets/botania/recipes/knockbackbelt.json
+++ b/src/main/resources/assets/botania/recipes/knockbackbelt.json
@@ -19,7 +19,7 @@
       "item": "#RUNEEARTHB"
     },
     "L": {
-      "item": "minecraft:leather"
+      "item": "#LEATHER"
     }
   }
 }

--- a/src/main/resources/assets/botania/recipes/lens_22.json
+++ b/src/main/resources/assets/botania/recipes/lens_22.json
@@ -11,7 +11,7 @@
   "type": "minecraft:crafting_shaped",
   "key": {
     "P": {
-      "item": "minecraft:paper"
+      "item": "#PAPER"
     },
     "L": {
       "item": "botania:lens",

--- a/src/main/resources/assets/botania/recipes/manavoid.json
+++ b/src/main/resources/assets/botania/recipes/manavoid.json
@@ -13,7 +13,7 @@
       "item": "#LIVINGROCK"
     },
     "O": {
-      "item": "minecraft:obsidian"
+      "item": "#OBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/botania/recipes/starfield.json
+++ b/src/main/resources/assets/botania/recipes/starfield.json
@@ -15,7 +15,7 @@
       "item": "#INGOTELVENELEMENTIUM"
     },
     "O": {
-      "item": "minecraft:obsidian"
+      "item": "#OBSIDIAN"
     }
   }
 }

--- a/src/main/resources/assets/botania/recipes/thornchakram_0.json
+++ b/src/main/resources/assets/botania/recipes/thornchakram_0.json
@@ -15,7 +15,7 @@
       "item": "#INGOTTERRASTEEL"
     },
     "V": {
-      "item": "minecraft:vine"
+      "item": "#VINE"
     }
   }
 }

--- a/src/main/resources/assets/botania/recipes/tornadorod.json
+++ b/src/main/resources/assets/botania/recipes/tornadorod.json
@@ -16,7 +16,7 @@
       "item": "#LIVINGWOODTWIG"
     },
     "F": {
-      "item": "minecraft:feather"
+      "item": "#FEATHER"
     }
   }
 }

--- a/src/main/resources/assets/botania/recipes/travelbelt.json
+++ b/src/main/resources/assets/botania/recipes/travelbelt.json
@@ -19,7 +19,7 @@
       "item": "#RUNEEARTHB"
     },
     "L": {
-      "item": "minecraft:leather"
+      "item": "#LEATHER"
     }
   }
 }


### PR DESCRIPTION
Replaces leather, feathers, obsidian, paper and vines with their oredict entries in crafting recipes. (Except the vine ball, as that wouldn't make too much sense).

Made mostly because I noticed some items taking only vanilla leather when all I had access to was oredicted replacements.

I did notice most brew recipes don't use oredict at all, but I left them alone as I didn't know how appropriate was replacing their ingredients.