### PR TITLE
Fix static model floating flowers crashing on moving with Quark's pistons, fix pasture seed effects not showing immediately

### DIFF
--- a/src/main/java/vazkii/botania/client/model/FloatingFlowerModel.java
+++ b/src/main/java/vazkii/botania/client/model/FloatingFlowerModel.java
@@ -105,6 +105,11 @@ public class FloatingFlowerModel implements IBakedModel {
 	private CompositeBakedModel getModel(IFloatingFlower.IslandType islandType, String identifier) {
 		ModelManager modelManager = Minecraft.getMinecraft().getRenderItem().getItemModelMesher().getModelManager();
 
+		if(islandType == null) // This and the next one can be null if obtained from a non-extended state
+			islandType = IFloatingFlower.IslandType.GRASS;
+		if(identifier == null)
+			identifier = "";
+
 		if(CACHE.contains(islandType, identifier)) {
 			return CACHE.get(islandType, identifier);
 		} else {

--- a/src/main/java/vazkii/botania/common/block/tile/TileFloatingFlower.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileFloatingFlower.java
@@ -13,6 +13,8 @@ package vazkii.botania.common.block.tile;
 import net.minecraft.item.EnumDyeColor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import vazkii.botania.api.item.IFloatingFlower;
 import vazkii.botania.api.state.BotaniaStateProps;
 import vazkii.botania.common.block.ModBlocks;
@@ -21,7 +23,7 @@ public class TileFloatingFlower extends TileMod implements IFloatingFlower {
 
 	public static final String TAG_ISLAND_TYPE = "islandType";
 	public static ItemStack forcedStack = ItemStack.EMPTY;
-	IslandType type = IslandType.GRASS;
+	private IslandType type = IslandType.GRASS;
 
 	@Override
 	public ItemStack getDisplayStack() {
@@ -33,6 +35,15 @@ public class TileFloatingFlower extends TileMod implements IFloatingFlower {
 		EnumDyeColor color = world.getBlockState(getPos()).getBlock() != ModBlocks.floatingFlower ? EnumDyeColor.WHITE
 				: world.getBlockState(getPos()).getValue(BotaniaStateProps.COLOR);
 		return new ItemStack(ModBlocks.shinyFlower, 1, color.getMetadata());
+	}
+
+	@Override
+	public void onDataPacket(NetworkManager net, SPacketUpdateTileEntity packet) {
+		IslandType oldType = getIslandType();
+		super.onDataPacket(net, packet);
+		if(oldType != getIslandType()) {
+			world.markBlockRangeForRenderUpdate(pos, pos);
+		}
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/tile/TileFloatingSpecialFlower.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileFloatingSpecialFlower.java
@@ -12,13 +12,15 @@ package vazkii.botania.common.block.tile;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import vazkii.botania.api.item.IFloatingFlower;
 import vazkii.botania.common.item.block.ItemBlockSpecialFlower;
 
 public class TileFloatingSpecialFlower extends TileSpecialFlower implements IFloatingFlower {
 
 	public static final String TAG_ISLAND_TYPE = "islandType";
-	IslandType type = IslandType.GRASS;
+	private IslandType type = IslandType.GRASS;
 
 	@Override
 	public boolean isOnSpecialSoil() {
@@ -44,6 +46,15 @@ public class TileFloatingSpecialFlower extends TileSpecialFlower implements IFlo
 	public void writePacketNBT(NBTTagCompound cmp) {
 		super.writePacketNBT(cmp);
 		cmp.setString(TAG_ISLAND_TYPE, type.toString());
+	}
+
+	@Override
+	public void onDataPacket(NetworkManager net, SPacketUpdateTileEntity packet) {
+		IslandType oldType = getIslandType();
+		super.onDataPacket(net, packet);
+		if(oldType != getIslandType()) {
+			world.markBlockRangeForRenderUpdate(pos, pos);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
* First commit fixes #2844. Piston rendering uses the normal block state directly instead of the extended one, which causes the island type and the flower type properties to be null, and the table used for caching does not accept nulls causing NPEs. Moving flowers will render as if they were always on normal grass, with the placeholder flower for special ones.
* Second commit fixes something I noticed during testing this bug - applying a pasture seed to a static model flower will not show the change until the chunk section is updated. Done in basically the same manner as the petal apothecary vines.