### PR TITLE
Use available baubles API methods when checking for rings instead of custom made ones

### DIFF
--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemDodgeRing.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemDodgeRing.java
@@ -20,8 +20,6 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.MathHelper;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.InputEvent.KeyInputEvent;
@@ -31,6 +29,7 @@ import net.minecraftforge.items.IItemHandler;
 import vazkii.botania.client.core.handler.ClientTickHandler;
 import vazkii.botania.common.core.helper.ItemNBTHelper;
 import vazkii.botania.common.core.helper.Vector3;
+import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.lib.LibItemNames;
 import vazkii.botania.common.lib.LibMisc;
 import vazkii.botania.common.network.PacketDodge;
@@ -55,13 +54,11 @@ public class ItemDodgeRing extends ItemBauble {
 		Minecraft mc = Minecraft.getMinecraft();
 
 		IItemHandler baublesInv = BaublesApi.getBaublesHandler(mc.player);
-		ItemStack ringStack = baublesInv.getStackInSlot(1);
-		if(ringStack.isEmpty() || !(ringStack.getItem() instanceof ItemDodgeRing)) {
-			ringStack = baublesInv.getStackInSlot(2);
-			if(ringStack.isEmpty() || !(ringStack.getItem() instanceof ItemDodgeRing))
+		int slot = BaublesApi.isBaubleEquipped(mc.player, ModItems.dodgeRing);
+		if(slot < 0) {
 				return;
 		}
-
+		ItemStack ringStack = baublesInv.getStackInSlot(slot);
 		if(ItemNBTHelper.getInt(ringStack, TAG_DODGE_COOLDOWN, 0) > 0)
 			return;
 

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/terrasteel/ItemTerraPick.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/terrasteel/ItemTerraPick.java
@@ -170,7 +170,7 @@ public class ItemTerraPick extends ItemManasteelPick implements IManaItem, ISequ
 
 		int fortune = EnchantmentHelper.getEnchantmentLevel(Enchantments.FORTUNE, stack);
 		boolean silk = EnchantmentHelper.getEnchantmentLevel(Enchantments.SILK_TOUCH, stack) > 0;
-		boolean thor = ItemThorRing.getThorRing(player) != null;
+		boolean thor = !ItemThorRing.getThorRing(player).isEmpty();
 		boolean doX = thor || side.getXOffset() == 0;
 		boolean doY = thor || side.getYOffset() == 0;
 		boolean doZ = thor || side.getZOffset() == 0;

--- a/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
+++ b/src/main/java/vazkii/botania/common/item/relic/ItemLokiRing.java
@@ -10,15 +10,17 @@
  */
 package vazkii.botania.common.item.relic;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
 import baubles.api.BaubleType;
 import baubles.api.BaublesApi;
-import com.google.common.collect.ImmutableList;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
-import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.init.Enchantments;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -27,7 +29,6 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
-import net.minecraft.world.World;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -44,10 +45,6 @@ import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.equipment.tool.ToolCommons;
 import vazkii.botania.common.lib.LibItemNames;
 import vazkii.botania.common.lib.LibMisc;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 @Mod.EventBusSubscriber(modid = LibMisc.MOD_ID)
 public class ItemLokiRing extends ItemRelicBauble implements IWireframeCoordinateListProvider, IManaUsingItem {
@@ -198,14 +195,13 @@ public class ItemLokiRing extends ItemRelicBauble implements IWireframeCoordinat
 
 	private static ItemStack getLokiRing(EntityPlayer player) {
 		IItemHandler baubles = BaublesApi.getBaublesHandler(player);
-		ItemStack stack1 = baubles.getStackInSlot(1);
-		ItemStack stack2 = baubles.getStackInSlot(2);
-		return isLokiRing(stack1) ? stack1 : isLokiRing(stack2) ? stack2 : ItemStack.EMPTY;
+		int slot = BaublesApi.isBaubleEquipped(player, ModItems.lokiRing);
+		if (slot < 0) {
+			return ItemStack.EMPTY;
+		}
+		return baubles.getStackInSlot(slot);
 	}
 
-	private static boolean isLokiRing(ItemStack stack) {
-		return !stack.isEmpty() && stack.getItem() == ModItems.lokiRing;
-	}
 
 	private static BlockPos getOriginPos(ItemStack stack) {
 		int x = ItemNBTHelper.getInt(stack, TAG_X_ORIGIN, 0);

--- a/src/main/java/vazkii/botania/common/item/relic/ItemOdinRing.java
+++ b/src/main/java/vazkii/botania/common/item/relic/ItemOdinRing.java
@@ -64,7 +64,7 @@ public class ItemOdinRing extends ItemRelicBauble {
 	public static void onPlayerAttacked(LivingAttackEvent event) {
 		if(event.getEntityLiving() instanceof EntityPlayer) {
 			EntityPlayer player = (EntityPlayer) event.getEntityLiving();
-			if(getOdinRing(player) != null && damageNegations.contains(event.getSource().damageType))
+			if(!getOdinRing(player).isEmpty() && damageNegations.contains(event.getSource().damageType))
 				event.setCanceled(true);
 		}
 	}
@@ -76,13 +76,11 @@ public class ItemOdinRing extends ItemRelicBauble {
 
 	public static ItemStack getOdinRing(EntityPlayer player) {
 		IItemHandler baubles = BaublesApi.getBaublesHandler(player);
-		ItemStack stack1 = baubles.getStackInSlot(1);
-		ItemStack stack2 = baubles.getStackInSlot(2);
-		return isOdinRing(stack1) ? stack1 : isOdinRing(stack2) ? stack2 : null;
-	}
-
-	private static boolean isOdinRing(ItemStack stack) {
-		return !stack.isEmpty() && stack.getItem() == ModItems.odinRing;
+		int slot = BaublesApi.isBaubleEquipped(player, ModItems.odinRing);
+		if (slot < 0) {
+			return ItemStack.EMPTY;
+		}
+		return baubles.getStackInSlot(slot);
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/item/relic/ItemThorRing.java
+++ b/src/main/java/vazkii/botania/common/item/relic/ItemThorRing.java
@@ -38,13 +38,10 @@ public class ItemThorRing extends ItemRelicBauble {
 
 	public static ItemStack getThorRing(EntityPlayer player) {
 		IItemHandler baubles = BaublesApi.getBaublesHandler(player);
-		ItemStack stack1 = baubles.getStackInSlot(1);
-		ItemStack stack2 = baubles.getStackInSlot(2);
-		return isThorRing(stack1) ? stack1 : isThorRing(stack2) ? stack2 : null;
+		int slot = BaublesApi.isBaubleEquipped(player, ModItems.thorRing);
+		if (slot < 0) {
+			return ItemStack.EMPTY;
+		}
+		return baubles.getStackInSlot(slot);
 	}
-
-	private static boolean isThorRing(ItemStack stack) {
-		return !stack.isEmpty() && stack.getItem() == ModItems.thorRing;
-	}
-
 }

--- a/src/main/java/vazkii/botania/common/network/PacketDodge.java
+++ b/src/main/java/vazkii/botania/common/network/PacketDodge.java
@@ -15,7 +15,6 @@ import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.SoundCategory;
-import net.minecraft.util.text.TextComponentString;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
@@ -23,6 +22,7 @@ import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 import net.minecraftforge.items.IItemHandler;
 import vazkii.botania.common.core.handler.ModSounds;
 import vazkii.botania.common.core.helper.ItemNBTHelper;
+import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.equipment.bauble.ItemDodgeRing;
 
 public class PacketDodge implements IMessage {
@@ -40,16 +40,13 @@ public class PacketDodge implements IMessage {
 			EntityPlayerMP player = ctx.getServerHandler().player;
 			player.server.addScheduledTask(() -> {
 				player.world.playSound(null, player.posX, player.posY, player.posZ, ModSounds.dash, SoundCategory.PLAYERS, 1F, 1F);
-
 				IItemHandler baublesInv = BaublesApi.getBaublesHandler(player);
-				ItemStack ringStack = baublesInv.getStackInSlot(1);
-				if(ringStack.isEmpty() || !(ringStack.getItem() instanceof ItemDodgeRing)) {
-					ringStack = baublesInv.getStackInSlot(2);
-					if(ringStack.isEmpty() || !(ringStack.getItem() instanceof ItemDodgeRing))
-						ctx.getServerHandler().disconnect(new TextComponentTranslation("botaniamisc.invalidDodge"));
+				int slot = BaublesApi.isBaubleEquipped(player, ModItems.dodgeRing);
+				if(slot < 0) {
+					ctx.getServerHandler().disconnect(new TextComponentTranslation("botaniamisc.invalidDodge"));
 					return;
 				}
-
+				ItemStack ringStack = baublesInv.getStackInSlot(slot);
 				player.addExhaustion(0.3F);
 				ItemNBTHelper.setInt(ringStack, ItemDodgeRing.TAG_DODGE_COOLDOWN, ItemDodgeRing.MAX_CD);
 			});


### PR DESCRIPTION
Allows compatibility with Bring Me The Rings, that changes the number of native ring slots.