### PR TITLE
Fix #2795 by tagging spawned apothecary item entities

### DIFF
--- a/src/main/java/vazkii/botania/common/block/tile/TileAltar.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileAltar.java
@@ -71,6 +71,8 @@ public class TileAltar extends TileSimpleInventory implements IPetalApothecary, 
 	public static final String TAG_HAS_LAVA = "hasLava";
 	public static final String TAG_IS_MOSSY = "isMossy";
 
+	private static final String ITEM_TAG_APOTHECARY_SPAWNED = "ApothecarySpawned";
+
 	public boolean hasWater = false;
 	public boolean hasLava = false;
 
@@ -138,6 +140,7 @@ public class TileAltar extends TileSimpleInventory implements IPetalApothecary, 
 					
 					ItemStack output = recipe.getOutput().copy();
 					EntityItem outputItem = new EntityItem(world, pos.getX() + 0.5, pos.getY() + 1.5, pos.getZ() + 0.5, output);
+					outputItem.addTag(ITEM_TAG_APOTHECARY_SPAWNED);
 					world.spawnEntity(outputItem);
 					
 					setWater(false);
@@ -148,7 +151,7 @@ public class TileAltar extends TileSimpleInventory implements IPetalApothecary, 
 					return true;
 				}
 			}
-		} else if(!hasFluidCapability) {
+		} else if(!hasFluidCapability && !item.getTags().contains(ITEM_TAG_APOTHECARY_SPAWNED)) {
 			if(!itemHandler.getStackInSlot(getSizeInventory() - 1).isEmpty())
 				return false;
 			


### PR DESCRIPTION
see #2795 

An unintended side effect of unlocking the Apothecary is that, if you immediately refill the Apothecary after crafting a flower (a common way to automate it), the flower would just go in the apothecary instead of being collectable.

This PR fixes it by tagging item entities that the Apothecary spawns and making the Apothecary ignore item entities with the tag.

(It's not impossible to automate the apothecary even without this fix, since you can leave it empty by default instead of full by default. But it's definitely kind of silly to enforce one method over the other.)