### PR TITLE
Improved support for Demagnetize

### DIFF
--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemMagnetRing.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemMagnetRing.java
@@ -105,7 +105,7 @@ public class ItemMagnetRing extends ItemBauble {
 	}
 
 	private boolean canPullItem(EntityItem item) {
-		if(item.isDead || item.pickupDelay >= 40 || SubTileSolegnolia.hasSolegnoliaAround(item))
+		if(item.isDead || item.pickupDelay >= 40 || SubTileSolegnolia.hasSolegnoliaAround(item) || item.getEntityData().getBoolean("PreventRemoteMovement"))
 			return false;
 
 		ItemStack stack = item.getItem();


### PR DESCRIPTION
My mod, [Demagnetize](https://minecraft.curseforge.com/projects/demagnetize), adds a Demagnetizer that disables magnets on items around it, like the Solegnolia. 
When I released the mod originally, I added support for Botania by [hackily](https://github.com/comp500/Demagnetize/blob/master/src/main/java/link/infra/demagnetize/blocks/DemagnetizerSolegnoliaCompat.java) emulating the Solegnolia, however this completely ignores the Whitelist/Blacklist functionality in my mod. Emulation of the Solegnolia also [breaks](https://github.com/comp500/Demagnetize/issues/1) this functionality in other mods' magnets that support the Solegnolia. I intended to submit a PR to Botania to improve this, but never got around to it.

To fix this, this PR adds a check for the boolean entity NBT tag `PreventRemoteMovement` in the magnet ring, originally standardised by Immersive Engineering and supported by almost all mods that add magnets. This will prevent the ring from working on items that have this tag. Immersive Engineering currently adds explicit support (through Botania's API) for preventing items on conveyors from being picked up by the ring, but after this is merged it will not be necessary; however it would be a bad idea to remove the compatibility from IE as it will break the functionality in older versions of Botania. A more thorough discussion of the `PreventRemoteMovement` tag and a related tag `AllowMachineRemoteMovement` was had [here](https://github.com/CoFH/Feedback/issues/1243).

An additional idea is that the Solegnolia could also add this tag (along with the `AllowMachineRemoteMovement` tag) to items in the area of the Solegnolia. This would significantly improve cross-mod compatibility for the Solegnolia, at the expense of changing the semantics of the Solegnolia. Currently, the Solegnolia prevents the magnet ring from operating when items or the player are in it's area. If the tag is added items will stay "demagnetized" forever, unless every item that has been in the area of a Solegnolia is kept track of and the tag is removed when they leave the area.