### PR TITLE
Flip hopperhock inventory sidedness

### DIFF
--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileHopperhock.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileHopperhock.java
@@ -79,7 +79,7 @@ public class SubTileHopperhock extends SubTileFunctional {
 			for(EnumFacing dir : EnumFacing.VALUES) {
 				BlockPos pos_ = pos.offset(dir);
 
-				InvWithLocation inv = InventoryHelper.getInventoryWithLocation(supertile.getWorld(), pos_, dir);
+				InvWithLocation inv = InventoryHelper.getInventoryWithLocation(supertile.getWorld(), pos_, dir.getOpposite());
 				if(inv != null) {
 					List<ItemStack> filter = getFilterForInventory(pos_, true);
 					boolean canAccept = canAcceptItem(stack, filter, filterType);


### PR DESCRIPTION
Hopperhocks now access the inventory on e.g. the east face of the block to their west, instead of the west face of the block to their west.

This closes #2838.