### PR TITLE
When matching recipe tags, also match the first items of nested lists

### DIFF
--- a/src/main/java/vazkii/botania/api/recipe/RecipePetals.java
+++ b/src/main/java/vazkii/botania/api/recipe/RecipePetals.java
@@ -12,7 +12,6 @@ package vazkii.botania.api.recipe;
 
 import com.google.common.collect.ImmutableList;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.oredict.OreDictionary;
 import vazkii.botania.common.core.helper.ItemNBTHelper;
@@ -80,7 +79,7 @@ public class RecipePetals {
 	}
 
 	private boolean compareStacks(ItemStack recipe, ItemStack supplied) {
-		return recipe.getItem() == supplied.getItem() && recipe.getItemDamage() == supplied.getItemDamage() && ItemNBTHelper.isTagSubset(recipe.getTagCompound(), supplied.getTagCompound());
+		return recipe.getItem() == supplied.getItem() && recipe.getItemDamage() == supplied.getItemDamage() && ItemNBTHelper.matchTag(recipe.getTagCompound(), supplied.getTagCompound());
 	}
 
 	public List<Object> getInputs() {


### PR DESCRIPTION
Mostly useful when adding CraftTweaker recipes which have Forestry bees
as inputs, since the bee's chromosomes are in a list and the recipe
only needs to match some of the item's chromosomes.

As requested here: https://github.com/quat1024/BotaniaTweaks/pull/48