### PR TITLE
Improve handling of brews in JEI

### DIFF
--- a/src/main/java/vazkii/botania/client/integration/jei/JEIBotaniaPlugin.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/JEIBotaniaPlugin.java
@@ -51,6 +51,7 @@ import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.crafting.recipe.SpecialFloatingFlowerRecipe;
 import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.block.ItemBlockSpecialFlower;
+import vazkii.botania.common.item.brew.ItemBrewBase;
 
 import javax.annotation.Nonnull;
 import java.util.stream.Collectors;
@@ -66,6 +67,10 @@ public class JEIBotaniaPlugin implements IModPlugin {
 	public void registerItemSubtypes(@Nonnull ISubtypeRegistry subtypeRegistry) {
 		subtypeRegistry.registerSubtypeInterpreter(Item.getItemFromBlock(ModBlocks.specialFlower), ItemBlockSpecialFlower::getType);
 		subtypeRegistry.registerSubtypeInterpreter(Item.getItemFromBlock(ModBlocks.floatingSpecialFlower), ItemBlockSpecialFlower::getType);
+		subtypeRegistry.registerSubtypeInterpreter(ModItems.brewVial, ItemBrewBase::getSubtype);
+		subtypeRegistry.registerSubtypeInterpreter(ModItems.brewFlask, ItemBrewBase::getSubtype);
+		subtypeRegistry.registerSubtypeInterpreter(ModItems.incenseStick, ItemBrewBase::getSubtype);
+		subtypeRegistry.registerSubtypeInterpreter(ModItems.bloodPendant, ItemBrewBase::getSubtype);
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/client/integration/jei/brewery/BreweryRecipeCategory.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/brewery/BreweryRecipeCategory.java
@@ -13,17 +13,16 @@ import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IDrawableStatic;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IFocus;
 import mezz.jei.api.recipe.IRecipeCategory;
 import mezz.jei.api.recipe.IRecipeWrapper;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import vazkii.botania.common.lib.LibMisc;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class BreweryRecipeCategory implements IRecipeCategory {
@@ -68,9 +67,11 @@ public class BreweryRecipeCategory implements IRecipeCategory {
 			return;
 
 		List<List<ItemStack>> inputs = ingredients.getInputs(ItemStack.class);
+		List<List<ItemStack>> outputs = ingredients.getOutputs(ItemStack.class);
+		IFocus<?> focus = recipeLayout.getFocus();
 
 		recipeLayout.getItemStacks().init(0, true, 39, 41);
-		recipeLayout.getItemStacks().set(0, inputs.get(0));
+		recipeLayout.getItemStacks().set(0, getItemMatchingFocus(focus, IFocus.Mode.OUTPUT, outputs.get(0), inputs.get(0)));
 
 		int index = 1, posX = 60;
 		for(int i = 1; i < inputs.size(); i++) {
@@ -82,6 +83,19 @@ public class BreweryRecipeCategory implements IRecipeCategory {
 		}
 
 		recipeLayout.getItemStacks().init(7, false, 87, 41);
-		recipeLayout.getItemStacks().set(7, ingredients.getOutputs(ItemStack.class).get(0));
+		recipeLayout.getItemStacks().set(7, getItemMatchingFocus(focus, IFocus.Mode.INPUT, inputs.get(0), outputs.get(0)));
+	}
+
+	/**
+	 * If an item in this recipe is focused, returns the corresponding item instead of all the containers/results.
+	 */
+	private List<ItemStack> getItemMatchingFocus(IFocus<?> focus, IFocus.Mode mode, List<ItemStack> focused, List<ItemStack> other) {
+		if(focus != null && focus.getMode() == mode) {
+			ItemStack focusStack = (ItemStack) focus.getValue();
+			for(int i = 0; i < focused.size(); i++)
+				if(focusStack.isItemEqual(focused.get(i)))
+					return Collections.singletonList(other.get(i));
+		}
+		return other;
 	}
 }

--- a/src/main/java/vazkii/botania/client/integration/jei/brewery/BreweryRecipeWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/brewery/BreweryRecipeWrapper.java
@@ -11,35 +11,48 @@ package vazkii.botania.client.integration.jei.brewery;
 import com.google.common.collect.ImmutableList;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.IRecipeWrapper;
-import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 import vazkii.botania.api.recipe.RecipeBrew;
 import vazkii.botania.common.item.ModItems;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 import java.util.List;
 
 public class BreweryRecipeWrapper implements IRecipeWrapper {
 
 	private final List<List<ItemStack>> input;
 	private final List<ItemStack> output;
+	
+	private static final List<ItemStack> inputs = Arrays.asList(new ItemStack(ModItems.vial), 
+		new ItemStack(ModItems.vial, 1, 1), new ItemStack(ModItems.incenseStick), new ItemStack(ModItems.bloodPendant));
 
-	@SuppressWarnings("unchecked")
 	public BreweryRecipeWrapper(RecipeBrew recipeBrew) {
-		ImmutableList.Builder<List<ItemStack>> builder = ImmutableList.builder();
-		builder.add(ImmutableList.of(new ItemStack(ModItems.vial, 1, 0), new ItemStack(ModItems.vial, 1, 1)));
+		ImmutableList.Builder<List<ItemStack>> inputBuilder = ImmutableList.builder();
+		ImmutableList.Builder<ItemStack> outputBuilder = ImmutableList.builder();
+		ImmutableList.Builder<ItemStack> containers = ImmutableList.builder();
+
+		for(ItemStack stack : inputs) {
+			ItemStack brewed = recipeBrew.getOutput(stack);
+			if(!brewed.isEmpty()) {
+				containers.add(stack);
+				outputBuilder.add(brewed);
+			}
+		}
+		inputBuilder.add(containers.build());
+		
 		for(Object o : recipeBrew.getInputs()) {
 			if(o instanceof ItemStack) {
-				builder.add(ImmutableList.of((ItemStack) o));
+				inputBuilder.add(ImmutableList.of((ItemStack) o));
 			}
 			if(o instanceof String) {
-				builder.add(OreDictionary.getOres((String) o));
+				inputBuilder.add(OreDictionary.getOres((String) o));
 			}
 		}
 
-		input = builder.build();
-		output = ImmutableList.of(recipeBrew.getOutput(new ItemStack(ModItems.vial)).copy(), recipeBrew.getOutput(new ItemStack(ModItems.vial, 1, 1)).copy());
+		input = inputBuilder.build();
+		output = outputBuilder.build();
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/item/brew/ItemBrewBase.java
+++ b/src/main/java/vazkii/botania/common/item/brew/ItemBrewBase.java
@@ -149,6 +149,11 @@ public abstract class ItemBrewBase extends ItemMod implements IBrewItem {
 		ItemNBTHelper.setString(stack, TAG_BREW_KEY, brew);
 	}
 
+	@Nonnull
+	public static String getSubtype(ItemStack stack) {
+		return stack.hasTagCompound() ? ItemNBTHelper.getString(stack, TAG_BREW_KEY, "none") : "none";
+	}
+	
 	public int getSwigsLeft(ItemStack stack) {
 		return ItemNBTHelper.getInt(stack, TAG_SWIGS_LEFT, swigs);
 	}


### PR DESCRIPTION
* Add subtype interpreters to make looking up specific brew recipes less annoying - clicking on "Vial of Fleetfeet" will show you only that specific recipe and not all of them.
* Add blood pendants and incense sticks to the brew recipe wrapper, so that they can be looked up too.
* Add locking of the other ingredient, so that when an item is focused, the other ingredient does not change to the items that don't fit (eg. you looked up the flask of fleetfeet, the input no longer swaps between vials and flasks, but stays locked to the alfglass flask - this was made more obvious by adding pendants and sticks).