### PR TITLE
ItemEntity Limit for ManaPool Tile

### DIFF
--- a/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
+++ b/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
@@ -187,6 +187,10 @@ public class TilePool extends TileMod implements IManaPool, IKeyLocked, ISparkAt
 
 		if(recipe != null) {
 			int mana = recipe.getManaToConsume();
+
+			if(recipe.getOutput().getCount() > 1 && !canSpawnAdditionalItems())
+				return false;
+
 			if(getCurrentMana() >= mana) {
 				recieveMana(-mana);
 
@@ -203,6 +207,14 @@ public class TilePool extends TileMod implements IManaPool, IKeyLocked, ISparkAt
 		}
 
 		return false;
+	}
+
+	private boolean canSpawnAdditionalItems(){
+		if(ConfigHandler.itemLimitManaPool == 0)
+			return true;
+
+		AxisAlignedBB area = new AxisAlignedBB(-2, -2, -2, 2, 2, 2).offset(getPos());
+		return world.getEntitiesWithinAABB(EntityItem.class, area).size() < ConfigHandler.itemLimitManaPool;
 	}
 
 	private void craftingFanciness() {

--- a/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
+++ b/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
@@ -186,10 +186,10 @@ public class TilePool extends TileMod implements IManaPool, IKeyLocked, ISparkAt
 		RecipeManaInfusion recipe = getMatchingRecipe(stack, world.getBlockState(pos.down()));
 
 		if(recipe != null) {
-			int mana = recipe.getManaToConsume();
-
 			if(recipe.getOutput().getCount() > 1 && !canSpawnAdditionalItems())
 				return false;
+
+			int mana = recipe.getManaToConsume();
 
 			if(getCurrentMana() >= mana) {
 				recieveMana(-mana);

--- a/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
+++ b/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
@@ -186,12 +186,12 @@ public class TilePool extends TileMod implements IManaPool, IKeyLocked, ISparkAt
 		RecipeManaInfusion recipe = getMatchingRecipe(stack, world.getBlockState(pos.down()));
 
 		if(recipe != null) {
-			if(recipe.getOutput().getCount() > 1 && !canSpawnAdditionalItems())
-				return false;
-
 			int mana = recipe.getManaToConsume();
 
 			if(getCurrentMana() >= mana) {
+				if(recipe.getOutput().getCount() > 1 && !canSpawnAdditionalItems())
+					return false;
+
 				recieveMana(-mana);
 
 				stack.shrink(1);

--- a/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
+++ b/src/main/java/vazkii/botania/common/block/tile/mana/TilePool.java
@@ -107,6 +107,8 @@ public class TilePool extends TileMod implements IManaPool, IKeyLocked, ISparkAt
 	private int ticks = 0;
 	private boolean sendPacket = false;
 
+	private int itemsAroundPool = ConfigHandler.itemLimitManaPool + 1; //initialize with higher value to force the first check
+
 	@Override
 	public boolean shouldRefresh(World world, BlockPos pos, @Nonnull IBlockState oldState, @Nonnull IBlockState newState) {
 		if(oldState.getBlock() != newState.getBlock())
@@ -189,7 +191,7 @@ public class TilePool extends TileMod implements IManaPool, IKeyLocked, ISparkAt
 			int mana = recipe.getManaToConsume();
 
 			if(getCurrentMana() >= mana) {
-				if(recipe.getOutput().getCount() > 1 && !canSpawnAdditionalItems())
+				if(recipe.getOutput().getCount() > 1 && !canSpawnAdditionalItems(recipe.getOutput().getCount() - 1))
 					return false;
 
 				recieveMana(-mana);
@@ -209,12 +211,18 @@ public class TilePool extends TileMod implements IManaPool, IKeyLocked, ISparkAt
 		return false;
 	}
 
-	private boolean canSpawnAdditionalItems(){
+	private boolean canSpawnAdditionalItems(int spawnItems){
 		if(ConfigHandler.itemLimitManaPool == 0)
 			return true;
 
-		AxisAlignedBB area = new AxisAlignedBB(-2, -2, -2, 2, 2, 2).offset(getPos());
-		return world.getEntitiesWithinAABB(EntityItem.class, area).size() < ConfigHandler.itemLimitManaPool;
+		itemsAroundPool+=spawnItems;
+
+		if(itemsAroundPool > ConfigHandler.itemLimitManaPool){
+			AxisAlignedBB area = new AxisAlignedBB(-2, -2, -2, 2, 2, 2).offset(getPos());
+			itemsAroundPool = world.getEntitiesWithinAABB(EntityItem.class, area).size();
+		}
+
+		return itemsAroundPool < ConfigHandler.itemLimitManaPool;
 	}
 
 	private void craftingFanciness() {

--- a/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
+++ b/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
@@ -97,6 +97,8 @@ public final class ConfigHandler {
 	public static double flowerTallChance = 0.05;
 	public static int mushroomQuantity = 40;
 
+	public static int itemLimitManaPool = 64;
+
 	public static void loadConfig(File configFile) {
 		config = new Configuration(configFile);
 
@@ -209,6 +211,9 @@ public final class ConfigHandler {
 
 		desc = "Turn this off ONLY IF you're on an extremely large world with an exaggerated count of Mana Spreaders/Mana Pools and are experiencing TPS lag. This toggles whether flowers are strict with their checking for connecting to pools/spreaders or just check whenever possible.";
 		flowerForceCheck = loadPropBool("flower.forceCheck", desc, flowerForceCheck);
+
+		desc = "The quantity of Items allowed around a mana pool when crafting a recipe which has a larger output than input (e.g. Coal => 2x Coal), set to 0 to disable";
+		itemLimitManaPool = loadPropInt("manapool.itemlimit", desc, itemLimitManaPool);
 
 		desc = "Set to false to disable the ability for the Hand of Ender to pickpocket other players' ender chests.";
 		enderPickpocketEnabled = loadPropBool("enderPickpocket.enabled", desc, enderPickpocketEnabled);


### PR DESCRIPTION
this commit adds a stack limit to craftingrecipes which have a output >1 (e.g. coal, redstone, glowstone dust duping) to pretend spawning of insane amounts of item entities in the world.

only applies if a recipe would output more than 1 item
only checks 2 block radius around the mana pool for items
can be disabled if the config value is set to 0 (defaults to max. 64 entities/stacks around the pool)
only checks on the first craft done and if the total amount of additional spawned items is larger than the limit