### PR TITLE
Add a hook for hidden lexicon categories

### DIFF
--- a/src/main/java/vazkii/botania/api/lexicon/LexiconCategory.java
+++ b/src/main/java/vazkii/botania/api/lexicon/LexiconCategory.java
@@ -10,6 +10,7 @@
  */
 package vazkii.botania.api.lexicon;
 
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 
 import javax.annotation.Nonnull;
@@ -73,5 +74,15 @@ public class LexiconCategory implements Comparable<LexiconCategory> {
 	@Override
 	public int compareTo(@Nonnull LexiconCategory category) {
 		return priority == category.priority ? sortingId - category.sortingId : category.priority - priority;
+	}
+
+	/**
+	 * Determines if the category shows up in the lexicon category index. 
+	 * Contained entries will still appear in the lexicon index 
+	 * and must be hidden separately if desired.
+	 * @param stack The lexicon stack used by the player
+	 */
+	public boolean isVisible(ItemStack stack) {
+		return true;
 	}
 }

--- a/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexicon.java
+++ b/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexicon.java
@@ -111,8 +111,6 @@ public class GuiLexicon extends GuiScreen {
 	public String note = "";
 	public String categoryHighlight = "";
 
-	List<LexiconCategory> allCategories;
-
 	String title;
 	final int guiWidth = 146;
 	final int guiHeight = 180;
@@ -148,9 +146,6 @@ public class GuiLexicon extends GuiScreen {
 			mc.gameSettings.guiScale = guiScale;
 		}
 
-		allCategories = new ArrayList<>(BotaniaAPI.getAllCategories());
-		Collections.sort(allCategories);
-
 		lastTime = ClientTickHandler.ticksInGame;
 
 		title = ItemLexicon.getTitle(stackUsed);
@@ -168,6 +163,10 @@ public class GuiLexicon extends GuiScreen {
 			}
 			populateIndex();
 		} else if(isCategoryIndex()) {
+			List<LexiconCategory> allCategories = new ArrayList<>(BotaniaAPI.getAllCategories());
+			allCategories.removeIf(cat -> !cat.isVisible(stackUsed));
+			Collections.sort(allCategories);
+
 			int categories = allCategories.size();
 			for(int i = 0; i < categories + 1; i++) {
 				LexiconCategory category;


### PR DESCRIPTION
Adds a simple method that lets a lexicon category say if it should be displayed in the category index. The use case is quat's addon Incorporeal adding enough Corporea stuff to justify moving it to a separate category, but that means displaying an entirely empty category if the lexicon isn't upgraded yet. Doing this externally involved some pretty ugly removal and rearrangement of buttons in the index.

@quat1024 Does this appear alright for you? 🤠 