### PR TITLE
Fix corporea interceptor causing wrong count on index requests

### DIFF
--- a/src/main/java/vazkii/botania/api/corporea/CorporeaHelper.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaHelper.java
@@ -194,11 +194,11 @@ public final class CorporeaHelper {
 			}
 		}
 
-		lastRequestMatches = request.foundItems;
-		lastRequestExtractions = request.extractedItems;
-
 		for(ICorporeaInterceptor interceptor : interceptors.keySet())
 			interceptor.interceptRequestLast(matcher, itemCount, interceptors.get(interceptor), spark, stacks, inventories, doit);
+
+		lastRequestMatches = request.foundItems;
+		lastRequestExtractions = request.extractedItems;
 
 		return stacks;
 	}


### PR DESCRIPTION
If the interceptor triggers a funnel making a request on the same network, it will overwrite the request counts with last funnel's request counts.

Despite getting 0 items from the request, the message will say that I have gotten the same amount as the last triggered funnel and had a bunch accessible.
For example, where I have a bunch of funnels requesting 1 snow and a double chest half filled with snow:
![obraz](https://user-images.githubusercontent.com/26120076/53167114-56157b80-35d7-11e9-8fae-1e622e2e31f4.png)

This PR swaps the order of interception and assigning this count to fix the message to correct it.