### PR TITLE
Fix Alfheim portal storing items not used in recipes

### DIFF
--- a/src/main/java/vazkii/botania/api/recipe/RecipeElvenTrade.java
+++ b/src/main/java/vazkii/botania/api/recipe/RecipeElvenTrade.java
@@ -44,11 +44,7 @@ public class RecipeElvenTrade {
 					List<ItemStack> validStacks = OreDictionary.getOres((String) input);
 					boolean found = false;
 					for(ItemStack ostack : validStacks) {
-						ItemStack cstack = ostack.copy();
-						if(cstack.getItemDamage() == Short.MAX_VALUE)
-							cstack.setItemDamage(stack.getItemDamage());
-
-						if(stack.isItemEqual(cstack)) {
+						if(OreDictionary.itemMatches(ostack, stack, false)) {
 							if(!stacksToRemove.contains(stack))
 								stacksToRemove.add(stack);
 							oredictIndex = j;

--- a/src/main/java/vazkii/botania/common/block/tile/TileAlfPortal.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileAlfPortal.java
@@ -21,6 +21,7 @@ import net.minecraft.util.ITickable;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.oredict.OreDictionary;
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.lexicon.ILexicon;
 import vazkii.botania.api.lexicon.multiblock.Multiblock;
@@ -141,7 +142,8 @@ public class TileAlfPortal extends TileMod implements ITickable {
 
 					if (consume) {
 						item.setDead();
-						addItem(stack);
+						if (validateItemUsage(stack))
+							addItem(stack);
 						ticksSinceLastItem = 0;
 					}
 				}
@@ -163,6 +165,24 @@ public class TileAlfPortal extends TileMod implements ITickable {
 					blockParticle(state);
 			world.setBlockState(getPos(), world.getBlockState(getPos()).withProperty(BotaniaStateProps.ALFPORTAL_STATE, newState), 1 | 2);
 		}
+	}
+
+	private boolean validateItemUsage(ItemStack inputStack) {
+		for(RecipeElvenTrade recipe : BotaniaAPI.elvenTradeRecipes) {
+			for(Object o : recipe.getInputs()) {
+				if(o instanceof String) {
+					for(ItemStack target : OreDictionary.getOres((String) o)) {
+						if(OreDictionary.itemMatches(target, inputStack, false))
+							return true;
+					}
+				} else if(o instanceof ItemStack) {
+					ItemStack target = (ItemStack) o;
+					if(inputStack.getItem() == target.getItem() && inputStack.getItemDamage() == target.getItemDamage())
+						return true;
+				}
+			}
+		}
+		return false;
 	}
 
 	private void blockParticle(AlfPortalState state) {

--- a/src/main/java/vazkii/botania/common/block/tile/TileAlfPortal.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileAlfPortal.java
@@ -14,6 +14,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
@@ -75,6 +76,7 @@ public class TileAlfPortal extends TileMod implements ITickable {
 	public int ticksOpen = 0;
 	private int ticksSinceLastItem = 0;
 	private boolean closeNow = false;
+	private boolean explode = false;
 
 	private static final Function<BlockPos, BlockPos> CONVERTER_X_Z = input -> new BlockPos(input.getZ(), input.getY(), input.getX());
 
@@ -164,6 +166,9 @@ public class TileAlfPortal extends TileMod implements ITickable {
 				for(int i = 0; i < 36; i++)
 					blockParticle(state);
 			world.setBlockState(getPos(), world.getBlockState(getPos()).withProperty(BotaniaStateProps.ALFPORTAL_STATE, newState), 1 | 2);
+		} else if(explode) {
+			world.createExplosion(null, pos.getX() + .5, pos.getY() + 2.0, pos.getZ() + .5, 3f, true);
+			explode = false;
 		}
 	}
 
@@ -182,6 +187,9 @@ public class TileAlfPortal extends TileMod implements ITickable {
 				}
 			}
 		}
+		if(inputStack.getItem() == Items.BREAD) //Don't teleport bread. (See also: #2403)
+			explode = true;
+
 		return false;
 	}
 


### PR DESCRIPTION
Fixes #2403 by checking if the item actually is a part of any recipe. Also simplifies the oredict stack check in the elven trade recipe logic.

Possibly mitigates #2669, as recipe checks are a bit simplified to not create stack copies (posting capability events and stuff) and the portal will not check items with no uses more than once. Of course if some mod/modpack developer adds a recipe that takes different items you are able to fill the portal tile with a lot of one component of the recipe, but this will make it rarer.

Also now includes a dumb reference to two things at once. I have done nothing but teleport bread for 5 minutes to test it. If you don't want to include it, don't pull the second commit.