### PR TITLE
Make magnet ring respect pickup delays and tweak the blacklist

### DIFF
--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemMagnetRing.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemMagnetRing.java
@@ -12,7 +12,7 @@ package vazkii.botania.common.item.equipment.bauble;
 
 import baubles.api.BaubleType;
 import baubles.api.BaublesApi;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.Item;
@@ -41,7 +41,7 @@ public class ItemMagnetRing extends ItemBauble {
 
 	private static final String TAG_COOLDOWN = "cooldown";
 
-	private static final List<ResourceLocation> BLACKLIST = ImmutableList.of(new ResourceLocation("appliedenergistics2", "item.ItemCrystalSeed"));
+	private static final List<ResourceLocation> BLACKLIST = Lists.newArrayList(new ResourceLocation("appliedenergistics2", "crystal_seed"));
 
 	private final int range;
 
@@ -105,7 +105,7 @@ public class ItemMagnetRing extends ItemBauble {
 	}
 
 	private boolean canPullItem(EntityItem item) {
-		if(item.isDead || SubTileSolegnolia.hasSolegnoliaAround(item))
+		if(item.isDead || item.pickupDelay >= 40 || SubTileSolegnolia.hasSolegnoliaAround(item))
 			return false;
 
 		ItemStack stack = item.getItem();


### PR DESCRIPTION
* Items with pickup delay >40 ticks will be ignored (closes #2648). 40 ticks is the typical delay from death drops and the longest one in survival vanilla, so I figured it's a decent condition (I'm fine with changing it though).
* Ignore AE2 seeds with their new name.
* Make the blacklist actually usable and not crash when added to with IMC. Seems like this was broken since the very day it was added as it was using Arrays.asList at the start and then much later replaced with ImmutableList.