### PR TITLE
Fix sticky comparators on corporea retainers

### DIFF
--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaRetainer.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaRetainer.java
@@ -72,6 +72,8 @@ public class TileCorporeaRetainer extends TileMod {
 				ICorporeaRequestor requestor = (ICorporeaRequestor) inv.world.getTileEntity(inv.pos);
 				requestor.doCorporeaRequest(request, requestCount, spark);
 				pendingRequest = false;
+				
+				compValue = 0;
 				world.updateComparatorOutputLevel(getPos(), world.getBlockState(getPos()).getBlock());
 			}
 		}


### PR DESCRIPTION
Completing a request in a corporea retainer now actually clears the comparator value of it... Fixes #2893

> who was the loser who added this bug

> `git blame`

> oh

