### PR TITLE
Give the red string container a dummy item handler when not bound

### DIFF
--- a/src/main/java/vazkii/botania/common/block/tile/string/TileRedStringContainer.java
+++ b/src/main/java/vazkii/botania/common/block/tile/string/TileRedStringContainer.java
@@ -15,6 +15,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.wrapper.EmptyHandler;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -31,19 +32,19 @@ public class TileRedStringContainer extends TileRedString {
 
 	@Override
 	public boolean hasCapability(@Nonnull Capability<?> cap, EnumFacing side) {
-		if(cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY
-				&& getTileAtBinding() != null
-				&& getTileAtBinding().hasCapability(cap, side))
+		if(cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
 			return true;
 		return super.hasCapability(cap, side);
 	}
 
 	@Override
 	public <T> T getCapability(@Nonnull Capability<T> cap, EnumFacing side) {
-		if(cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY
-				&& getTileAtBinding() != null
-				&& getTileAtBinding().hasCapability(cap, side))
-			return getTileAtBinding().getCapability(cap, side);
+		if(cap == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+			if(getTileAtBinding() != null && getTileAtBinding().hasCapability(cap, side)) {
+				return getTileAtBinding().getCapability(cap, side);
+			}
+			return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(EmptyHandler.INSTANCE);
+		}
 		return super.getCapability(cap, side);
 	}
 


### PR DESCRIPTION
Fixes #2790 by giving the container a dummy item handler which will always be available if the container isnt bound to an inventory. Thanks, Forge, for making this easy by providing a dummy handler.