### PR TITLE
Clean up JEI plugin warnings, formatting, add wrappers for a few recipe types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ Thumbs.db
 /*.ipr
 /*.iws
 /*.iml
+/classes
 
 ## Private Stuffs
 /private.properties

--- a/src/main/java/vazkii/botania/client/integration/jei/JEIBotaniaPlugin.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/JEIBotaniaPlugin.java
@@ -11,10 +11,12 @@ package vazkii.botania.client.integration.jei;
 import mezz.jei.api.IJeiRuntime;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.IModRegistry;
+import mezz.jei.api.IRecipeRegistry;
 import mezz.jei.api.IRecipesGui;
 import mezz.jei.api.ISubtypeRegistry;
 import mezz.jei.api.JEIPlugin;
 import mezz.jei.api.recipe.IRecipeCategoryRegistration;
+import mezz.jei.api.recipe.IRecipeWrapper;
 import mezz.jei.api.recipe.VanillaRecipeCategoryUid;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -35,7 +37,10 @@ import vazkii.botania.client.core.handler.CorporeaInputHandler;
 import vazkii.botania.client.gui.crafting.ContainerCraftingHalo;
 import vazkii.botania.client.integration.jei.brewery.BreweryRecipeCategory;
 import vazkii.botania.client.integration.jei.brewery.BreweryRecipeWrapper;
+import vazkii.botania.client.integration.jei.crafting.AncientWillRecipeWrapper;
+import vazkii.botania.client.integration.jei.crafting.CompositeLensRecipeWrapper;
 import vazkii.botania.client.integration.jei.crafting.SpecialFloatingFlowerWrapper;
+import vazkii.botania.client.integration.jei.crafting.TerraPickTippingRecipeWrapper;
 import vazkii.botania.client.integration.jei.elventrade.ElvenTradeRecipeCategory;
 import vazkii.botania.client.integration.jei.elventrade.ElvenTradeRecipeWrapper;
 import vazkii.botania.client.integration.jei.manapool.ManaPoolRecipeCategory;
@@ -51,12 +56,16 @@ import vazkii.botania.client.integration.jei.puredaisy.PureDaisyRecipeWrapper;
 import vazkii.botania.client.integration.jei.runicaltar.RunicAltarRecipeCategory;
 import vazkii.botania.client.integration.jei.runicaltar.RunicAltarRecipeWrapper;
 import vazkii.botania.common.block.ModBlocks;
+import vazkii.botania.common.crafting.recipe.AncientWillRecipe;
+import vazkii.botania.common.crafting.recipe.CompositeLensRecipe;
 import vazkii.botania.common.crafting.recipe.SpecialFloatingFlowerRecipe;
+import vazkii.botania.common.crafting.recipe.TerraPickTippingRecipe;
 import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.block.ItemBlockSpecialFlower;
 import vazkii.botania.common.item.brew.ItemBrewBase;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static vazkii.botania.common.lib.LibBlockNames.SUBTILE_ORECHID;
@@ -104,8 +113,12 @@ public class JEIBotaniaPlugin implements IModPlugin {
 		registry.handleRecipes(RecipePetals.class, PetalApothecaryRecipeWrapper::new, PetalApothecaryRecipeCategory.UID);
 		registry.handleRecipes(RecipeElvenTrade.class, ElvenTradeRecipeWrapper::new, ElvenTradeRecipeCategory.UID);
 		registry.handleRecipes(RecipeManaInfusion.class, ManaPoolRecipeWrapper::new, ManaPoolRecipeCategory.UID);
+		
 		registry.handleRecipes(SpecialFloatingFlowerRecipe.class, SpecialFloatingFlowerWrapper::new, VanillaRecipeCategoryUid.CRAFTING);
-
+		registry.handleRecipes(AncientWillRecipe.class, AncientWillRecipeWrapper::new, VanillaRecipeCategoryUid.CRAFTING);
+		registry.handleRecipes(TerraPickTippingRecipe.class, TerraPickTippingRecipeWrapper::new, VanillaRecipeCategoryUid.CRAFTING);
+		registry.handleRecipes(CompositeLensRecipe.class, r -> new CompositeLensRecipeWrapper(), VanillaRecipeCategoryUid.CRAFTING);
+		
 		registry.addRecipes(BotaniaAPI.brewRecipes, BreweryRecipeCategory.UID);
 		registry.addRecipes(BotaniaAPI.pureDaisyRecipes, PureDaisyRecipeCategory.UID);
 		registry.addRecipes(BotaniaAPI.petalRecipes, PetalApothecaryRecipeCategory.UID);
@@ -159,6 +172,19 @@ public class JEIBotaniaPlugin implements IModPlugin {
 
 	@Override
 	public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
+		IRecipeRegistry recipeRegistry = jeiRuntime.getRecipeRegistry();
+		for(RecipeElvenTrade recipe : BotaniaAPI.elvenTradeRecipes) {
+			List<Object> inputs = recipe.getInputs();
+			List<ItemStack> outputs = recipe.getOutputs();
+			if(inputs.size() == 1 && outputs.size() == 1 && inputs.get(0) instanceof ItemStack
+					&& ItemStack.areItemStacksEqual((ItemStack) inputs.get(0), outputs.get(0))) {
+				IRecipeWrapper wrapper = recipeRegistry.getRecipeWrapper(recipe, ElvenTradeRecipeCategory.UID);
+				if(wrapper != null) {
+					recipeRegistry.hideRecipe(wrapper, ElvenTradeRecipeCategory.UID);
+				}
+			}
+		}
+		
 		CorporeaInputHandler.jeiPanelSupplier = () -> {
 			Object o = jeiRuntime.getIngredientListOverlay().getIngredientUnderMouse();
 

--- a/src/main/java/vazkii/botania/client/integration/jei/brewery/BreweryRecipeCategory.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/brewery/BreweryRecipeCategory.java
@@ -13,9 +13,9 @@ import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IDrawableStatic;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IFocus;
 import mezz.jei.api.recipe.IRecipeCategory;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -25,7 +25,7 @@ import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
-public class BreweryRecipeCategory implements IRecipeCategory {
+public class BreweryRecipeCategory implements IRecipeCategory<BreweryRecipeWrapper> {
 
 	public static final String UID = "botania.brewery";
 	private final IDrawableStatic background;
@@ -33,7 +33,7 @@ public class BreweryRecipeCategory implements IRecipeCategory {
 
 	public BreweryRecipeCategory(IGuiHelper guiHelper) {
 		ResourceLocation location = new ResourceLocation("botania", "textures/gui/neiBrewery.png");
-		background = guiHelper.createDrawable(location, 0, 0, 166, 65, 0, 0, 0, 0);
+		background = guiHelper.createDrawable(location, 0, 0, 166, 65);
 		localizedName = I18n.format("botania.nei.brewery");
 	}
 
@@ -62,12 +62,10 @@ public class BreweryRecipeCategory implements IRecipeCategory {
 	}
 
 	@Override
-	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull IRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
-		if(!(recipeWrapper instanceof BreweryRecipeWrapper))
-			return;
+	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull BreweryRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
 
-		List<List<ItemStack>> inputs = ingredients.getInputs(ItemStack.class);
-		List<List<ItemStack>> outputs = ingredients.getOutputs(ItemStack.class);
+		List<List<ItemStack>> inputs = ingredients.getInputs(VanillaTypes.ITEM);
+		List<List<ItemStack>> outputs = ingredients.getOutputs(VanillaTypes.ITEM);
 		IFocus<?> focus = recipeLayout.getFocus();
 
 		recipeLayout.getItemStacks().init(0, true, 39, 41);

--- a/src/main/java/vazkii/botania/client/integration/jei/brewery/BreweryRecipeWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/brewery/BreweryRecipeWrapper.java
@@ -10,6 +10,7 @@ package vazkii.botania.client.integration.jei.brewery;
 
 import com.google.common.collect.ImmutableList;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
@@ -24,8 +25,8 @@ public class BreweryRecipeWrapper implements IRecipeWrapper {
 
 	private final List<List<ItemStack>> input;
 	private final List<ItemStack> output;
-	
-	private static final List<ItemStack> inputs = Arrays.asList(new ItemStack(ModItems.vial), 
+
+	private static final List<ItemStack> inputs = Arrays.asList(new ItemStack(ModItems.vial),
 		new ItemStack(ModItems.vial, 1, 1), new ItemStack(ModItems.incenseStick), new ItemStack(ModItems.bloodPendant));
 
 	public BreweryRecipeWrapper(RecipeBrew recipeBrew) {
@@ -41,7 +42,7 @@ public class BreweryRecipeWrapper implements IRecipeWrapper {
 			}
 		}
 		inputBuilder.add(containers.build());
-		
+
 		for(Object o : recipeBrew.getInputs()) {
 			if(o instanceof ItemStack) {
 				inputBuilder.add(ImmutableList.of((ItemStack) o));
@@ -57,7 +58,7 @@ public class BreweryRecipeWrapper implements IRecipeWrapper {
 
 	@Override
 	public void getIngredients(@Nonnull IIngredients ingredients) {
-		ingredients.setInputLists(ItemStack.class, input);
-		ingredients.setOutputLists(ItemStack.class, ImmutableList.of(output));
+		ingredients.setInputLists(VanillaTypes.ITEM, input);
+		ingredients.setOutputLists(VanillaTypes.ITEM, ImmutableList.of(output));
 	}
 }

--- a/src/main/java/vazkii/botania/client/integration/jei/crafting/AncientWillRecipeWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/crafting/AncientWillRecipeWrapper.java
@@ -1,0 +1,100 @@
+package vazkii.botania.client.integration.jei.crafting;
+
+import com.google.common.collect.ImmutableList;
+import mezz.jei.api.gui.IGuiItemStackGroup;
+import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
+import mezz.jei.api.recipe.IFocus;
+import mezz.jei.api.recipe.wrapper.ICustomCraftingRecipeWrapper;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import vazkii.botania.api.item.IAncientWillContainer;
+import vazkii.botania.common.Botania;
+import vazkii.botania.common.crafting.recipe.AncientWillRecipe;
+import vazkii.botania.common.item.ModItems;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class AncientWillRecipeWrapper implements ICustomCraftingRecipeWrapper {
+	private final ResourceLocation name;
+	private final List<List<ItemStack>> inputs;
+	private final List<ItemStack> output;
+
+	public AncientWillRecipeWrapper(AncientWillRecipe recipe) {
+		this.name = recipe.getRegistryName();
+
+		ImmutableList.Builder<List<ItemStack>> builder = ImmutableList.builder();
+		ImmutableList.Builder<ItemStack> helmets = ImmutableList.builder();
+		ImmutableList.Builder<ItemStack> wills = ImmutableList.builder();
+		helmets.add(new ItemStack(ModItems.terrasteelHelm));
+		if(Botania.thaumcraftLoaded) {
+			helmets.add(new ItemStack(ModItems.terrasteelHelmRevealing));
+		}
+		for(int i = 0; i < 6; i++) {
+			wills.add(new ItemStack(ModItems.ancientWill, 1, i));
+		}
+
+		output = helmets.build();
+		builder.add(output);
+		builder.add(wills.build());
+		inputs = builder.build();
+	}
+
+	@Override
+	public void getIngredients(@Nonnull IIngredients ingredients) {
+		ingredients.setInputLists(VanillaTypes.ITEM, inputs);
+		ingredients.setOutputLists(VanillaTypes.ITEM, ImmutableList.of(output));
+	}
+
+	@Nullable
+	@Override
+	public ResourceLocation getRegistryName() {
+		return name;
+	}
+
+	@Override
+	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull IIngredients ingredients) {
+		IFocus<?> focus = recipeLayout.getFocus();
+		IGuiItemStackGroup group = recipeLayout.getItemStacks();
+		group.set(ingredients);
+
+		if(focus != null) {
+			ItemStack focused = (ItemStack) focus.getValue();
+
+			if(focus.getMode() == IFocus.Mode.INPUT && focused.getItem() == ModItems.ancientWill) {
+				group.set(2, new ItemStack(ModItems.ancientWill, 1, focused.getMetadata()));
+				group.set(0, getHelmetsWithWill(focused.getMetadata()));
+			} else if(focused.getItem() instanceof IAncientWillContainer) { //helmet
+				group.set(1, new ItemStack(focused.getItem()));
+				group.set(0, getWillsOnHelmet(focused.getItem()));
+			}
+		}
+	}
+
+	private List<ItemStack> getHelmetsWithWill(int meta) {
+		ImmutableList.Builder<ItemStack> builder = ImmutableList.builder();
+		for(ItemStack itemStack : output) {
+			ItemStack toAdd = itemStack.copy();
+			((IAncientWillContainer) toAdd.getItem()).addAncientWill(toAdd, meta);
+			builder.add(toAdd);
+		}
+		return builder.build();
+	}
+
+	private List<ItemStack> getWillsOnHelmet(Item item) {
+		if(item instanceof IAncientWillContainer) {
+			ImmutableList.Builder<ItemStack> builder = ImmutableList.builder();
+			for(int i = 0; i < 6; i++) {
+				ItemStack stack = new ItemStack(item);
+				((IAncientWillContainer) item).addAncientWill(stack, i);
+				builder.add(stack);
+			}
+			return builder.build();
+		}
+		return ImmutableList.of();
+	}
+}

--- a/src/main/java/vazkii/botania/client/integration/jei/crafting/CompositeLensRecipeWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/crafting/CompositeLensRecipeWrapper.java
@@ -1,0 +1,81 @@
+package vazkii.botania.client.integration.jei.crafting;
+
+import com.google.common.collect.ImmutableList;
+import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
+import mezz.jei.api.recipe.wrapper.ICustomCraftingRecipeWrapper;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import vazkii.botania.common.item.ModItems;
+import vazkii.botania.common.item.lens.ItemLens;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CompositeLensRecipeWrapper implements ICustomCraftingRecipeWrapper {
+	private final List<List<ItemStack>> inputs;
+	private static final List<ItemStack> lenses;
+
+	static {
+		NonNullList<ItemStack> allLenses = NonNullList.create();
+		ItemLens lens = (ItemLens) ModItems.lens;
+		lens.getSubItems(CreativeTabs.SEARCH, allLenses);
+		lenses = ImmutableList.copyOf(allLenses.stream().filter(stack -> !lens.isControlLens(stack)).filter(lens::isCombinable).collect(Collectors.toList()));
+	}
+
+	public CompositeLensRecipeWrapper() {
+		inputs = ImmutableList.of(lenses, ImmutableList.of(new ItemStack(Items.SLIME_BALL)), lenses);
+	}
+
+	@Override
+	public void getIngredients(@Nonnull IIngredients ingredients) {
+		ingredients.setInputLists(VanillaTypes.ITEM, inputs);
+	}
+
+	@Override
+	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull IIngredients ingredients) {
+		recipeLayout.getItemStacks().set(ingredients);
+		recipeLayout.setShapeless();
+		if(recipeLayout.getFocus() != null) {
+			ItemStack stack = (ItemStack) recipeLayout.getFocus().getValue();
+			if(stack.getItem() == ModItems.lens) {
+				setLenses(recipeLayout, stack.getMetadata(), stack.getMetadata());
+				return;
+			}
+		}
+		setLenses(recipeLayout, 1, ItemLens.SUBTYPES - 1);
+	}
+
+	private void setLenses(IRecipeLayout recipeLayout, int start, int end) {
+		List<ItemStack> firstInput = new ArrayList<>();
+		List<ItemStack> secondInput = new ArrayList<>();
+		List<ItemStack> outputs = new ArrayList<>();
+
+		if(end >= ItemLens.SUBTYPES)
+			end = ItemLens.SUBTYPES - 1;
+
+		for(int i = start; i <= end; i++) {
+			ItemStack firstLens = new ItemStack(ModItems.lens, 1, i);
+			for(ItemStack secondLens : lenses) {
+				if(secondLens.getMetadata() == i)
+					continue;
+
+				if(((ItemLens) ModItems.lens).canCombineLenses(firstLens, secondLens)) {
+					firstInput.add(firstLens);
+					secondInput.add(secondLens);
+					outputs.add(((ItemLens) ModItems.lens).setCompositeLens(firstLens.copy(), secondLens));
+				}
+			}
+
+		}
+		recipeLayout.getItemStacks().set(1, firstInput);
+		recipeLayout.getItemStacks().set(3, secondInput);
+		recipeLayout.getItemStacks().set(0, outputs);
+	}
+
+}

--- a/src/main/java/vazkii/botania/client/integration/jei/crafting/SpecialFloatingFlowerWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/crafting/SpecialFloatingFlowerWrapper.java
@@ -2,34 +2,45 @@ package vazkii.botania.client.integration.jei.crafting;
 
 import com.google.common.collect.ImmutableList;
 import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
+import mezz.jei.api.ingredients.VanillaTypes;
+import mezz.jei.api.recipe.wrapper.ICraftingRecipeWrapper;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
-import vazkii.botania.api.BotaniaAPI;
+import net.minecraft.util.ResourceLocation;
 import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.crafting.recipe.SpecialFloatingFlowerRecipe;
 import vazkii.botania.common.item.block.ItemBlockSpecialFlower;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SpecialFloatingFlowerWrapper implements IRecipeWrapper {
-    private final List<List<ItemStack>> inputs = new ArrayList<>();
-    private final ItemStack output;
+public class SpecialFloatingFlowerWrapper implements ICraftingRecipeWrapper {
+	private final List<List<ItemStack>> inputs = new ArrayList<>();
+	private final ItemStack output;
+	private final ResourceLocation name;
 
-    public SpecialFloatingFlowerWrapper(SpecialFloatingFlowerRecipe recipe) {
-        inputs.add(ImmutableList.of(ItemBlockSpecialFlower.ofType(recipe.type)));
-        List<ItemStack> normalFloaters = new ArrayList<>();
-        for (EnumDyeColor color : EnumDyeColor.values()) {
-            normalFloaters.add(new ItemStack(ModBlocks.floatingFlower, 1, color.getMetadata()));
-        }
-        inputs.add(normalFloaters);
-        output = ItemBlockSpecialFlower.ofType(new ItemStack(ModBlocks.floatingSpecialFlower), recipe.type);
-    }
+	public SpecialFloatingFlowerWrapper(SpecialFloatingFlowerRecipe recipe) {
+		name = recipe.getRegistryName();
+		inputs.add(ImmutableList.of(ItemBlockSpecialFlower.ofType(recipe.type)));
+		List<ItemStack> normalFloaters = new ArrayList<>();
+		for(EnumDyeColor color : EnumDyeColor.values()) {
+			normalFloaters.add(new ItemStack(ModBlocks.floatingFlower, 1, color.getMetadata()));
+		}
+		inputs.add(normalFloaters);
+		output = ItemBlockSpecialFlower.ofType(new ItemStack(ModBlocks.floatingSpecialFlower), recipe.type);
+	}
 
-    @Override
-    public void getIngredients(IIngredients ingredients) {
-        ingredients.setInputLists(ItemStack.class, inputs);
-        ingredients.setOutput(ItemStack.class, output);
-    }
+	@Override
+	public void getIngredients(@Nonnull IIngredients ingredients) {
+		ingredients.setInputLists(VanillaTypes.ITEM, inputs);
+		ingredients.setOutput(VanillaTypes.ITEM, output);
+	}
+
+	@Nullable
+	@Override
+	public ResourceLocation getRegistryName() {
+		return name;
+	}
 }

--- a/src/main/java/vazkii/botania/client/integration/jei/crafting/TerraPickTippingRecipeWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/crafting/TerraPickTippingRecipeWrapper.java
@@ -1,0 +1,41 @@
+package vazkii.botania.client.integration.jei.crafting;
+
+import com.google.common.collect.ImmutableList;
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
+import mezz.jei.api.recipe.wrapper.ICraftingRecipeWrapper;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+import vazkii.botania.common.crafting.recipe.TerraPickTippingRecipe;
+import vazkii.botania.common.item.ModItems;
+import vazkii.botania.common.item.equipment.tool.terrasteel.ItemTerraPick;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class TerraPickTippingRecipeWrapper implements ICraftingRecipeWrapper {
+	private final List<List<ItemStack>> inputs;
+	private final ItemStack output;
+	private final ResourceLocation name;
+	
+	public TerraPickTippingRecipeWrapper(TerraPickTippingRecipe recipe) {
+		inputs = ImmutableList.of(ImmutableList.of(new ItemStack(ModItems.terraPick)), ImmutableList.of(new ItemStack(ModItems.elementiumPick)));
+		output = new ItemStack(ModItems.terraPick);
+		ItemTerraPick.setTipped(output);
+		
+		this.name = recipe.getRegistryName();
+	}
+	
+	@Override
+	public void getIngredients(@Nonnull IIngredients ingredients) {
+		ingredients.setInputLists(VanillaTypes.ITEM, inputs);
+		ingredients.setOutput(VanillaTypes.ITEM, output);
+	}
+
+	@Nullable
+	@Override
+	public ResourceLocation getRegistryName() {
+		return name;
+	}
+}

--- a/src/main/java/vazkii/botania/client/integration/jei/elventrade/ElvenTradeRecipeCategory.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/elventrade/ElvenTradeRecipeCategory.java
@@ -12,8 +12,8 @@ import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategory;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.GlStateManager;
@@ -29,11 +29,9 @@ import vazkii.botania.client.core.handler.MiscellaneousIcons;
 import vazkii.botania.common.lib.LibMisc;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 
-public class ElvenTradeRecipeCategory implements IRecipeCategory {
+public class ElvenTradeRecipeCategory implements IRecipeCategory<ElvenTradeRecipeWrapper> {
 
 	public static final String UID = "botania.elvenTrade";
 	private final String localizedName;
@@ -89,20 +87,17 @@ public class ElvenTradeRecipeCategory implements IRecipeCategory {
 	}
 
 	@Override
-	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull IRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
-		if(!(recipeWrapper instanceof ElvenTradeRecipeWrapper))
-			return;
-
+	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull ElvenTradeRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
 		int index = 0, posX = 42;
-		for(List<ItemStack> o : ingredients.getInputs(ItemStack.class)) {
+		for(List<ItemStack> o : ingredients.getInputs(VanillaTypes.ITEM)) {
 			recipeLayout.getItemStacks().init(index, true, posX, 0);
 			recipeLayout.getItemStacks().set(index, o);
 			index++;
 			posX += 18;
 		}
 
-		for (int i = 0; i < ingredients.getOutputs(ItemStack.class).size(); i++) {
-			List<ItemStack> stacks = ingredients.getOutputs(ItemStack.class).get(i);
+		for(int i = 0; i < ingredients.getOutputs(VanillaTypes.ITEM).size(); i++) {
+			List<ItemStack> stacks = ingredients.getOutputs(VanillaTypes.ITEM).get(i);
 			recipeLayout.getItemStacks().init(index + i, false, 93 + i % 2 * 20, 41 + i / 2 * 20);
 			recipeLayout.getItemStacks().set(index + i, stacks);
 		}
@@ -113,5 +108,5 @@ public class ElvenTradeRecipeCategory implements IRecipeCategory {
 	public String getModName() {
 		return LibMisc.MOD_NAME;
 	}
-	
+
 }

--- a/src/main/java/vazkii/botania/client/integration/jei/elventrade/ElvenTradeRecipeWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/elventrade/ElvenTradeRecipeWrapper.java
@@ -10,6 +10,7 @@ package vazkii.botania.client.integration.jei.elventrade;
 
 import com.google.common.collect.ImmutableList;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
@@ -24,7 +25,6 @@ public class ElvenTradeRecipeWrapper implements IRecipeWrapper {
 	private final List<List<ItemStack>> input;
 	private final List<ItemStack> outputs;
 
-	@SuppressWarnings("unchecked")
 	public ElvenTradeRecipeWrapper(RecipeElvenTrade recipe) {
 		ImmutableList.Builder<List<ItemStack>> builder = ImmutableList.builder();
 		for(Object o : recipe.getInputs()) {
@@ -41,7 +41,7 @@ public class ElvenTradeRecipeWrapper implements IRecipeWrapper {
 
 	@Override
 	public void getIngredients(@Nonnull IIngredients ingredients) {
-		ingredients.setInputLists(ItemStack.class, input);
-		ingredients.setOutputs(ItemStack.class, outputs);
+		ingredients.setInputLists(VanillaTypes.ITEM, input);
+		ingredients.setOutputs(VanillaTypes.ITEM, outputs);
 	}
 }

--- a/src/main/java/vazkii/botania/client/integration/jei/manapool/ManaPoolRecipeCategory.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/manapool/ManaPoolRecipeCategory.java
@@ -12,8 +12,8 @@ import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategory;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.resources.I18n;
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ManaPoolRecipeCategory implements IRecipeCategory {
+public class ManaPoolRecipeCategory implements IRecipeCategory<ManaPoolRecipeWrapper> {
 
 	public static final String UID = "botania.manaPool";
 	private final IDrawable background;
@@ -78,21 +78,18 @@ public class ManaPoolRecipeCategory implements IRecipeCategory {
 	}
 
 	@Override
-	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull IRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
-		if(!(recipeWrapper instanceof ManaPoolRecipeWrapper))
-			return;
-
+	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull ManaPoolRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
 		int index = 0;
 
 		recipeLayout.getItemStacks().init(index, true, 40, 12);
-		recipeLayout.getItemStacks().set(index, ingredients.getInputs(ItemStack.class).get(0));
+		recipeLayout.getItemStacks().set(index, ingredients.getInputs(VanillaTypes.ITEM).get(0));
 
 		index++;
 
-		if(ingredients.getInputs(ItemStack.class).size() > 1) {
+		if(ingredients.getInputs(VanillaTypes.ITEM).size() > 1) {
 			// Has catalyst
 			recipeLayout.getItemStacks().init(index, true, 20, 12);
-			recipeLayout.getItemStacks().set(index, ingredients.getInputs(ItemStack.class).get(1));
+			recipeLayout.getItemStacks().set(index, ingredients.getInputs(VanillaTypes.ITEM).get(1));
 			index++;
 		}
 
@@ -101,12 +98,13 @@ public class ManaPoolRecipeCategory implements IRecipeCategory {
 		index++;
 
 		recipeLayout.getItemStacks().init(index, false, 99, 12);
-		recipeLayout.getItemStacks().set(index, ingredients.getOutputs(ItemStack.class).get(0));
+		recipeLayout.getItemStacks().set(index, ingredients.getOutputs(VanillaTypes.ITEM).get(0));
 	}
 
+	@Nonnull
 	@Override
-	public List getTooltipStrings(int mouseX, int mouseY) {
-		return new ArrayList();
+	public List<String> getTooltipStrings(int mouseX, int mouseY) {
+		return new ArrayList<>();
 	}
 
 	@Nonnull

--- a/src/main/java/vazkii/botania/client/integration/jei/manapool/ManaPoolRecipeWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/manapool/ManaPoolRecipeWrapper.java
@@ -10,6 +10,7 @@ package vazkii.botania.client.integration.jei.manapool;
 
 import com.google.common.collect.ImmutableList;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
@@ -54,8 +55,8 @@ public class ManaPoolRecipeWrapper implements IRecipeWrapper {
 
 	@Override
 	public void getIngredients(@Nonnull IIngredients ingredients) {
-		ingredients.setInputLists(ItemStack.class, input);
-		ingredients.setOutput(ItemStack.class, output);
+		ingredients.setInputLists(VanillaTypes.ITEM, input);
+		ingredients.setOutput(VanillaTypes.ITEM, output);
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidIgnemRecipeCategory.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidIgnemRecipeCategory.java
@@ -14,12 +14,11 @@ import mezz.jei.api.gui.IDrawableStatic;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategory;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.resources.I18n;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import vazkii.botania.common.item.block.ItemBlockSpecialFlower;
 import vazkii.botania.common.lib.LibBlockNames;
@@ -27,66 +26,66 @@ import vazkii.botania.common.lib.LibMisc;
 
 import javax.annotation.Nonnull;
 
-public class OrechidIgnemRecipeCategory implements IRecipeCategory {
+public class OrechidIgnemRecipeCategory implements IRecipeCategory<OrechidIgnemRecipeWrapper> {
 
-    public static final String UID = "botania.orechid_ignem";
-    private final IDrawableStatic background;
-    private final String localizedName;
-    private final IDrawableStatic overlay;
+	public static final String UID = "botania.orechid_ignem";
+	private final IDrawableStatic background;
+	private final String localizedName;
+	private final IDrawableStatic overlay;
 
-    public OrechidIgnemRecipeCategory(IGuiHelper guiHelper) {
-        background = guiHelper.createBlankDrawable(168, 64);
-        localizedName = I18n.format("botania.nei.orechidIgnem");
-        overlay = guiHelper.createDrawable(new ResourceLocation("botania", "textures/gui/pureDaisyOverlay.png"),
-                0, 0, 64, 46);
-    }
+	public OrechidIgnemRecipeCategory(IGuiHelper guiHelper) {
+		background = guiHelper.createBlankDrawable(168, 64);
+		localizedName = I18n.format("botania.nei.orechidIgnem");
+		overlay = guiHelper.createDrawable(new ResourceLocation("botania", "textures/gui/pureDaisyOverlay.png"),
+				0, 0, 64, 46);
+	}
 
-    @Nonnull
-    @Override
-    public String getUid() {
-        return UID;
-    }
+	@Nonnull
+	@Override
+	public String getUid() {
+		return UID;
+	}
 
-    @Nonnull
-    @Override
-    public String getTitle() {
-        return localizedName;
-    }
+	@Nonnull
+	@Override
+	public String getTitle() {
+		return localizedName;
+	}
 
-    @Nonnull
-    @Override
-    public IDrawable getBackground() {
-        return background;
-    }
+	@Nonnull
+	@Override
+	public IDrawable getBackground() {
+		return background;
+	}
 
 
-    @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        final IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+	@Override
+	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull OrechidIgnemRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
+		final IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
 
-        itemStacks.init(0, true, 40, 12);
-        itemStacks.set(0, ingredients.getInputs(ItemStack.class).get(0));
+		itemStacks.init(0, true, 40, 12);
+		itemStacks.set(0, ingredients.getInputs(VanillaTypes.ITEM).get(0));
 
-        itemStacks.init(1, true, 70, 12);
-        itemStacks.set(1, ItemBlockSpecialFlower.ofType(LibBlockNames.SUBTILE_ORECHID_IGNEM));
+		itemStacks.init(1, true, 70, 12);
+		itemStacks.set(1, ItemBlockSpecialFlower.ofType(LibBlockNames.SUBTILE_ORECHID_IGNEM));
 
-        itemStacks.init(2, true, 99, 12);
-        itemStacks.set(2, ingredients.getOutputs(ItemStack.class).get(0));
-    }
+		itemStacks.init(2, true, 99, 12);
+		itemStacks.set(2, ingredients.getOutputs(VanillaTypes.ITEM).get(0));
+	}
 
-    @Override
-    public void drawExtras(@Nonnull Minecraft minecraft) {
-        GlStateManager.enableAlpha();
-        GlStateManager.enableBlend();
-        overlay.draw(minecraft, 48, 0);
-        GlStateManager.disableBlend();
-        GlStateManager.disableAlpha();
-    }
+	@Override
+	public void drawExtras(@Nonnull Minecraft minecraft) {
+		GlStateManager.enableAlpha();
+		GlStateManager.enableBlend();
+		overlay.draw(minecraft, 48, 0);
+		GlStateManager.disableBlend();
+		GlStateManager.disableAlpha();
+	}
 
-    @Nonnull
-    @Override
-    public String getModName() {
-        return LibMisc.MOD_NAME;
-    }
+	@Nonnull
+	@Override
+	public String getModName() {
+		return LibMisc.MOD_NAME;
+	}
 
 }

--- a/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidIgnemRecipeWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidIgnemRecipeWrapper.java
@@ -15,18 +15,18 @@ import vazkii.botania.api.BotaniaAPI;
 import java.util.Map;
 
 public class OrechidIgnemRecipeWrapper extends OrechidRecipeWrapper {
-    
-    public OrechidIgnemRecipeWrapper(Map.Entry<String, Integer> entry) {
-        super(entry);
-    }
 
-    @Override
-    protected ItemStack getInputStack() {
-        return new ItemStack(Blocks.NETHERRACK, 64);
-    }
+	public OrechidIgnemRecipeWrapper(Map.Entry<String, Integer> entry) {
+		super(entry);
+	}
 
-    public Map<String, Integer> getOreWeights() {
-        return BotaniaAPI.oreWeightsNether;
-    }
+	@Override
+	protected ItemStack getInputStack() {
+		return new ItemStack(Blocks.NETHERRACK, 64);
+	}
+
+	public Map<String, Integer> getOreWeights() {
+		return BotaniaAPI.oreWeightsNether;
+	}
 
 }

--- a/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidRecipeCategory.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidRecipeCategory.java
@@ -14,12 +14,11 @@ import mezz.jei.api.gui.IDrawableStatic;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategory;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.resources.I18n;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import vazkii.botania.common.item.block.ItemBlockSpecialFlower;
 import vazkii.botania.common.lib.LibBlockNames;
@@ -27,66 +26,66 @@ import vazkii.botania.common.lib.LibMisc;
 
 import javax.annotation.Nonnull;
 
-public class OrechidRecipeCategory implements IRecipeCategory {
+public class OrechidRecipeCategory implements IRecipeCategory<OrechidRecipeWrapper> {
 
-    public static final String UID = "botania.orechid";
-    private final IDrawableStatic background;
-    private final String localizedName;
-    private final IDrawableStatic overlay;
+	public static final String UID = "botania.orechid";
+	private final IDrawableStatic background;
+	private final String localizedName;
+	private final IDrawableStatic overlay;
 
-    public OrechidRecipeCategory(IGuiHelper guiHelper) {
-        background = guiHelper.createBlankDrawable(168, 64);
-        localizedName = I18n.format("botania.nei.orechid");
-        overlay = guiHelper.createDrawable(new ResourceLocation("botania", "textures/gui/pureDaisyOverlay.png"),
-                0, 0, 64, 46);
-    }
+	public OrechidRecipeCategory(IGuiHelper guiHelper) {
+		background = guiHelper.createBlankDrawable(168, 64);
+		localizedName = I18n.format("botania.nei.orechid");
+		overlay = guiHelper.createDrawable(new ResourceLocation("botania", "textures/gui/pureDaisyOverlay.png"),
+				0, 0, 64, 46);
+	}
 
-    @Nonnull
-    @Override
-    public String getUid() {
-        return UID;
-    }
+	@Nonnull
+	@Override
+	public String getUid() {
+		return UID;
+	}
 
-    @Nonnull
-    @Override
-    public String getTitle() {
-        return localizedName;
-    }
+	@Nonnull
+	@Override
+	public String getTitle() {
+		return localizedName;
+	}
 
-    @Nonnull
-    @Override
-    public IDrawable getBackground() {
-        return background;
-    }
+	@Nonnull
+	@Override
+	public IDrawable getBackground() {
+		return background;
+	}
 
 
-    @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        final IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+	@Override
+	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull OrechidRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
+		final IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
 
-        itemStacks.init(0, true, 40, 12);
-        itemStacks.set(0, ingredients.getInputs(ItemStack.class).get(0));
+		itemStacks.init(0, true, 40, 12);
+		itemStacks.set(0, ingredients.getInputs(VanillaTypes.ITEM).get(0));
 
-        itemStacks.init(1, true, 70, 12);
-        itemStacks.set(1, ItemBlockSpecialFlower.ofType(LibBlockNames.SUBTILE_ORECHID));
+		itemStacks.init(1, true, 70, 12);
+		itemStacks.set(1, ItemBlockSpecialFlower.ofType(LibBlockNames.SUBTILE_ORECHID));
 
-        itemStacks.init(2, true, 99, 12);
-        itemStacks.set(2, ingredients.getOutputs(ItemStack.class).get(0));
-    }
+		itemStacks.init(2, true, 99, 12);
+		itemStacks.set(2, ingredients.getOutputs(VanillaTypes.ITEM).get(0));
+	}
 
-    @Override
-    public void drawExtras(@Nonnull Minecraft minecraft) {
-        GlStateManager.enableAlpha();
-        GlStateManager.enableBlend();
-        overlay.draw(minecraft, 48, 0);
-        GlStateManager.disableBlend();
-        GlStateManager.disableAlpha();
-    }
+	@Override
+	public void drawExtras(@Nonnull Minecraft minecraft) {
+		GlStateManager.enableAlpha();
+		GlStateManager.enableBlend();
+		overlay.draw(minecraft, 48, 0);
+		GlStateManager.disableBlend();
+		GlStateManager.disableAlpha();
+	}
 
-    @Nonnull
-    @Override
-    public String getModName() {
-        return LibMisc.MOD_NAME;
-    }
+	@Nonnull
+	@Override
+	public String getModName() {
+		return LibMisc.MOD_NAME;
+	}
 
 }

--- a/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidRecipeWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/orechid/OrechidRecipeWrapper.java
@@ -17,6 +17,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 import vazkii.botania.api.BotaniaAPI;
 
+import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -26,49 +27,49 @@ import static vazkii.botania.client.integration.jei.JEIBotaniaPlugin.doesOreExis
 
 public class OrechidRecipeWrapper implements IRecipeWrapper, Comparable<OrechidRecipeWrapper> {
 
-    private final int weight;
-    private final List<List<ItemStack>> outputStacks;
+	private final int weight;
+	private final List<List<ItemStack>> outputStacks;
 
-    protected ItemStack getInputStack() {
-        return new ItemStack(Blocks.STONE, 64);
-    }
+	protected ItemStack getInputStack() {
+		return new ItemStack(Blocks.STONE, 64);
+	}
 
-    public OrechidRecipeWrapper(Map.Entry<String, Integer> entry) {
-        this.weight = entry.getValue();
+	public OrechidRecipeWrapper(Map.Entry<String, Integer> entry) {
+		this.weight = entry.getValue();
 
-        final int amount = Math.max(1, Math.round((float) weight * 64 / getTotalOreWeight()));
+		final int amount = Math.max(1, Math.round((float) weight * 64 / getTotalOreWeight()));
 
-        // Shouldn't ever return an empty list since the ore weight
-        // list is filtered to only have ores with ItemBlocks
-        List<ItemStack> stackList = OreDictionary.getOres(entry.getKey()).stream()
-                .filter(s -> s.getItem() instanceof ItemBlock)
-                .map(ItemStack::copy)
-                .collect(Collectors.toList());
+		// Shouldn't ever return an empty list since the ore weight
+		// list is filtered to only have ores with ItemBlocks
+		List<ItemStack> stackList = OreDictionary.getOres(entry.getKey()).stream()
+				.filter(s -> s.getItem() instanceof ItemBlock)
+				.map(ItemStack::copy)
+				.collect(Collectors.toList());
 
-        stackList.forEach(s -> s.setCount(amount));
+		stackList.forEach(s -> s.setCount(amount));
 
-        outputStacks = Collections.singletonList(stackList);
-    }
+		outputStacks = Collections.singletonList(stackList);
+	}
 
-    public Map<String, Integer> getOreWeights() {
-        return BotaniaAPI.oreWeights;
-    }
+	public Map<String, Integer> getOreWeights() {
+		return BotaniaAPI.oreWeights;
+	}
 
-    private float getTotalOreWeight() {
-        return (getOreWeights().entrySet().stream()
-                .filter(e -> doesOreExist(e.getKey()))
-                .map(Map.Entry::getValue)
-                .reduce(Integer::sum)).orElse(weight * 64 * 64);
-    }
+	private float getTotalOreWeight() {
+		return (getOreWeights().entrySet().stream()
+				.filter(e -> doesOreExist(e.getKey()))
+				.map(Map.Entry::getValue)
+				.reduce(Integer::sum)).orElse(weight * 64 * 64);
+	}
 
-    @Override
-    public void getIngredients(IIngredients ingredients) {
-        ingredients.setInput(VanillaTypes.ITEM, getInputStack());
-        ingredients.setOutputLists(VanillaTypes.ITEM, outputStacks);
-    }
+	@Override
+	public void getIngredients(@Nonnull IIngredients ingredients) {
+		ingredients.setInput(VanillaTypes.ITEM, getInputStack());
+		ingredients.setOutputLists(VanillaTypes.ITEM, outputStacks);
+	}
 
-    @Override
-    public int compareTo(OrechidRecipeWrapper o) {
-        return Integer.compare(o.weight, weight);
-    }
+	@Override
+	public int compareTo(@Nonnull OrechidRecipeWrapper o) {
+		return Integer.compare(o.weight, weight);
+	}
 }

--- a/src/main/java/vazkii/botania/client/integration/jei/petalapothecary/PetalApothecaryRecipeCategory.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/petalapothecary/PetalApothecaryRecipeCategory.java
@@ -13,6 +13,7 @@ import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IDrawableStatic;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategory;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
@@ -29,7 +30,7 @@ import java.awt.Point;
 import java.util.ArrayList;
 import java.util.List;
 
-public class PetalApothecaryRecipeCategory implements IRecipeCategory {
+public class PetalApothecaryRecipeCategory implements IRecipeCategory<PetalApothecaryRecipeWrapper> {
 
 	public static final String UID = "botania.petals";
 	private final IDrawableStatic background;
@@ -71,18 +72,15 @@ public class PetalApothecaryRecipeCategory implements IRecipeCategory {
 	}
 
 	@Override
-	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull IRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
-		if(!(recipeWrapper instanceof PetalApothecaryRecipeWrapper))
-			return;
-
+	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull PetalApothecaryRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
 		recipeLayout.getItemStacks().init(0, true, 64, 52);
 		recipeLayout.getItemStacks().set(0, new ItemStack(ModBlocks.altar));
 
 		int index = 1;
-		double angleBetweenEach = 360.0 / ingredients.getInputs(ItemStack.class).size();
+		double angleBetweenEach = 360.0 / ingredients.getInputs(VanillaTypes.ITEM).size();
 		Point point = new Point(64, 20), center = new Point(64, 52);
 
-		for(List<ItemStack> o : ingredients.getInputs(ItemStack.class)) {
+		for(List<ItemStack> o : ingredients.getInputs(VanillaTypes.ITEM)) {
 			recipeLayout.getItemStacks().init(index, true, point.x, point.y);
 			recipeLayout.getItemStacks().set(index, o);
 			index += 1;
@@ -90,7 +88,7 @@ public class PetalApothecaryRecipeCategory implements IRecipeCategory {
 		}
 
 		recipeLayout.getItemStacks().init(index, false, 103, 17);
-		recipeLayout.getItemStacks().set(index, ingredients.getOutputs(ItemStack.class).get(0));
+		recipeLayout.getItemStacks().set(index, ingredients.getOutputs(VanillaTypes.ITEM).get(0));
 	}
 
 	private Point rotatePointAbout(Point in, Point about, double degrees) {

--- a/src/main/java/vazkii/botania/client/integration/jei/petalapothecary/PetalApothecaryRecipeWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/petalapothecary/PetalApothecaryRecipeWrapper.java
@@ -10,8 +10,8 @@ package vazkii.botania.client.integration.jei.petalapothecary;
 
 import com.google.common.collect.ImmutableList;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
-import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 import vazkii.botania.api.recipe.RecipePetals;
@@ -40,8 +40,8 @@ public class PetalApothecaryRecipeWrapper implements IRecipeWrapper {
 
 	@Override
 	public void getIngredients(@Nonnull IIngredients ingredients) {
-		ingredients.setInputLists(ItemStack.class, input);
-		ingredients.setOutput(ItemStack.class, output);
+		ingredients.setInputLists(VanillaTypes.ITEM, input);
+		ingredients.setOutput(VanillaTypes.ITEM, output);
 	}
 
 }

--- a/src/main/java/vazkii/botania/client/integration/jei/puredaisy/PureDaisyRecipeCategory.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/puredaisy/PureDaisyRecipeCategory.java
@@ -12,6 +12,7 @@ import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategory;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
@@ -29,7 +30,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class PureDaisyRecipeCategory implements IRecipeCategory {
+public class PureDaisyRecipeCategory implements IRecipeCategory<PureDaisyRecipeWrapper> {
 
 	public static final String UID = "botania.pureDaisy";
 	private final IDrawable background;
@@ -71,19 +72,16 @@ public class PureDaisyRecipeCategory implements IRecipeCategory {
 	}
 
 	@Override
-	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull IRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
-		if(!(recipeWrapper instanceof PureDaisyRecipeWrapper))
-			return;
-
-		boolean inputFluid = !ingredients.getInputs(FluidStack.class).isEmpty();
-		boolean outputFluid = !ingredients.getOutputs(FluidStack.class).isEmpty();
+	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull PureDaisyRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
+		boolean inputFluid = !ingredients.getInputs(VanillaTypes.FLUID).isEmpty();
+		boolean outputFluid = !ingredients.getOutputs(VanillaTypes.FLUID).isEmpty();
 
 		if(inputFluid) {
 			recipeLayout.getFluidStacks().init(0, true, 40, 12, 16, 16, 1000, false, null);
-			recipeLayout.getFluidStacks().set(0, ingredients.getInputs(FluidStack.class).get(0));
+			recipeLayout.getFluidStacks().set(0, ingredients.getInputs(VanillaTypes.FLUID).get(0));
 		} else {
 			recipeLayout.getItemStacks().init(0, true, 40, 12);
-			recipeLayout.getItemStacks().set(0, ingredients.getInputs(ItemStack.class).get(0));
+			recipeLayout.getItemStacks().set(0, ingredients.getInputs(VanillaTypes.ITEM).get(0));
 		}
 
 		recipeLayout.getItemStacks().init(1, true, 70, 12);
@@ -91,10 +89,10 @@ public class PureDaisyRecipeCategory implements IRecipeCategory {
 
 		if(outputFluid) {
 			recipeLayout.getFluidStacks().init(2, false, 99, 12, 16, 16, 1000, false, null);
-			recipeLayout.getFluidStacks().set(2, ingredients.getOutputs(FluidStack.class).get(0));
+			recipeLayout.getFluidStacks().set(2, ingredients.getOutputs(VanillaTypes.FLUID).get(0));
 		} else {
 			recipeLayout.getItemStacks().init(2, false, 99, 12);
-			recipeLayout.getItemStacks().set(2, ingredients.getOutputs(ItemStack.class).get(0));
+			recipeLayout.getItemStacks().set(2, ingredients.getOutputs(VanillaTypes.ITEM).get(0));
 		}
 	}
 

--- a/src/main/java/vazkii/botania/client/integration/jei/puredaisy/PureDaisyRecipeWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/puredaisy/PureDaisyRecipeWrapper.java
@@ -10,6 +10,7 @@ package vazkii.botania.client.integration.jei.puredaisy;
 
 import com.google.common.collect.ImmutableList;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
@@ -54,18 +55,18 @@ public class PureDaisyRecipeWrapper implements IRecipeWrapper {
 
 	@Override
 	public void getIngredients(@Nonnull IIngredients ingredients) {
-		ingredients.setInputs(ItemStack.class, inputs);
+		ingredients.setInputs(VanillaTypes.ITEM, inputs);
 
 		if (fluidInput != null) {
-			ingredients.setInput(FluidStack.class, fluidInput);
+			ingredients.setInput(VanillaTypes.FLUID, fluidInput);
 		}
 
 		if (!output.isEmpty()) {
-			ingredients.setOutput(ItemStack.class, output);
+			ingredients.setOutput(VanillaTypes.ITEM, output);
 		}
 
 		if (fluidOutput != null) {
-			ingredients.setOutput(FluidStack.class, fluidOutput);
+			ingredients.setOutput(VanillaTypes.FLUID, fluidOutput);
 		}
 	}
 

--- a/src/main/java/vazkii/botania/client/integration/jei/runicaltar/RunicAltarRecipeCategory.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/runicaltar/RunicAltarRecipeCategory.java
@@ -12,8 +12,8 @@ import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategory;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.resources.I18n;
@@ -23,12 +23,10 @@ import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.lib.LibMisc;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.awt.Point;
-import java.util.ArrayList;
 import java.util.List;
 
-public class RunicAltarRecipeCategory implements IRecipeCategory {
+public class RunicAltarRecipeCategory implements IRecipeCategory<RunicAltarRecipeWrapper> {
 
 	public static final String UID = "botania.runicAltar";
 	private final IDrawable background;
@@ -70,19 +68,15 @@ public class RunicAltarRecipeCategory implements IRecipeCategory {
 	}
 
 	@Override
-	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull IRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
-		if(!(recipeWrapper instanceof RunicAltarRecipeWrapper))
-			return;
-		RunicAltarRecipeWrapper wrapper = (RunicAltarRecipeWrapper) recipeWrapper;
-
+	public void setRecipe(@Nonnull IRecipeLayout recipeLayout, @Nonnull RunicAltarRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
 		recipeLayout.getItemStacks().init(0, true, 64, 52);
 		recipeLayout.getItemStacks().set(0, new ItemStack(ModBlocks.runeAltar));
 
 		int index = 1;
-		double angleBetweenEach = 360.0 / ingredients.getInputs(ItemStack.class).size();
+		double angleBetweenEach = 360.0 / ingredients.getInputs(VanillaTypes.ITEM).size();
 		Point point = new Point(64, 20), center = new Point(64, 52);
 
-		for(List<ItemStack> o : ingredients.getInputs(ItemStack.class)) {
+		for(List<ItemStack> o : ingredients.getInputs(VanillaTypes.ITEM)) {
 			recipeLayout.getItemStacks().init(index, true, point.x, point.y);
 			recipeLayout.getItemStacks().set(index, o);
 			index += 1;
@@ -90,7 +84,7 @@ public class RunicAltarRecipeCategory implements IRecipeCategory {
 		}
 
 		recipeLayout.getItemStacks().init(index, false, 103, 17);
-		recipeLayout.getItemStacks().set(index, ingredients.getOutputs(ItemStack.class).get(0));
+		recipeLayout.getItemStacks().set(index, ingredients.getOutputs(VanillaTypes.ITEM).get(0));
 
 	}
 
@@ -106,5 +100,5 @@ public class RunicAltarRecipeCategory implements IRecipeCategory {
 	public String getModName() {
 		return LibMisc.MOD_NAME;
 	}
-	
+
 }

--- a/src/main/java/vazkii/botania/client/integration/jei/runicaltar/RunicAltarRecipeWrapper.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/runicaltar/RunicAltarRecipeWrapper.java
@@ -10,6 +10,7 @@ package vazkii.botania.client.integration.jei.runicaltar;
 
 import com.google.common.collect.ImmutableList;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
@@ -28,7 +29,6 @@ public class RunicAltarRecipeWrapper implements IRecipeWrapper {
 	private final ItemStack output;
 	private final int manaUsage;
 
-	@SuppressWarnings("unchecked")
 	public RunicAltarRecipeWrapper(RecipeRuneAltar recipe) {
 		ImmutableList.Builder<List<ItemStack>> builder = ImmutableList.builder();
 		for(Object o : recipe.getInputs()) {
@@ -46,8 +46,8 @@ public class RunicAltarRecipeWrapper implements IRecipeWrapper {
 
 	@Override
 	public void getIngredients(@Nonnull IIngredients ingredients) {
-		ingredients.setInputLists(ItemStack.class, input);
-		ingredients.setOutput(ItemStack.class, output);
+		ingredients.setInputLists(VanillaTypes.ITEM, input);
+		ingredients.setOutput(VanillaTypes.ITEM, output);
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/item/block/ItemBlockSpecialFlower.java
+++ b/src/main/java/vazkii/botania/common/item/block/ItemBlockSpecialFlower.java
@@ -114,6 +114,7 @@ public class ItemBlockSpecialFlower extends ItemBlockMod implements IRecipeKeyPr
 		return LibMisc.MOD_ID;
 	}
 
+	@Nonnull
 	public static String getType(ItemStack stack) {
 		return stack.hasTagCompound() ? ItemNBTHelper.getString(stack, SubTileEntity.TAG_TYPE, "") : "";
 	}


### PR DESCRIPTION
* Clean up all the deprecation and other compiler warnings in the plugin
* Fix indentation in the orechid JEI stuff
* Add wrappers for: terra shatterer tipping, composite lens combining, ancient will applying (see #1874)
* Hide elven trades that result in giving the same item back