### PR TITLE
Tweaks to Thaumcraft integration

### DIFF
--- a/src/main/java/vazkii/botania/common/Botania.java
+++ b/src/main/java/vazkii/botania/common/Botania.java
@@ -165,9 +165,14 @@ public class Botania {
 
 		for(Block b : new Block[]{ ModBlocks.manaGlass, ModBlocks.elfGlass, ModBlocks.bifrostPerm })
 			FMLInterModComms.sendMessage("chiselsandbits", "ignoreblocklogic", b.getRegistryName().toString());
-
-		if(Botania.thaumcraftLoaded && ConfigHandler.enableThaumcraftAspects)
-			MinecraftForge.EVENT_BUS.register(TCAspects.class);
+		
+		if(Botania.thaumcraftLoaded) {
+			if(ConfigHandler.enableThaumcraftAspects) {
+				MinecraftForge.EVENT_BUS.register(TCAspects.class);
+			}
+			ModBrews.initTC();
+			ModBrewRecipes.initTC();
+		}
 
 		if(Botania.bcApiLoaded)
 			new StatementAPIPlugin();
@@ -177,8 +182,6 @@ public class Botania {
 	@EventHandler
 	public void postInit(FMLPostInitializationEvent event) {
 		if(Botania.thaumcraftLoaded) {
-			ModBrews.initTC();
-			ModBrewRecipes.initTC();
 			try {
 				@SuppressWarnings("unchecked")
 				Class<? extends Entity> clazz = (Class<? extends Entity>) Class.forName("thaumcraft.common.entities.EntityFluxRift");

--- a/src/main/java/vazkii/botania/common/integration/thaumcraft/TCAspects.java
+++ b/src/main/java/vazkii/botania/common/integration/thaumcraft/TCAspects.java
@@ -21,9 +21,11 @@ import net.minecraftforge.oredict.OreDictionary;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectEventProxy;
+import thaumcraft.api.aspects.AspectHelper;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.aspects.AspectRegistryEvent;
 import vazkii.botania.api.BotaniaAPI;
+import vazkii.botania.api.recipe.RecipeBrew;
 import vazkii.botania.common.Botania;
 import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.block.ModFluffBlocks;
@@ -33,6 +35,9 @@ import vazkii.botania.common.item.block.ItemBlockSpecialFlower;
 import vazkii.botania.common.lib.LibBlockNames;
 import vazkii.botania.common.lib.LibEntityNames;
 import vazkii.botania.common.lib.LibOreDict;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static thaumcraft.api.aspects.Aspect.*;
 
@@ -49,6 +54,7 @@ public class TCAspects {
 		TCAspects handler = new TCAspects(event.register);
 		handler.registerFlowerAspects();
 		handler.registerItemAspects();
+		handler.registerBrewAspects();
 		handler.registerEntityAspects();
 	}
 
@@ -65,6 +71,7 @@ public class TCAspects {
 		registerFlower(LibBlockNames.SUBTILE_KEKIMURUS,      new AspectList().add(DESIRE, 10));
 		registerFlower(LibBlockNames.SUBTILE_GOURMARYLLIS,   new AspectList().add(DESIRE, 5).add(LIFE, 5));
 		registerFlower(LibBlockNames.SUBTILE_NARSLIMMUS,     new AspectList().add(WATER, 5).add(LIFE, 5));
+		registerFlower(LibBlockNames.SUBTILE_SPECTROLUS,     new AspectList().add(SENSES, 10).add(BEAST, 5));
 		registerFlower(LibBlockNames.SUBTILE_RAFFLOWSIA,     new AspectList().add(VOID, 10));
 		registerFlower(LibBlockNames.SUBTILE_SHULK_ME_NOT,   new AspectList().add(FLIGHT, 5).add(TRAP, 5));
 		registerFlower(LibBlockNames.SUBTILE_DANDELIFEON,    new AspectList().add(ORDER, 5).add(MECHANISM, 5).add(LIFE, 5));
@@ -100,16 +107,16 @@ public class TCAspects {
 	//Each category is mostly ordered by order of its recipe registration.
 	private void registerItemAspects() {
 		//Pure Daisy
-		register(LibOreDict.LIVING_WOOD, new AspectList(new ItemStack(Blocks.LOG)).add(LIFE, 5));
-		register(LibOreDict.LIVING_ROCK, new AspectList(new ItemStack(Blocks.STONE)).add(LIFE, 3));
+		register(LibOreDict.LIVING_WOOD, new AspectList().add(PLANT, 20).add(LIFE, 5));
+		register(LibOreDict.LIVING_ROCK, new AspectList().add(EARTH, 5).add(LIFE, 3));
 
 		//Mana Infusion
 		register(LibOreDict.MANA_STEEL, new AspectList().add(METAL, 10).add(MAGIC, 5));
 		register(LibOreDict.MANA_PEARL, new AspectList().add(ELDRITCH, 10).add(MAGIC, 5).add(MOTION, 5));
 		register(LibOreDict.MANA_DIAMOND, new AspectList(new ItemStack(Items.DIAMOND)).add(MAGIC, 5));
 		register(LibOreDict.MANA_POWDER, new AspectList().add(ENERGY, 3).add(MAGIC, 3));
-		register(ModBlocks.pistonRelay, ANY, new AspectList(new ItemStack(Blocks.PISTON)).add(AURA, 10));
-		register(ModItems.manaCookie, ANY, new AspectList(new ItemStack(Items.COOKIE)).merge(LIFE, 20).add(MAGIC, 5));
+		register(ModBlocks.pistonRelay, 0, new AspectList(new ItemStack(Blocks.PISTON)).add(AURA, 10));
+		register(ModItems.manaCookie, 0, new AspectList(new ItemStack(Items.COOKIE)).merge(LIFE, 20).add(MAGIC, 5));
 
 		AspectList grassSeedAspects =  new AspectList().add(PLANT, 5).add(LIFE, 5).add(EXCHANGE, 2);
 		register(ModItems.grassSeeds, 0, grassSeedAspects); //Pasture Seed
@@ -119,17 +126,17 @@ public class TCAspects {
 		register(ModItems.quartz, 1, new AspectList(new ItemStack(Items.QUARTZ)).add(MAGIC, 2)); //Mana Quartz
 		register(ModBlocks.tinyPotato, ANY, new AspectList(new ItemStack(Items.POTATO)).add(LIFE, 5).add(MOTION, 2));
 		register(ModItems.manaInkwell, ANY, new AspectList().add(SENSES, 5).add(MAGIC, 5).add(WATER, 2).add(BEAST, 1));
-		register(ModBlocks.manaGlass, ANY, new AspectList(new ItemStack(Blocks.GLASS)).add(LIGHT, 5).add(MAGIC, 1));
+		register(ModBlocks.manaGlass, 0, new AspectList(new ItemStack(Blocks.GLASS)).add(LIGHT, 5).add(MAGIC, 1));
 		register(ModItems.manaResource, 16, new AspectList(new ItemStack(Items.STRING)).merge(CRAFT, 2).add(MAGIC, 2)); //Mana Infused String
 		register(ModItems.manaBottle, ANY, new AspectList().add(MAGIC, 5).add(CRYSTAL, 5));
 
 		//Elven Trade
-		register(LibOreDict.DREAM_WOOD, new AspectList(new ItemStack(Blocks.LOG)).add(ELDRITCH, 3));
+		register(LibOreDict.DREAM_WOOD, new AspectList().add(PLANT, 20).add(ELDRITCH, 3));
 		register(LibOreDict.ELEMENTIUM, new AspectList().add(METAL, 10).add(ELDRITCH, 5));
 		register(LibOreDict.PIXIE_DUST, new AspectList(new ItemStack(Items.ENDER_PEARL)).add(MAGIC, 10));
 		register(LibOreDict.DRAGONSTONE, new AspectList(new ItemStack(Items.DIAMOND)).add(ELDRITCH, 10));
 		register(ModItems.quartz, 5, new AspectList(new ItemStack(Items.QUARTZ)).add(ELDRITCH, 1));
-		register(ModBlocks.elfGlass, ANY, new AspectList(new ItemStack(Blocks.GLASS)).add(LIGHT, 5).add(ELDRITCH, 1));
+		register(ModBlocks.elfGlass, 0, new AspectList(new ItemStack(Blocks.GLASS)).add(LIGHT, 5).add(ELDRITCH, 1));
 
 		//Runic Altar
 		AspectList runeAspects = new AspectList().add(EARTH, 5).add(MAGIC, 5);
@@ -164,24 +171,25 @@ public class TCAspects {
 		for(String name : LibOreDict.PETAL)
 			register(name, new AspectList().add(SENSES, 5).add(PLANT, 5));
 
-		register(ModItems.dye, ANY, new AspectList().add(SENSES, 5).add(PLANT, 1));
-		registerComplex(ModItems.lexicon, ANY, new AspectList().add(MAGIC, 5).add(MIND, 10));
+		for(int i = 0; i < 15; i++)
+			register(ModItems.dye, i, new AspectList().add(SENSES, 5).add(PLANT, 1));
+		registerComplex(ModItems.lexicon, 0, new AspectList().add(MAGIC, 5).add(MIND, 10));
 
-		registerComplex(ModItems.pestleAndMortar, ANY, new AspectList().add(TOOL, 4));
+		registerComplex(ModItems.pestleAndMortar, 0, new AspectList().add(TOOL, 4));
 		register(LibOreDict.LIVINGWOOD_TWIG, new AspectList().add(PLANT, 8).add(LIFE, 4));
 		register(LibOreDict.DREAMWOOD_TWIG, new AspectList().add(PLANT, 8).add(ELDRITCH, 4));
-		registerComplex(ModItems.twigWand, ANY, new AspectList().add(TOOL, 8));
+		registerComplex(ModItems.twigWand, 0, new AspectList().add(TOOL, 8));
 
 		//Lenses
-		registerComplex(ModItems.lens,  1, new AspectList().add(MOTION, 10));               //Velocity
-		registerComplex(ModItems.lens,  2, new AspectList().add(ENERGY, 10));               //Potency
-		registerComplex(ModItems.lens,  3, new AspectList().add(PROTECT, 10));              //Resistance
-		registerComplex(ModItems.lens,  4, new AspectList().add(TRAP, 10));                 //Efficiency
-		registerComplex(ModItems.lens,  5, new AspectList().add(MOTION, 10));               //Bounce
-		registerComplex(ModItems.lens,  6, new AspectList().add(EARTH, 10));                //Gravity
-		registerComplex(ModItems.lens,  7, new AspectList().add(TOOL, 10));                 //Bore
-		registerComplex(ModItems.lens,  8, new AspectList().add(AVERSION, 10));             //Damaging
-		registerComplex(ModItems.lens,  9, new AspectList().add(ELDRITCH, 10));             //Phantom
+		registerComplex(ModItems.lens,  1, new AspectList().add(MOTION, 10));              //Velocity
+		registerComplex(ModItems.lens,  2, new AspectList().add(ENERGY, 10));              //Potency
+		registerComplex(ModItems.lens,  3, new AspectList().add(PROTECT, 10));             //Resistance
+		registerComplex(ModItems.lens,  4, new AspectList().add(TRAP, 10));                //Efficiency
+		registerComplex(ModItems.lens,  5, new AspectList().add(MOTION, 10));              //Bounce
+		registerComplex(ModItems.lens,  6, new AspectList().add(EARTH, 10));               //Gravity
+		registerComplex(ModItems.lens,  7, new AspectList().add(TOOL, 10));                //Bore
+		registerComplex(ModItems.lens,  8, new AspectList().add(AVERSION, 10));            //Damaging
+		registerComplex(ModItems.lens,  9, new AspectList().add(ELDRITCH, 10));            //Phantom
 		registerComplex(ModItems.lens, 10, new AspectList().add(DESIRE, 10));              //Magnetizing
 		registerComplex(ModItems.lens, 11, new AspectList().add(ENTROPY, 10));             //Entropic
 		registerComplex(ModItems.lens, 12, new AspectList().add(DESIRE, 10));              //Influence
@@ -197,24 +205,24 @@ public class TCAspects {
 		registerComplex(ModItems.lens, 23, new AspectList().add(MAN, 10));                 //Tripwire
 
 		//Rods
-		registerComplex(ModItems.terraformRod, ANY, new AspectList().add(EXCHANGE, 15));
-		registerComplex(ModItems.rainbowRod,   ANY, new AspectList().add(SENSES, 10).add(LIGHT, 10));
-		registerComplex(ModItems.tornadoRod,   ANY, new AspectList().add(FLIGHT, 20));
-		registerComplex(ModItems.diviningRod,  ANY, new AspectList().add(SENSES, 20));
-		registerComplex(ModItems.gravityRod,   ANY, new AspectList().add(MOTION, 20));
-		registerComplex(ModItems.missileRod,   ANY, new AspectList().add(AVERSION, 30));
-		registerComplex(ModItems.cobbleRod,    ANY, new AspectList().add(EARTH, 20));
-		registerComplex(ModItems.exchangeRod,  ANY, new AspectList().add(EXCHANGE, 30));
+		registerComplex(ModItems.terraformRod, 0, new AspectList().add(EXCHANGE, 15));
+		registerComplex(ModItems.rainbowRod,   0, new AspectList().add(SENSES, 10).add(LIGHT, 10));
+		registerComplex(ModItems.tornadoRod,   0, new AspectList().add(FLIGHT, 20));
+		registerComplex(ModItems.diviningRod,  0, new AspectList().add(SENSES, 20));
+		registerComplex(ModItems.gravityRod,   0, new AspectList().add(MOTION, 20));
+		registerComplex(ModItems.missileRod,   0, new AspectList().add(AVERSION, 30));
+		registerComplex(ModItems.cobbleRod,    0, new AspectList().add(EARTH, 20));
+		registerComplex(ModItems.exchangeRod,  0, new AspectList().add(EXCHANGE, 30));
 
 		register(LibOreDict.RED_STRING, new AspectList()
 				.add(ENERGY, 30).add(EXCHANGE, 20).add(ELDRITCH, 15).add(MECHANISM, 15).add(MAGIC, 10));
 		registerComplex(ModItems.manaTablet, ANY, new AspectList().add(VOID, 5).add(MAGIC, 5));
-		registerComplex(ModItems.fertilizer, ANY, new AspectList().add(LIFE, 4));
-		registerComplex(ModItems.grassHorn, ANY, new AspectList().add(SENSES, 10).add(TOOL, 8));
+		registerComplex(ModItems.fertilizer, 0, new AspectList().add(LIFE, 4));
+		registerComplex(ModItems.grassHorn, 0, new AspectList().add(SENSES, 10).add(TOOL, 8));
 		register(ModItems.manaMirror, ANY, new AspectList()
 				.add(EARTH, 10).add(PLANT, 10).add(ELDRITCH, 10).add(EXCHANGE, 5).add(MAGIC, 10).add(METAL, 10));
-		registerComplex(ModItems.travelBelt, ANY, new AspectList().add(MOTION, 10));
-		registerComplex(ModItems.magnetRing, ANY, new AspectList().add(DESIRE, 10));
+		registerComplex(ModItems.travelBelt, 0, new AspectList().add(MOTION, 10));
+		registerComplex(ModItems.magnetRing, 0, new AspectList().add(DESIRE, 10));
 		registerComplex(ModItems.flightTiara, ANY, new AspectList().add(FLIGHT, 38));
 
 		if(ConfigHandler.darkQuartzEnabled)
@@ -224,26 +232,27 @@ public class TCAspects {
 		register(ModItems.quartz, 4, new AspectList(new ItemStack(Items.QUARTZ)).add(ENERGY, 2));               //Redquartz
 		register(ModItems.quartz, 6, new AspectList(new ItemStack(Items.QUARTZ)).add(SENSES, 1).add(PLANT, 1)); //Sunny
 
-		registerComplex(ModItems.openBucket, ANY, new AspectList().add(VOID, 15));
-		registerComplex(ModItems.pixieRing, ANY, new AspectList().add(AURA, 5).add(FLIGHT, 5));
-		registerComplex(ModItems.superTravelBelt, ANY, new AspectList().add(MOTION, 10));
-		registerComplex(ModItems.itemFinder, ANY, new AspectList().add(SENSES, 20));
-		register(ModItems.enderHand, ANY, new AspectList(new ItemStack(Blocks.ENDER_CHEST)).add(BEAST, 15));
+		registerComplex(ModItems.openBucket, 0, new AspectList().add(VOID, 15));
+		registerComplex(ModItems.pixieRing, 0, new AspectList().add(AURA, 5).add(FLIGHT, 5));
+		registerComplex(ModItems.superTravelBelt, 0, new AspectList().add(MOTION, 10));
+		registerComplex(ModItems.laputaShard, ANY, new AspectList().add(FLIGHT, 20));
+		registerComplex(ModItems.itemFinder, 0, new AspectList().add(SENSES, 20));
+		register(ModItems.enderHand, 0, new AspectList(new ItemStack(Blocks.ENDER_CHEST)).add(BEAST, 15));
 		register(ModItems.spark, 0, new AspectList().add(AURA, 15).add(MOTION, 15).add(FIRE, 10).add(SENSES, 10));
 		register(ModItems.vial, 0, new AspectList(new ItemStack(ModBlocks.manaGlass)).add(VOID, 2));
 		register(ModItems.vial, 1, new AspectList(new ItemStack(ModBlocks.elfGlass)).add(VOID, 3));
-		registerComplex(ModItems.holyCloak, ANY, new AspectList().add(PROTECT, 15));
-		registerComplex(ModItems.unholyCloak, ANY, new AspectList().add(AVERSION, 15));
-		registerComplex(ModItems.balanceCloak, ANY, new AspectList().add(PROTECT, 10).add(AVERSION, 10));
-		registerComplex(ModItems.craftingHalo, ANY, new AspectList().add(CRAFT, 15));
+		registerComplex(ModItems.holyCloak, 0, new AspectList().add(PROTECT, 15));
+		registerComplex(ModItems.unholyCloak, 0, new AspectList().add(AVERSION, 15));
+		registerComplex(ModItems.balanceCloak, 0, new AspectList().add(PROTECT, 10).add(AVERSION, 10));
+		registerComplex(ModItems.craftingHalo, 0, new AspectList().add(CRAFT, 15));
 		register(ModItems.blackLotus, 0, new AspectList().add(MAGIC, 10).add(ORDER, 10).add(ELDRITCH, 5));
 		register(ModItems.blackLotus, 1, new AspectList().add(MAGIC, 30).add(ORDER, 20).add(ELDRITCH, 10));
-		registerComplex(ModItems.monocle, ANY, new AspectList().add(SENSES, 10));
+		registerComplex(ModItems.monocle, 0, new AspectList().add(SENSES, 10));
 		register(ModItems.clip, 0, new AspectList(new ItemStack(ModBlocks.dreamwood)).add(VOID, 5).add(MECHANISM, 2));
-		registerComplex(ModItems.worldSeed, ANY, new AspectList().add(MOTION, 10).add(PLANT, 5).add(ELDRITCH, 3));
+		registerComplex(ModItems.worldSeed, 0, new AspectList().add(MOTION, 10).add(PLANT, 5).add(ELDRITCH, 3));
 		registerComplex(ModItems.thornChakram, 0, new AspectList().add(AVERSION, 12).add(DEATH, 6));
 		registerComplex(ModItems.thornChakram, 1, new AspectList().merge(AVERSION, 7)); //Flare Chakram
-		register(ModItems.overgrowthSeed, ANY, new AspectList().add(LIFE, 30).add(MAGIC, 25));
+		register(ModItems.overgrowthSeed, 0, new AspectList().add(LIFE, 30).add(MAGIC, 25));
 		register(ModItems.craftPattern, ANY, new AspectList().add(CRAFT, 10).add(ENERGY, 10));
 
 		registerComplex(ModItems.swapRing, 0, new AspectList().add(TOOL, 8).add(EXCHANGE, 8));
@@ -259,38 +268,37 @@ public class TCAspects {
 		register(ModItems.ancientWill, 4, willAspects.copy().add(DEATH, 10));   //Verac - armor pierce
 		register(ModItems.ancientWill, 5, willAspects.copy().add(FLUX, 10));    //Karil - withering
 
-		register(ModItems.pinkinator,    ANY, new AspectList().add(LIFE, 30).add(ORDER, 20).add(EXCHANGE, 20));
+		register(ModItems.pinkinator, 0, new AspectList().add(LIFE, 30).add(ORDER, 20).add(EXCHANGE, 20));
 
 		AspectList relicAspects = new AspectList().add(MAGIC, 30).add(DESIRE, 25).add(ELDRITCH, 15);
-		register(ModItems.dice,          ANY, relicAspects.copy().add(ELDRITCH, 15));
-		register(ModItems.infiniteFruit, ANY, relicAspects.copy().add(LIFE,     50).add(PLANT,   30));
-		register(ModItems.kingKey,       ANY, relicAspects.copy().add(AVERSION, 50).add(TRAP,    30));
-		register(ModItems.flugelEye,     ANY, relicAspects.copy().add(MOTION,   50).add(FLIGHT,  30));
-		register(ModItems.thorRing,      ANY, relicAspects.copy().add(TOOL,     50).add(ENTROPY, 30));
-		register(ModItems.odinRing,      ANY, relicAspects.copy().add(PROTECT,  50).add(LIFE,    30));
-		register(ModItems.lokiRing,      ANY, relicAspects.copy().add(AURA,     50).add(MAN,     30));
+		register(ModItems.dice,          0, relicAspects.copy().add(ELDRITCH, 15));
+		register(ModItems.infiniteFruit, 0, relicAspects.copy().add(LIFE,     50).add(PLANT,   30));
+		register(ModItems.kingKey,       0, relicAspects.copy().add(AVERSION, 50).add(TRAP,    30));
+		register(ModItems.flugelEye,     0, relicAspects.copy().add(MOTION,   50).add(FLIGHT,  30));
+		register(ModItems.thorRing,      0, relicAspects.copy().add(TOOL,     50).add(ENTROPY, 30));
+		register(ModItems.odinRing,      0, relicAspects.copy().add(PROTECT,  50).add(LIFE,    30));
+		register(ModItems.lokiRing,      0, relicAspects.copy().add(AURA,     50).add(MAN,     30));
 
-		register(ModItems.recordGaia1, ANY, new AspectList().add(SENSES, 15).add(DESIRE, 10).add(AIR, 5).add(VOID, 5));     //Endure Emptiness
-		register(ModItems.recordGaia2, ANY, new AspectList().add(SENSES, 15).add(DESIRE, 10).add(AIR, 5).add(AVERSION, 5)); //Fight For Quiescence
+		register(ModItems.recordGaia1, 0, new AspectList().add(SENSES, 15).add(DESIRE, 10).add(AIR, 5).add(VOID, 5));     //Endure Emptiness
+		register(ModItems.recordGaia2, 0, new AspectList().add(SENSES, 15).add(DESIRE, 10).add(AIR, 5).add(AVERSION, 5)); //Fight For Quiescence
 
-		registerComplex(ModItems.blackHoleTalisman, ANY, new AspectList().add(VOID, 30));
+		registerComplex(ModItems.blackHoleTalisman, 0, new AspectList().add(VOID, 30));
 		registerComplex(ModItems.temperanceStone, ANY, new AspectList().add(TRAP, 5));
-		registerComplex(ModItems.obedienceStick, ANY, new AspectList().add(TOOL, 4));
-		registerComplex(ModItems.slimeBottle, ANY, new AspectList(new ItemStack(Items.SLIME_BALL)).add(SENSES, 10));
-		registerComplex(ModItems.magnetRingGreater, ANY, new AspectList().add(DESIRE, 15));
-		registerComplex(ModItems.thunderSword, ANY, new AspectList().add(ENERGY, 15));
-		registerComplex(ModItems.autocraftingHalo, ANY, new AspectList().add(CRAFT, 15).add(EXCHANGE, 10));
-		register(ModItems.gaiaHead, ANY, new AspectList().add(DEATH, 10).add(SOUL, 15).add(ELDRITCH, 10).add(EARTH, 10));
-		register(ModBlocks.gaiaHead, ANY, new AspectList(new ItemStack(ModItems.gaiaHead)));
-		registerComplex(ModItems.sextant, ANY, new AspectList().add(TOOL, 8));
-		registerComplex(ModItems.speedUpBelt, ANY, new AspectList().add(MOTION, 10));
-		registerComplex(ModItems.baubleBox, ANY, new AspectList().add(VOID, 5));
-		registerComplex(ModItems.dodgeRing, ANY, new AspectList().add(MOTION, 10));
-		registerComplex(ModItems.invisibilityCloak, ANY, new AspectList().add(SENSES, 15));
+		registerComplex(ModItems.obedienceStick, 0, new AspectList().add(TOOL, 4));
+		registerComplex(ModItems.slimeBottle, 0, new AspectList(new ItemStack(Items.SLIME_BALL)).add(SENSES, 10));
+		registerComplex(ModItems.magnetRingGreater, 0, new AspectList().add(DESIRE, 15));
+		registerComplex(ModItems.thunderSword, 0, new AspectList().add(ENERGY, 15));
+		registerComplex(ModItems.autocraftingHalo, 0, new AspectList().add(CRAFT, 15).add(EXCHANGE, 10));
+		register(ModItems.gaiaHead, 0, new AspectList().add(DEATH, 10).add(SOUL, 15).add(ELDRITCH, 10).add(EARTH, 10));
+		registerComplex(ModItems.sextant, 0, new AspectList().add(TOOL, 8));
+		registerComplex(ModItems.speedUpBelt, 0, new AspectList().add(MOTION, 10));
+		registerComplex(ModItems.baubleBox, 0, new AspectList().add(VOID, 5));
+		registerComplex(ModItems.dodgeRing, 0, new AspectList().add(MOTION, 10));
+		registerComplex(ModItems.invisibilityCloak, 0, new AspectList().add(SENSES, 15));
 
 		//Blocks
-		registerComplex(ModBlocks.altar, ANY, new AspectList().add(CRAFT, 10));
-		registerComplex(ModBlocks.runeAltar, ANY, new AspectList().add(CRAFT, 10).add(MAGIC, 5));
+		registerComplex(ModBlocks.altar, 0, new AspectList().add(CRAFT, 10));
+		registerComplex(ModBlocks.runeAltar, 0, new AspectList().add(CRAFT, 10).add(MAGIC, 5));
 
 		registerComplex(ModBlocks.spreader, 0, new AspectList().add(MOTION, 10).add(MAGIC, 10));
 		registerComplex(ModBlocks.spreader, 1, new AspectList(new ItemStack(ModBlocks.spreader)).add(ENERGY, 10).add(MECHANISM, 5));
@@ -300,52 +308,52 @@ public class TCAspects {
 		registerComplex(ModBlocks.pool, 0, new AspectList().add(VOID, 10).add(MAGIC, 5)); //Mana Pool
 		registerComplex(ModBlocks.pool, 2, new AspectList().add(VOID, 3).add(MAGIC, 3)); //Diluted
 		//Next entry is made with shimmerrock, and proper autoassignment depends on this
-		register(ModBlocks.bifrostPerm, ANY, new AspectList(new ItemStack(ModBlocks.elfGlass)).add(SENSES, 5));
+		register(ModBlocks.bifrostPerm, 0, new AspectList(new ItemStack(ModBlocks.elfGlass)).add(SENSES, 5));
 		registerComplex(ModBlocks.pool, 3, new AspectList().add(VOID, 10).add(MAGIC, 5)); //Fabulous
 
-		registerComplex(ModBlocks.distributor, ANY, new AspectList().add(MECHANISM, 5).add(MAGIC, 5));
-		registerComplex(ModBlocks.manaVoid, ANY, new AspectList().add(VOID, 20));
-		registerComplex(ModBlocks.manaDetector, ANY, new AspectList().add(SENSES, 10));
-		register(ModBlocks.enchanter, ANY, new AspectList(new ItemStack(Blocks.LAPIS_BLOCK)).add(MAGIC, 25).add(CRAFT, 15));
-		registerComplex(ModBlocks.tinyPlanet, ANY, new AspectList().add(EARTH, 50));
+		registerComplex(ModBlocks.distributor, 0, new AspectList().add(MECHANISM, 5).add(MAGIC, 5));
+		registerComplex(ModBlocks.manaVoid, 0, new AspectList().add(VOID, 20));
+		registerComplex(ModBlocks.manaDetector, 0, new AspectList().add(SENSES, 10));
+		register(ModBlocks.enchanter, 0, new AspectList(new ItemStack(Blocks.LAPIS_BLOCK)).add(MAGIC, 25).add(CRAFT, 15));
+		registerComplex(ModBlocks.tinyPlanet, 0, new AspectList().add(EARTH, 50));
 		registerComplex(ModBlocks.openCrate, 0, new AspectList().add(VOID, 5));
 		registerComplex(ModBlocks.openCrate, 1, new AspectList().add(MECHANISM, 5)); //Crafty Crate
 		registerComplex(ModBlocks.forestEye, 0, new AspectList().add(SENSES, 10).add(BEAST, 10));
 		registerComplex(ModBlocks.forestDrum, 1, new AspectList().add(SENSES, 5).add(TOOL, 5));
-		register(ModBlocks.bifrost, ANY, new AspectList(new ItemStack(ModBlocks.bifrostPerm)));
+		register(ModBlocks.bifrost, 0, new AspectList(new ItemStack(ModBlocks.bifrostPerm)));
 		registerComplex(ModBlocks.floatingFlower, ANY, new AspectList().add(FLIGHT, 5));
-		registerComplex(ModBlocks.spawnerClaw, ANY, new AspectList().add(LIFE, 30));
-		registerComplex(ModBlocks.alfPortal, ANY, new AspectList().merge(EXCHANGE, 20).add(ELDRITCH, 20));
+		registerComplex(ModBlocks.spawnerClaw, 0, new AspectList().add(LIFE, 30));
+		registerComplex(ModBlocks.alfPortal, 0, new AspectList().merge(EXCHANGE, 20).add(ELDRITCH, 20));
 
 		register(ModBlocks.customBrick, ANY, new AspectList(new ItemStack(Blocks.QUARTZ_BLOCK))
 				.add(SENSES, 3).add(DESIRE, 1).add(EARTH, 1)); //Azulejo
-		registerComplex(ModBlocks.enderEye, ANY, new AspectList().add(MECHANISM, 10));
-		registerComplex(ModBlocks.starfield, ANY, new AspectList().add(DARKNESS, 20).add(LIGHT, 20));
-		registerComplex(ModBlocks.rfGenerator, ANY, new AspectList().add(MECHANISM, 20));
-		registerComplex(ModBlocks.terraPlate, ANY, new AspectList().add(CRAFT, 20).add(EXCHANGE, 20));
-		register(ModBlocks.enchantedSoil, ANY, new AspectList().add(LIFE, 20).add(MAGIC, 15).add(EARTH, 10));
+		registerComplex(ModBlocks.enderEye, 0, new AspectList().add(MECHANISM, 10));
+		registerComplex(ModBlocks.starfield, 0, new AspectList().add(DARKNESS, 20).add(LIGHT, 20));
+		registerComplex(ModBlocks.rfGenerator, 0, new AspectList().add(MECHANISM, 20));
+		registerComplex(ModBlocks.terraPlate, 0, new AspectList().add(CRAFT, 20).add(EXCHANGE, 20));
+		register(ModBlocks.enchantedSoil, 0, new AspectList().add(LIFE, 20).add(MAGIC, 15).add(EARTH, 10));
 
 		AspectList corporeaAspects = new AspectList(new ItemStack(ModItems.corporeaSpark)).add(MECHANISM, 15).merge(ELDRITCH, 15).remove(AURA);
-		register(ModBlocks.corporeaIndex, ANY, corporeaAspects.copy().add(DESIRE, 25).add(MIND, 25));
-		register(ModBlocks.corporeaCrystalCube, ANY, corporeaAspects.copy().add(SENSES, 15).add(CRYSTAL, 15));
-		register(ModBlocks.corporeaFunnel, ANY, corporeaAspects.copy().add(DESIRE, 20));
-		register(ModBlocks.corporeaInterceptor, ANY, corporeaAspects.copy().add(ENERGY, 20));
-		register(ModBlocks.corporeaRetainer, ANY, corporeaAspects.copy().add(VOID, 20));
+		register(ModBlocks.corporeaIndex, 0, corporeaAspects.copy().add(DESIRE, 25).add(MIND, 25));
+		register(ModBlocks.corporeaCrystalCube, 0, corporeaAspects.copy().add(SENSES, 15).add(CRYSTAL, 15));
+		register(ModBlocks.corporeaFunnel, 0, corporeaAspects.copy().add(DESIRE, 20));
+		register(ModBlocks.corporeaInterceptor, 0, corporeaAspects.copy().add(ENERGY, 20));
+		register(ModBlocks.corporeaRetainer, 0, corporeaAspects.copy().add(VOID, 20));
 
-		registerComplex(ModBlocks.pump, ANY, new AspectList().add(MECHANISM, 10).add(EXCHANGE, 10));
-		registerComplex(ModBlocks.incensePlate, ANY, new AspectList().add(ALCHEMY, 15));
-		registerComplex(ModBlocks.hourglass, ANY, new AspectList().add(MECHANISM, 10));
-		registerComplex(ModBlocks.ghostRail, ANY, new AspectList().add(SOUL, 10));
-		registerComplex(ModBlocks.sparkChanger, ANY, new AspectList().add(MECHANISM, 10));
-		register(ModBlocks.felPumpkin, ANY, new AspectList().add(ENTROPY, 15).add(SOUL, 10).add(LIFE, 5).add(BEAST, 5).add(PLANT, 5));
-		registerComplex(ModBlocks.cocoon, ANY, new AspectList().add(LIFE, 10));
+		registerComplex(ModBlocks.pump, 0, new AspectList().add(MECHANISM, 10).add(EXCHANGE, 10));
+		registerComplex(ModBlocks.incensePlate, 0, new AspectList().add(ALCHEMY, 15));
+		registerComplex(ModBlocks.hourglass, 0, new AspectList().add(MECHANISM, 10));
+		registerComplex(ModBlocks.ghostRail, 0, new AspectList().add(SOUL, 10));
+		registerComplex(ModBlocks.sparkChanger, 0, new AspectList().add(MECHANISM, 10));
+		register(ModBlocks.felPumpkin, 0, new AspectList().add(ENTROPY, 15).add(SOUL, 10).add(LIFE, 5).add(BEAST, 5).add(PLANT, 5));
+		registerComplex(ModBlocks.cocoon, 0, new AspectList().add(LIFE, 10));
 		registerComplex(ModBlocks.lightRelay, 0, new AspectList().add(MOTION, 15));
-		register(ModBlocks.cacophonium, ANY, new AspectList(new ItemStack(Blocks.NOTEBLOCK)).add(DESIRE, 10));
-		registerComplex(ModBlocks.teruTeruBozu, ANY, new AspectList().add(EXCHANGE, 10).add(SENSES, 10));
-		registerComplex(ModBlocks.avatar, ANY, new AspectList().add(MECHANISM, 15).add(MAN, 10));
+		register(ModBlocks.cacophonium, 0, new AspectList(new ItemStack(Blocks.NOTEBLOCK)).add(DESIRE, 10));
+		registerComplex(ModBlocks.teruTeruBozu, 0, new AspectList().add(EXCHANGE, 10).add(SENSES, 10));
+		registerComplex(ModBlocks.avatar, 0, new AspectList().add(MECHANISM, 15).add(MAN, 10));
 
 		register(ModBlocks.altGrass, ANY, new AspectList(new ItemStack(Blocks.GRASS)).add(SENSES, 3));
-		registerComplex(ModBlocks.animatedTorch, ANY, new AspectList().add(MOTION, 5));
+		registerComplex(ModBlocks.animatedTorch, 0, new AspectList().add(MOTION, 5));
 
 		//Livingrock Brick variants
 		register(ModBlocks.livingrock, 2, new AspectList(new ItemStack(ModBlocks.livingrock, 1, 1)).add(PLANT, 3));   //Mossy
@@ -353,7 +361,7 @@ public class TCAspects {
 		register(ModBlocks.livingrock, 4, new AspectList(new ItemStack(ModBlocks.livingrock, 1, 1)).add(ORDER, 1));   //Chiseled
 
 		//Metamorphic stone from the Marimorphosis
-		AspectList stoneAspects = new AspectList(new ItemStack(Blocks.STONE));
+		AspectList stoneAspects = new AspectList().add(EARTH, 5);
 		register(ModFluffBlocks.biomeStoneA, 0, stoneAspects.copy().add(PLANT, 1));   //Forest
 		register(ModFluffBlocks.biomeStoneA, 1, stoneAspects.copy().add(AIR, 1));     //Plains
 		register(ModFluffBlocks.biomeStoneA, 2, stoneAspects.copy().add(EARTH, 1));   //Mountain
@@ -380,20 +388,45 @@ public class TCAspects {
 		}
 	}
 
+	private final List<ItemStack> brewContainers = Arrays.asList(new ItemStack(ModItems.vial),
+		new ItemStack(ModItems.vial, 1, 1), new ItemStack(ModItems.incenseStick), new ItemStack(ModItems.bloodPendant));
+
+	private void registerBrewAspects() {
+		for(RecipeBrew brewRecipe : BotaniaAPI.brewRecipes) {
+			AspectList aspects = new AspectList();
+			
+			for(Object input : brewRecipe.getInputs()) {
+				ItemStack toAdd = ItemStack.EMPTY;
+				if(input instanceof ItemStack) {
+					toAdd = (ItemStack) input;
+				} else if(input instanceof String) {
+					toAdd = OreDictionary.getOres((String) input).get(0);
+				}
+				AspectList ingredientAspects = AspectHelper.getObjectAspects(toAdd);
+				for (Aspect a : ingredientAspects.getAspects())
+					aspects.add(a, ingredientAspects.getAmount(a));
+			}
+			for(Aspect aspect : aspects.getAspects()) {
+				aspects.reduce(aspect, aspects.getAmount(aspect) / 2);
+			}
+			aspects.add(ALCHEMY, 8);
+			
+			for(ItemStack brewContainer : brewContainers) {
+				ItemStack brewed = brewRecipe.getOutput(brewContainer);
+				if(!brewed.isEmpty()) {
+					proxy.registerObjectTag(brewed, new AspectList().add(aspects));
+				}
+			}
+		}
+	}
+
 	private void registerEntityAspects() {
 		registerEntity(LibEntityNames.MANA_BURST,       new AspectList().add(ENERGY, 5).add(MOTION, 5).add(AURA, 5));
-		registerEntity(LibEntityNames.SIGNAL_FLARE,     new AspectList().add(SENSES, 10).add(LIGHT, 5));
 		registerEntity(LibEntityNames.PIXIE,            new AspectList().add(FLIGHT, 5).add(ELDRITCH, 5).add(LIGHT, 5));
 		registerEntity(LibEntityNames.FLAME_RING,       new AspectList().add(FIRE, 20));
-		registerEntity(LibEntityNames.VINE_BALL,        new AspectList(new ItemStack(ModItems.vineBall)));
 		registerEntity(LibEntityNames.DOPPLEGANGER,     new AspectList().add(MAN, 30).add(EARTH, 30).add(DARKNESS, 30).add(ELDRITCH, 30).add(PROTECT, 30));
 		registerEntity(LibEntityNames.MAGIC_LANDMINE,   new AspectList().add(AVERSION, 10).add(DEATH, 10));
-		registerEntity(LibEntityNames.SPARK,            new AspectList(new ItemStack(ModItems.spark)));
 		registerEntity(LibEntityNames.MAGIC_MISSILE,    new AspectList().add(AVERSION, 5).add(MAGIC, 5));
-		registerEntity(LibEntityNames.THORN_CHAKRAM,    new AspectList(new ItemStack(ModItems.thornChakram)));
-		registerEntity(LibEntityNames.CORPOREA_SPARK,   new AspectList(new ItemStack(ModItems.corporeaSpark)));
-		registerEntity(LibEntityNames.ENDER_AIR_BOTTLE, new AspectList(new ItemStack(ModItems.manaResource, 1, 15)));
-		registerEntity(LibEntityNames.POOL_MINECART,    new AspectList(new ItemStack(ModItems.poolMinecart)));
 		registerEntity(LibEntityNames.PINK_WITHER,      new AspectList().add(LIFE, 50).add(UNDEAD, 30).add(ORDER, 25).add(FIRE, 25));
 		registerEntity(LibEntityNames.PLAYER_MOVER,     new AspectList().add(MOTION, 15).add(LIGHT, 5));
 		registerEntity(LibEntityNames.MANA_STORM,       new AspectList().add(ENTROPY, 150).add(FIRE, 100).add(MAGIC, 50).add(ALCHEMY, 50));
@@ -403,7 +436,7 @@ public class TCAspects {
 
 	private void registerFlower(String flowerId, AspectList extraAspects) {
 		AspectList aspects = extraAspects.copy().add(PLANT, 15).add(SENSES, 15).add(MAGIC, 5);
-		AspectList floatingAspects = aspects.copy().add(FLIGHT, 5).add(LIGHT, 5).add(EARTH, 3);
+		AspectList floatingAspects = aspects.copy().add(FLIGHT, 5).add(LIGHT, 5);
 
 		proxy.registerObjectTag(ItemBlockSpecialFlower.ofType(flowerId), aspects);
 		proxy.registerObjectTag(ItemBlockSpecialFlower.ofType(new ItemStack(ModBlocks.floatingSpecialFlower), flowerId), floatingAspects);


### PR DESCRIPTION
* Add brew aspects, generated from the potion's ingredients similiarly to vanilla potions.
* Add Spectrolus aspects, as I missed that one...
* Tweak a few aspect lists.
* Move TC brew recipes to init - registering them in postinit was too late to assign aspects to the brew, as aspect registration is done in Thaumcraft's postinit which runs earlier. Should not have any side effects.
* Replace wood and stone stacks with their aspects, avoids livingwood having just Victus in some modpacks.
* Reduce the amount of wildcard metadata, which can rarely cause some minor issues with items not having expected aspects and is just unnecessary for many things.
* Remove aspects from entities that are just entity form of items. I was getting annoyed around Corporea sparks when using my Thaumometer.

Beta 26 added some new stabilizer mechanics and I am wondering if it is worth messing with (for example, tweaking the effects pylons have on infusion), but I am not sure what are his plans with that part of the API, so leaving that alone for now.