### PR TITLE
Tentative mana spreader path tracing optimizations

### DIFF
--- a/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
+++ b/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
@@ -72,6 +72,7 @@ public final class ConfigHandler {
 
 //	public static boolean versionCheckEnabled = true;
 	public static int spreaderPositionShift = 1;
+	public static int spreaderTraceTime = 400;
 	public static boolean flowerForceCheck = true;
 	public static boolean enderPickpocketEnabled = true;
 
@@ -199,6 +200,9 @@ public final class ConfigHandler {
 
 		desc = "Do not ever touch this value if not asked to. Possible symptoms of doing so include your head turning backwards, the appearance of Titans near the walls or you being trapped in a game of Sword Art Online.";
 		spreaderPositionShift = loadPropInt("spreader.posShift", desc, spreaderPositionShift);
+
+		desc = "How many ticks into the future will mana spreaders attempt to predict where mana bursts go? Setting this lower will improve spreader performance, but will cause them to not fire at targets that are too far away.";
+		spreaderTraceTime = loadPropInt("spreader.traceTime", desc, spreaderTraceTime);
 
 		desc = "Turn this off ONLY IF you're on an extremely large world with an exaggerated count of Mana Spreaders/Mana Pools and are experiencing TPS lag. This toggles whether flowers are strict with their checking for connecting to pools/spreaders or just check whenever possible.";
 		flowerForceCheck = loadPropBool("flower.forceCheck", desc, flowerForceCheck);

--- a/src/main/java/vazkii/botania/common/entity/EntityManaBurst.java
+++ b/src/main/java/vazkii/botania/common/entity/EntityManaBurst.java
@@ -68,6 +68,8 @@ import vazkii.botania.common.item.equipment.bauble.ItemTinyPlanet;
 @Optional.Interface(iface="elucent.albedo.lighting.ILightProvider", modid="albedo")
 public class EntityManaBurst extends EntityThrowable implements IManaBurst, ILightProvider {
 
+	private static final int MAX_SIMULATION_TICKS = 400;
+	
 	private static final String TAG_TICKS_EXISTED = "ticksExisted";
 	private static final String TAG_COLOR = "color";
 	private static final String TAG_MANA = "mana";
@@ -192,7 +194,7 @@ public class EntityManaBurst extends EntityThrowable implements IManaBurst, ILig
 			vec3d1 = new Vec3d(raytraceresult.hitVec.x, raytraceresult.hitVec.y, raytraceresult.hitVec.z);
 		}
 
-		if(!world.isRemote) { // Botania - only do entity colliding on server
+		if(!scanBeam && !world.isRemote) { // Botania - only do entity colliding on server and while not scanning
 			Entity entity = null;
 			List<Entity> list = world.getEntitiesWithinAABBExcludingEntity(this, getEntityBoundingBox().offset(motionX, motionY, motionZ).grow(1.0D));
 			double d0 = 0.0D;
@@ -288,6 +290,8 @@ public class EntityManaBurst extends EntityThrowable implements IManaBurst, ILig
 		rotationYaw = prevRotationYaw + (rotationYaw - prevRotationYaw) * 0.2F;
 		float f2 = getGravityVelocity();
 
+		// Botania - don't do water particles, bursts are never inWater
+		/*
 		if (isInWater())
 		{
 			for (int j = 0; j < 4; ++j)
@@ -295,7 +299,7 @@ public class EntityManaBurst extends EntityThrowable implements IManaBurst, ILig
 				float f3 = 0.25F;
 				world.spawnParticle(EnumParticleTypes.WATER_BUBBLE, posX - motionX * f3, posY - motionY * f3, posZ - motionZ * f3, motionX, motionY, motionZ, new int[0]);
 			}
-		}
+		}*/
 
 		// Botania - don't apply drag
 		// this.motionX *= (double)f1;
@@ -310,7 +314,7 @@ public class EntityManaBurst extends EntityThrowable implements IManaBurst, ILig
 		setTicksExisted(getTicksExisted() + 1);
 		superUpdate();
 
-		if(!fake && !isDead)
+		if(!fake && !isDead && !scanBeam)
 			ping();
 
 		ILensEffect lens = getLensInstance();
@@ -364,8 +368,11 @@ public class EntityManaBurst extends EntityThrowable implements IManaBurst, ILig
 	public TileEntity getCollidedTile(boolean noParticles) {
 		this.noParticles = noParticles;
 
-		while(!isDead)
+		int iterations = 0;
+		while(!isDead && iterations < MAX_SIMULATION_TICKS) {
 			onUpdate();
+			iterations++;
+		}
 
 		if(fake)
 			incrementFakeParticleTick();

--- a/src/main/java/vazkii/botania/common/entity/EntityManaBurst.java
+++ b/src/main/java/vazkii/botania/common/entity/EntityManaBurst.java
@@ -67,8 +67,6 @@ import vazkii.botania.common.item.equipment.bauble.ItemTinyPlanet;
 
 @Optional.Interface(iface="elucent.albedo.lighting.ILightProvider", modid="albedo")
 public class EntityManaBurst extends EntityThrowable implements IManaBurst, ILightProvider {
-
-	private static final int MAX_SIMULATION_TICKS = 400;
 	
 	private static final String TAG_TICKS_EXISTED = "ticksExisted";
 	private static final String TAG_COLOR = "color";
@@ -369,7 +367,7 @@ public class EntityManaBurst extends EntityThrowable implements IManaBurst, ILig
 		this.noParticles = noParticles;
 
 		int iterations = 0;
-		while(!isDead && iterations < MAX_SIMULATION_TICKS) {
+		while(!isDead && iterations < ConfigHandler.spreaderTraceTime) {
 			onUpdate();
 			iterations++;
 		}

--- a/src/main/java/vazkii/botania/common/entity/EntityManaBurst.java
+++ b/src/main/java/vazkii/botania/common/entity/EntityManaBurst.java
@@ -360,6 +360,12 @@ public class EntityManaBurst extends EntityThrowable implements IManaBurst, ILig
 		return false;
 	}
 
+	@Override
+	public boolean isInLava() {
+		//Avoids expensive getBlockState check in Entity#onEntityUpdate (see super impl)
+		return false;
+	}
+
 	private TileEntity collidedTile = null;
 	private boolean noParticles = false;
 

--- a/src/main/resources/assets/botania/lang/en_us.lang
+++ b/src/main/resources/assets/botania/lang/en_us.lang
@@ -354,6 +354,7 @@ references.enabled=Enable Tooltip References
 shaders.enabled=Enable Shader Usage
 baubleRender.enabled=Enable Bauble Rendering
 spreader.posShift=Spreader Pos Shift
+spreader.traceTime=Spreader Trace Time
 staticFloaters.enabled=Enable Static Floating Flowers
 debugInfo.enabled=Enable Botania's F3 debug information
 versionChecking.enabled=Enable Version Checking


### PR DESCRIPTION
Mana spreader code is lovely as we all know so I'd like to get a few more eyes on this, if at all possible? (And someone who knows how to use a profiler would be really nice, ha!)

This PR:
* caps the maximum mana burst beam-scan distance to 400 ticks into the future, preventing big lags from https://github.com/Vazkii/Botania/issues/2787
  * This changes gameplay behavior but nobody will actually care
* stops beam-scan mana bursts from searching for entities (this information was simply thrown away, resulting in lots and lots and lots of wasted calls to `getEntitiesWithinAABBExcludingEntity`)
  * The Tripwire lens still works btw
* stops beam-scan mana bursts from sending "pings" to the mana spreader - this information was also simply thrown away, resulting in a lot of useless calls to `getTileEntity`
  * This is something I am unsure about, maybe something breaks here.
* comments out "inWater" related code from all mana bursts - I was never able to make a mana burst actually appear `inWater`, no matter how I aimed it at a pool of water.

Potential future areas of spreader/burst optimization (read: maybe don't merge yet?):

* is PositionProperties a hot spot? lots of little allocations there I'm sure
* what about `getLensInstance`?
* `onEntityUpdate` seems to be doing a *huge* amount of useless things. Running particles? Riding entities? Fire damage? DEFINITELY check this out. Lots of stuff that's not really that bad on its own but when you have a bunch of mana bursts doing these pointless checks every tick + spreaders occasionally doing 400 or so in a single tick... it can add up

Feel free to look in to any of those areas - I'll probably do it myself later when I get the time, but it's like 2:30am