### PR TITLE
Add JEI recipe gui support for the corporea request key

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ jar {
 dependencies {
     deobfCompile "com.mod-buildcraft:buildcraft-api:7.99.17"
     deobfCompile "com.azanor.baubles:Baubles:1.12-1.5.2"
-    deobfCompile "mezz.jei:jei_1.12.2:4.10.0.198"
+    deobfCompile "mezz.jei:jei_1.12.2:4.13.1.220"
     deobfCompile "thaumcraft:Thaumcraft:1.12.2:6.1.BETA21"
 
     //and a bit more for SCP

--- a/src/main/java/vazkii/botania/client/core/handler/CorporeaInputHandler.java
+++ b/src/main/java/vazkii/botania/client/core/handler/CorporeaInputHandler.java
@@ -25,6 +25,7 @@ import vazkii.botania.client.core.proxy.ClientProxy;
 import vazkii.botania.common.block.tile.corporea.TileCorporeaIndex;
 import vazkii.botania.common.lib.LibMisc;
 
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 @Mod.EventBusSubscriber(modid = LibMisc.MOD_ID, value = Side.CLIENT)
@@ -33,10 +34,13 @@ public class CorporeaInputHandler {
 	/** Replaced in JEIBotaniaPlugin when JEI's loaded to provide stacks from the JEI item panel. */
 	public static Supplier<ItemStack> jeiPanelSupplier = () -> ItemStack.EMPTY;
 
+	/** Filter for usable guis to handle requests. Added to in JEIBotaniaPlugin */
+	public static Predicate<GuiScreen> supportedGuiFilter = gui -> gui instanceof GuiContainer;
+
 	@SubscribeEvent
 	public static void buttonPressed(KeyboardInputEvent.Post event) {
 		Minecraft mc = Minecraft.getMinecraft();
-		if(mc.world == null || !(mc.currentScreen instanceof GuiContainer)
+		if(mc.world == null || !supportedGuiFilter.test(mc.currentScreen)
 				|| Keyboard.getEventKey() != ClientProxy.CORPOREA_REQUEST.getKeyCode()
 				|| !Keyboard.getEventKeyState()
 				|| Keyboard.isRepeatEvent()

--- a/src/main/java/vazkii/botania/client/integration/jei/JEIBotaniaPlugin.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/JEIBotaniaPlugin.java
@@ -11,10 +11,13 @@ package vazkii.botania.client.integration.jei;
 import mezz.jei.api.IJeiRuntime;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.IModRegistry;
+import mezz.jei.api.IRecipesGui;
 import mezz.jei.api.ISubtypeRegistry;
 import mezz.jei.api.JEIPlugin;
 import mezz.jei.api.recipe.IRecipeCategoryRegistration;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
@@ -158,10 +161,16 @@ public class JEIBotaniaPlugin implements IModPlugin {
 	public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
 		CorporeaInputHandler.jeiPanelSupplier = () -> {
 			Object o = jeiRuntime.getIngredientListOverlay().getIngredientUnderMouse();
+
+			if(o == null && Minecraft.getMinecraft().currentScreen == jeiRuntime.getRecipesGui())
+				o = jeiRuntime.getRecipesGui().getIngredientUnderMouse();
+
 			if(o instanceof ItemStack)
 				return (ItemStack) o;
 			return ItemStack.EMPTY;
 		};
+
+		CorporeaInputHandler.supportedGuiFilter = gui -> gui instanceof GuiContainer || gui instanceof IRecipesGui;
 	}
 
 }

--- a/src/main/java/vazkii/botania/common/lib/LibMisc.java
+++ b/src/main/java/vazkii/botania/common/lib/LibMisc.java
@@ -17,7 +17,7 @@ public final class LibMisc {
 	public static final String MOD_NAME = "Botania";
 	public static final String BUILD = "GRADLE:BUILD";
 	public static final String VERSION = "GRADLE:VERSION-" + BUILD;
-	public static final String DEPENDENCIES = "required-after:baubles@[1.5.2,);after:thaumcraft@[6.1.BETA21,);after:jei@[1.12.2-4.10.0.198,)";
+	public static final String DEPENDENCIES = "required-after:baubles@[1.5.2,);after:thaumcraft@[6.1.BETA21,);after:jei@[1.12.2-4.13.1.220,)";
 
 	// Network Contants
 	public static final String NETWORK_CHANNEL = MOD_ID;


### PR DESCRIPTION
Bumps required JEI version to 4.13.1.220, which added the required hook (see mezz/JustEnoughItems#1374). If you want to wait a bit until a stable release is made with this hook to merge, I'll be fine with that.

This might not seem like much, but after playing a bit with Corporea as a storage solution, I think I will cherrypick this and make a custom build for personal use, just to use this - it is a giant difference when you don't have to leave the crafting screen to type in the names and request all the items.