### PR TITLE
Add missing null check in PacketBotaniaEffect

### DIFF
--- a/src/main/java/vazkii/botania/common/network/PacketBotaniaEffect.java
+++ b/src/main/java/vazkii/botania/common/network/PacketBotaniaEffect.java
@@ -107,6 +107,8 @@ public class PacketBotaniaEffect implements IMessage {
 					}
 					case ITEM_SMOKE: {
 						Entity item = world.getEntityByID(message.args[0]);
+						if (item == null) return;
+						
 						int p = message.args[1];
 
 						for(int i = 0; i < p; i++) {


### PR DESCRIPTION
Server mate encountered a crash with a NullPointerException at the indicated line. It appears this case of the switch block is missing the entity null check, since the other cases do have them.