### PR TITLE
Add llamas and parrots to the cocoon's rare animal spawns

### DIFF
--- a/src/main/java/vazkii/botania/common/block/tile/TileCocoon.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileCocoon.java
@@ -16,8 +16,10 @@ import net.minecraft.entity.monster.EntityShulker;
 import net.minecraft.entity.passive.EntityChicken;
 import net.minecraft.entity.passive.EntityCow;
 import net.minecraft.entity.passive.EntityHorse;
+import net.minecraft.entity.passive.EntityLlama;
 import net.minecraft.entity.passive.EntityMooshroom;
 import net.minecraft.entity.passive.EntityOcelot;
+import net.minecraft.entity.passive.EntityParrot;
 import net.minecraft.entity.passive.EntityPig;
 import net.minecraft.entity.passive.EntityRabbit;
 import net.minecraft.entity.passive.EntitySheep;
@@ -66,7 +68,7 @@ public class TileCocoon extends TileMod implements ITickable{
 			} else {
 				float specialChance = 0.05F;
 				if(Math.random() < specialChance) {
-					int entityType = world.rand.nextInt(3);
+					int entityType = world.rand.nextInt(5);
 					switch(entityType) {
 					case 0:
 						entity = new EntityHorse(world);
@@ -76,6 +78,12 @@ public class TileCocoon extends TileMod implements ITickable{
 						break;
 					case 2:
 						entity = new EntityOcelot(world);
+						break;
+					case 3:
+						entity = new EntityParrot(world);
+						break;
+					case 4:
+						entity = new EntityLlama(world);
 						break;
 					}
 				} else {


### PR DESCRIPTION
A minor nitpick PR, I guess.

Llamas were added in 1.11, while parrots were added in 1.12.
Both of them are a rare pet and so should be available from the cocoon. I assume the only reason they were not available is that no one actually thought about it. The last functionality change of the cocoon was adding shulker spawning in early 1.11.

This ensures that GoG players will be capable of obtaining these mobs, possibly giving access to some parts of other mods as well.

This does make the other rare mobs slightly rarer, but while I did think about buffing the rare mob chance slightly, I doubt this will matter too much in the long run as reliably getting a pair of all the rare mobs already requires a decent investment, but I am open to tweaking the numbers.

Oh, there were some talks in Vazkii's discord about making this more dynamic but I decided it would be a bad idea because who knows what weird entites other mods add... 