### PR TITLE
Add corporea crystal cube locking

### DIFF
--- a/src/main/java/vazkii/botania/client/core/handler/HUDHandler.java
+++ b/src/main/java/vazkii/botania/client/core/handler/HUDHandler.java
@@ -141,16 +141,17 @@ public final class HUDHandler {
 						}
 					} else if(block != null && PlayerHelper.hasHeldItemClass(mc.player, ILexicon.class))
 						drawLexiconHUD(PlayerHelper.getFirstHeldItemClass(mc.player, ILexicon.class), state, pos, event.getResolution());
-					if(tile != null && tile instanceof TilePool && !mc.player.getHeldItemMainhand().isEmpty())
+					if(tile instanceof TilePool && !mc.player.getHeldItemMainhand().isEmpty())
 						renderPoolRecipeHUD(event.getResolution(), (TilePool) tile, mc.player.getHeldItemMainhand());
 				}
-				if(tile != null && tile instanceof TileAltar)
-					((TileAltar) tile).renderHUD(mc, event.getResolution());
-				else if(tile != null && tile instanceof TileRuneAltar)
-					((TileRuneAltar) tile).renderHUD(mc, event.getResolution());
-
-				if(tile != null && tile instanceof TileCorporeaCrystalCube)
-					renderCrystalCubeHUD(event.getResolution(), (TileCorporeaCrystalCube) tile);
+				if(!PlayerHelper.hasHeldItemClass(mc.player, ILexicon.class)) {
+					if(tile instanceof TileAltar)
+						((TileAltar) tile).renderHUD(mc, event.getResolution());
+					else if(tile instanceof TileRuneAltar)
+						((TileRuneAltar) tile).renderHUD(mc, event.getResolution());
+					else if(tile instanceof TileCorporeaCrystalCube)
+						renderCrystalCubeHUD(event.getResolution(), (TileCorporeaCrystalCube) tile);
+				}
 			}
 
 			TileCorporeaIndex.getInputHandler();

--- a/src/main/java/vazkii/botania/client/core/handler/HUDHandler.java
+++ b/src/main/java/vazkii/botania/client/core/handler/HUDHandler.java
@@ -356,11 +356,14 @@ public final class HUDHandler {
 			int strlen = Math.max(mc.fontRenderer.getStringWidth(s1), mc.fontRenderer.getStringWidth(s2));
 			int w = res.getScaledWidth();
 			int h = res.getScaledHeight();
-			Gui.drawRect(w / 2 + 8, h / 2 - 12, w / 2 + strlen + 32, h / 2 + 10, 0x44000000);
-			Gui.drawRect(w / 2 + 6, h / 2 - 14, w / 2 + strlen + 34, h / 2 + 12, 0x44000000);
+			int boxH = h / 2 + (tile.locked ? 20 : 10);
+			Gui.drawRect(w / 2 + 8, h / 2 - 12, w / 2 + strlen + 32, boxH, 0x44000000);
+			Gui.drawRect(w / 2 + 6, h / 2 - 14, w / 2 + strlen + 34, boxH + 2, 0x44000000);
 
 			mc.fontRenderer.drawStringWithShadow(target.getDisplayName(), w / 2 + 30, h / 2 - 10, 0x6666FF);
 			mc.fontRenderer.drawStringWithShadow(tile.getItemCount() + "x", w / 2 + 30, h / 2, 0xFFFFFF);
+			if(tile.locked)
+				mc.fontRenderer.drawStringWithShadow(I18n.format("botaniamisc.locked"), w / 2 + 30, h / 2 + 10, 0xFFAA00);
 			net.minecraft.client.renderer.RenderHelper.enableGUIStandardItemLighting();
 			GlStateManager.enableRescaleNormal();
 			mc.getRenderItem().renderItemAndEffectIntoGUI(target, w / 2 + 10, h / 2 - 10);

--- a/src/main/java/vazkii/botania/common/block/BlockHourglass.java
+++ b/src/main/java/vazkii/botania/common/block/BlockHourglass.java
@@ -36,6 +36,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.ItemHandlerHelper;
 import vazkii.botania.api.internal.IManaBurst;
+import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.api.lexicon.ILexiconable;
 import vazkii.botania.api.lexicon.LexiconEntry;
 import vazkii.botania.api.mana.IManaTrigger;
@@ -185,7 +186,9 @@ public class BlockHourglass extends BlockMod implements IManaTrigger, IWandable,
 	public boolean onUsedByWand(EntityPlayer player, ItemStack stack, World world, BlockPos pos, EnumFacing side) {
 		TileHourglass tile = (TileHourglass) world.getTileEntity(pos);
 		tile.lock = !tile.lock;
-		return false;
+		if(!world.isRemote)
+			VanillaPacketDispatcher.dispatchTEToNearbyPlayers(tile);
+		return true;
 	}
 
 	@SideOnly(Side.CLIENT)

--- a/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaCrystalCube.java
+++ b/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaCrystalCube.java
@@ -10,6 +10,8 @@
  */
 package vazkii.botania.common.block.corporea;
 
+import javax.annotation.Nonnull;
+
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
@@ -23,6 +25,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.client.ForgeHooksClient;
@@ -31,17 +34,18 @@ import net.minecraftforge.common.property.IUnlistedProperty;
 import net.minecraftforge.common.property.Properties;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.api.lexicon.ILexiconable;
 import vazkii.botania.api.lexicon.LexiconEntry;
+import vazkii.botania.api.wand.IWandable;
 import vazkii.botania.client.core.handler.ModelHandler;
 import vazkii.botania.common.block.tile.corporea.TileCorporeaBase;
 import vazkii.botania.common.block.tile.corporea.TileCorporeaCrystalCube;
+import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.lexicon.LexiconData;
 import vazkii.botania.common.lib.LibBlockNames;
 
-import javax.annotation.Nonnull;
-
-public class BlockCorporeaCrystalCube extends BlockCorporeaBase implements ILexiconable {
+public class BlockCorporeaCrystalCube extends BlockCorporeaBase implements ILexiconable, IWandable {
 
 	private static final AxisAlignedBB AABB = new AxisAlignedBB(3.0/16, 0, 3.0/16, 13.0/16, 1, 13.0/16);
 
@@ -93,8 +97,26 @@ public class BlockCorporeaCrystalCube extends BlockCorporeaBase implements ILexi
 	public boolean onBlockActivated(World world, BlockPos pos, IBlockState state, EntityPlayer player, EnumHand hand, EnumFacing s, float xs, float ys, float zs) {
 		ItemStack stack = player.getHeldItem(hand);
 		if(!stack.isEmpty()) {
+			if(stack.getItem() == ModItems.twigWand && player.isSneaking())
+				return false;
 			TileCorporeaCrystalCube cube = (TileCorporeaCrystalCube) world.getTileEntity(pos);
-			cube.setRequestTarget(stack);
+			if(cube.locked) {
+				if(!world.isRemote)
+					player.sendStatusMessage(new TextComponentTranslation("botaniamisc.crystalCubeLocked"), false);
+			} else
+				cube.setRequestTarget(stack);
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean onUsedByWand(EntityPlayer player, ItemStack stack, World world, BlockPos pos, EnumFacing side) {
+		if(player == null || player.isSneaking()) {
+			TileCorporeaCrystalCube cube = (TileCorporeaCrystalCube) world.getTileEntity(pos);
+			cube.locked = !cube.locked;
+			if(!world.isRemote)
+				VanillaPacketDispatcher.dispatchTEToNearbyPlayers(cube);
 			return true;
 		}
 		return false;
@@ -143,5 +165,4 @@ public class BlockCorporeaCrystalCube extends BlockCorporeaBase implements ILexi
 		ModelHandler.registerInventoryVariant(this);
 		ForgeHooksClient.registerTESRItemStack(Item.getItemFromBlock(this), 0, TileCorporeaCrystalCube.class);
 	}
-
 }

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaCrystalCube.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaCrystalCube.java
@@ -35,13 +35,13 @@ public class TileCorporeaCrystalCube extends TileCorporeaBase implements ICorpor
 
 	private static final String TAG_REQUEST_TARGET = "requestTarget";
 	private static final String TAG_ITEM_COUNT = "itemCount";
+	private static final String TAG_LOCK = "lock";
 
-	private static final double LOG_2 = Math.log(2);
-
-	ItemStack requestTarget = ItemStack.EMPTY;
-	int itemCount = 0;
-	int ticks = 0;
-	int compValue = 0;
+	private ItemStack requestTarget = ItemStack.EMPTY;
+	private int itemCount = 0;
+	private int ticks = 0;
+	private int compValue = 0;
+	public boolean locked = false;
 
 	private final IAnimationStateMachine asm;
 
@@ -61,7 +61,7 @@ public class TileCorporeaCrystalCube extends TileCorporeaBase implements ICorpor
 	}
 
 	public void setRequestTarget(ItemStack stack) {
-		if(!stack.isEmpty()) {
+		if(!stack.isEmpty() && !locked) {
 			ItemStack copy = stack.copy();
 			copy.setCount(1);
 			requestTarget = copy;
@@ -125,6 +125,7 @@ public class TileCorporeaCrystalCube extends TileCorporeaBase implements ICorpor
 			cmp = requestTarget.writeToNBT(cmp);
 		par1nbtTagCompound.setTag(TAG_REQUEST_TARGET, cmp);
 		par1nbtTagCompound.setInteger(TAG_ITEM_COUNT, itemCount);
+		par1nbtTagCompound.setBoolean(TAG_LOCK, locked);
 	}
 
 	@Override
@@ -133,6 +134,7 @@ public class TileCorporeaCrystalCube extends TileCorporeaBase implements ICorpor
 		NBTTagCompound cmp = par1nbtTagCompound.getCompoundTag(TAG_REQUEST_TARGET);
 		requestTarget = new ItemStack(cmp);
 		itemCount = par1nbtTagCompound.getInteger(TAG_ITEM_COUNT);
+		locked = par1nbtTagCompound.getBoolean(TAG_LOCK);
 	}
 
 	public int getComparatorValue() {

--- a/src/main/java/vazkii/botania/common/lexicon/LexiconData.java
+++ b/src/main/java/vazkii/botania/common/lexicon/LexiconData.java
@@ -1118,7 +1118,7 @@ public final class LexiconData {
 				new PageCraftingRecipe("3", ModCraftingRecipes.recipeBlackHoleTalisman));
 
 		corporeaCrystalCube = new AlfheimLexiconEntry(LibLexicon.ENDER_CORPOREA_CRYSTAL_CUBE, categoryEnder);
-		corporeaCrystalCube.setLexiconPages(new PageText("0"), new PageText("1"), new PageText("3"),
+		corporeaCrystalCube.setLexiconPages(new PageText("0"), new PageText("1"), new PageText("3"), new PageText("4"),
 				new PageCraftingRecipe("2", ModCraftingRecipes.recipeCorporeaCrystalCube));
 
 		luminizerTransport = new AlfheimLexiconEntry(LibLexicon.ENDER_LUMINIZER_TRANSPORT, categoryEnder);

--- a/src/main/resources/assets/botania/lang/en_us.lang
+++ b/src/main/resources/assets/botania/lang/en_us.lang
@@ -119,6 +119,7 @@ botaniamisc.inactive=&cInactive
 botaniamisc.advancements=Botania Advancements
 botaniamisc.dropIkea=&bDropping this item will break it down into its components
 botaniamisc.hourglassLock=This Hourglass is locked. Right click it with a Wand of the Forest to unlock it.
+botaniamisc.crystalCubeLocked=This Crystal Cube is locked. To change the displayed item, unlock it with a Wand of the Forest.
 botaniamisc.locked=Locked
 botaniamisc.stopped=Stopped
 botaniamisc.lockedStopped=Locked, Stopped
@@ -3292,6 +3293,7 @@ botania.tagline.corporeaCrystalCube=View and request items from a Corporea netwo
 botania.page.corporeaCrystalCube0=A seer usually looks through a crystal ball to see the future. Well, a corporea handler would look through a crystal cube to see the present. The &1Corporea Crystal Cube&0 acts as a visual medium to interact ith one's &4Corporea Network&0. Placing the block down and giving it a &1Corporea Spark&0 is the obvious first step to hooking it up to the network.
 botania.page.corporeaCrystalCube1=When the block is connected, right clicking it with any sort of item will have it monitor that item, allowing someone who's looking at it see how many exist in the network. The display updates about once every second.<br>While there's an item selected, left clicking the block will request one of that item from the network. Shift-left clicking requests a whole stack.
 botania.page.corporeaCrystalCube3=The &1Corporea Crystal Cube&0 can be used alongside a &1Redstone Comparator&0. This will output the amount of items of the type it's looking for in the system. The output value follows a logarithmic progression, or on layman's terms, every level requires twice as many of the item as the previous one, starting at 1. 0 items would be signal 0. 1 item for 1, 2 items for 2, 4 items for 3, 8 items for 4, 16 items for 5 and so on up to 15.
+botania.page.corporeaCrystalCube4=Right clicking on the block with a &1Wand of the Forest&0 while sneaking locks (and unlocks) it, similarly to the &1Hovering Hourglass&0. When locked, the monitored item can't be changed, just in case someone right clicks it on accident.
 botania.page.corporeaCrystalCube2=I can see forever
 
 # -- CORPOREA RETAINER


### PR DESCRIPTION
![obraz](https://user-images.githubusercontent.com/26120076/52733392-e5f96b00-2fc2-11e9-8951-eae5ed7385ac.png)

This PR adds locking of Corporea Crystal Cubes, modeled after the Hovering Hourglass lock.
* Sneak-using a Wand of the Forest on a crystal cube will lock the monitored item, preventing players from accidentally setting it to something else. Lexicon entry page included. This is shown on the contents render and sends a chat message to the player if they attempt to set it when locked. Locking can be done with dispensers, I made sure it properly syncs to players in that case.
  * Withdrawing items is not affected by the lock, in case that wasn't clear.
  * Why sneak-using and not just using the wand like the hourglass? Sooner or later someone will complain they can't put the wands there.
* Rendering of the overlay for runic altars, petal apothecaries and crystal cubes is disabled if someone is pointing a Lexica Botania at them. It looked pretty bad with overlapping stuff.
* Applied the same sync fix to the hourglass because dispensers pointed at the hourglass ended up desyncing that as well, making you think you can take out the sand when you can't. Yes I know it's very very very very useful to have a dispenser lock a hourglass on a timer.

How the render looks:
![obraz](https://user-images.githubusercontent.com/26120076/52733376-df6af380-2fc2-11e9-8a12-2c50d8df9e08.png)
