### PR TITLE
Fix the portal not returning the lexicon

### DIFF
--- a/src/main/java/vazkii/botania/common/block/tile/TileAlfPortal.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileAlfPortal.java
@@ -39,6 +39,7 @@ import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.block.tile.mana.TilePool;
 import vazkii.botania.common.core.handler.ConfigHandler;
 import vazkii.botania.common.item.ItemLexicon;
+import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.lexicon.LexiconData;
 
 import javax.annotation.Nonnull;
@@ -173,6 +174,9 @@ public class TileAlfPortal extends TileMod implements ITickable {
 	}
 
 	private boolean validateItemUsage(ItemStack inputStack) {
+		if(inputStack.getItem() == ModItems.lexicon)
+			return true;
+
 		for(RecipeElvenTrade recipe : BotaniaAPI.elvenTradeRecipes) {
 			for(Object o : recipe.getInputs()) {
 				if(o instanceof String) {


### PR DESCRIPTION
Fixes #2725. I swear I am somewhat competent and just forgot that the lexicon is a dumb hardcoded special case. Can we move all Botania recipes to proper ingredients and stuff yet? 