### PR TITLE
Some stuff involving special grasses

### DIFF
--- a/src/main/java/vazkii/botania/common/block/BlockAltGrass.java
+++ b/src/main/java/vazkii/botania/common/block/BlockAltGrass.java
@@ -11,6 +11,7 @@
 package vazkii.botania.common.block;
 
 import net.minecraft.block.BlockDirt;
+import net.minecraft.block.BlockStem;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.BlockStateContainer;
@@ -111,7 +112,7 @@ public class BlockAltGrass extends BlockMod implements ILexiconable {
 	@Override
 	public boolean canSustainPlant(@Nonnull IBlockState state, @Nonnull IBlockAccess world, BlockPos pos, @Nonnull EnumFacing direction, IPlantable plantable) {
 		EnumPlantType type = plantable.getPlantType(world, pos.down());
-		return type == EnumPlantType.Plains || type == EnumPlantType.Beach;
+		return type == EnumPlantType.Plains || type == EnumPlantType.Beach || plantable instanceof BlockStem;
 	}
 
 	@SideOnly(Side.CLIENT)

--- a/src/main/java/vazkii/botania/common/block/BlockAltGrass.java
+++ b/src/main/java/vazkii/botania/common/block/BlockAltGrass.java
@@ -20,8 +20,10 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemHoe;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
@@ -81,7 +83,19 @@ public class BlockAltGrass extends BlockMod implements ILexiconable {
 		for(int i = 0; i < 6; i++)
 			list.add(new ItemStack(this, 1, i));
 	}
-
+	
+	@Override
+	public boolean onBlockActivated(World world, BlockPos pos, IBlockState state, EntityPlayer player, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) {
+		ItemStack held = player.getHeldItem(hand);
+		if(held.getItem() instanceof ItemHoe && world.isAirBlock(pos.up())) {
+			held.damageItem(1, player);
+			world.setBlockState(pos, Blocks.FARMLAND.getDefaultState(), 1 | 2);
+			return true;
+		}
+		
+		return false;
+	}
+	
 	@Override
 	public void updateTick(World world, BlockPos pos, IBlockState state, Random rand) {
 		if(!world.isRemote && state.getBlock() == this && world.getLight(pos.up()) >= 9) {


### PR DESCRIPTION
- Fixes #2812 by special-casing stems. (I can't just check the `IPlantable` since melon/pumpkin stems and regular crops both have the `Crop` plant type, and you'd be able to plant seeds on special grass etc.)

- You can use a hoe on special grass to till it into farmland. (This is a less jank upstream merge of a [Botania Tweaks feature](https://github.com/quat1024/BotaniaTweaks/blob/master/src/main/java/quaternary/botaniatweaks/modules/botania/handler/TillAltGrassHandler.java)).