### PR TITLE
Change how NBT matching works, now it's faster and works better with nested tags

### DIFF
--- a/src/main/java/vazkii/botania/api/recipe/RecipePetals.java
+++ b/src/main/java/vazkii/botania/api/recipe/RecipePetals.java
@@ -15,6 +15,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.oredict.OreDictionary;
+import vazkii.botania.common.core.helper.ItemNBTHelper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -79,19 +80,7 @@ public class RecipePetals {
 	}
 
 	private boolean compareStacks(ItemStack recipe, ItemStack supplied) {
-		if(recipe.getItem() == supplied.getItem() && recipe.getItemDamage() == supplied.getItemDamage()) {
-			//check that the user supplied nbt tag is a superset of the recipe item nbt tag
-			//if the recipe doesn't have an NBT tag, the user supplied one doesn't matter, it is a superset
-			if(!recipe.hasTagCompound()) return true;
-			//if the recipe does have an NBT tag but the user supplied doesn't, also no way it's a superset
-			if(!supplied.hasTagCompound()) return false;
-			
-			NBTTagCompound mergedNBT = supplied.getTagCompound().copy();
-			mergedNBT.merge(recipe.getTagCompound());
-			return supplied.getTagCompound().equals(mergedNBT);
-		}
-		
-		return false;
+		return recipe.getItem() == supplied.getItem() && recipe.getItemDamage() == supplied.getItemDamage() && ItemNBTHelper.isTagSubset(recipe.getTagCompound(), supplied.getTagCompound());
 	}
 
 	public List<Object> getInputs() {

--- a/src/main/java/vazkii/botania/common/core/helper/ItemNBTHelper.java
+++ b/src/main/java/vazkii/botania/common/core/helper/ItemNBTHelper.java
@@ -14,8 +14,11 @@
 package vazkii.botania.common.core.helper;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+
+import javax.annotation.Nullable;
 
 public final class ItemNBTHelper {
 
@@ -132,4 +135,36 @@ public final class ItemNBTHelper {
 		return verifyExistance(stack, tag) ? getNBT(stack).getTagList(tag, objtype) : nullifyOnFail ? null : new NBTTagList();
 	}
 
+	/**
+	 * Checks that one tag is a subset of another - that is, it's ok if the superset has more NBT keys than the subset, but the subset has to have at least all the same keys as the superset, and the values of the keys that *are* shared between the two must match.
+	 * 
+	 * This is useful when, e.g. matching NBT tags in recipes.
+	 */
+	public static boolean isTagSubset(@Nullable NBTTagCompound subset, @Nullable NBTTagCompound superset) {
+		//an empty set is a subset of everything
+		if(subset == null || subset.isEmpty()) return true;
+		//an empty set is a superset of only another empty set (which was already checked above)
+		if(superset == null || superset.isEmpty()) return false;
+		//a subset can't be bigger than its superset
+		if(subset.getKeySet().size() > superset.getKeySet().size()) return false;
+		
+		//it's not an easy case, so we actually have to check the contents of each tag
+		for(String key : superset.getKeySet()) {
+			//it's ok if the subset is missing a key from the superset
+			if(!subset.hasKey(key)) continue;
+			
+			NBTBase supersetEntry = superset.getTag(key);
+			NBTBase subsetEntry = subset.getTag(key);
+			
+			//if a value is present on both tags, but they do not match, fail
+			if(supersetEntry instanceof NBTTagCompound && subsetEntry instanceof NBTTagCompound) {
+				//recurse into tag compounds (this properly compares nested tag compounds)
+				if(!isTagSubset((NBTTagCompound) subsetEntry, (NBTTagCompound) supersetEntry)) return false;
+			} else {
+				if(!supersetEntry.equals(subsetEntry)) return false;
+			}
+		}
+		
+		return true;
+	}
 }


### PR DESCRIPTION
This is an upstream fix of this issue in Botania Tweaks: https://github.com/quat1024/BotaniaTweaks/issues/42

The idea is that when an item has an NBT tag in a recipe, items must have *at least* those NBT tags. In other words, the NBT tag on the recipe item has to be a subset of the NBT tag on whatever item the player throws in. This makes it ok to not specify *all* the nbt tags *ever* on an item when writing recipes, which is what players would expect anyways.

However, previously this did not work properly with nested tags. An item with a tag like `{out:{in:1,extra:2}}` would match a recipe with a tag like `{}`, but would not match `{out:{in:1}}`. This creates problems when trying to create recipes for items with lots of weirdly structured NBT data (the use case in the original issue is bees lol `oof`)

I broke this code out into a separate function, too, so I can call it from btweaks next time we both update, and stop duplicating it.