### PR TITLE
fix #2825 (manasteel and elementium shears drop apples and saplings)

### DIFF
--- a/src/main/java/vazkii/botania/common/item/equipment/tool/manasteel/ItemManasteelShears.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/manasteel/ItemManasteelShears.java
@@ -111,6 +111,7 @@ public class ItemManasteelShears extends ItemShears implements IManaUsingItem, I
 
 				ToolCommons.damageItem(itemstack, 1, player, MANA_PER_DAMAGE);
 				player.addStat(StatList.getBlockStats(block), 1);
+				return true;
 			}
 		}
 


### PR DESCRIPTION
The onBlockStartBreak function for manasteel and elementium shears didn't return true so the game treated it like it was being broken with your fists.  Since the shears did drop leaves this would allow someone to break the same leaf block repeatedly for materials.  