### PR TITLE
Fixed issues #2945 and #2804

### DIFF
--- a/src/main/java/vazkii/botania/common/item/ItemCacophonium.java
+++ b/src/main/java/vazkii/botania/common/item/ItemCacophonium.java
@@ -121,12 +121,6 @@ public class ItemCacophonium extends ItemMod {
 			list.add(I18n.format(ItemNBTHelper.getString(stack, TAG_SOUND_NAME, "")));
 	}
 
-	@Nonnull
-	@Override
-	public EnumAction getItemUseAction(ItemStack par1ItemStack) {
-		return EnumAction.NONE;
-	}
-
 	@Override
 	public int getMaxItemUseDuration(ItemStack par1ItemStack) {
 		return 72000;

--- a/src/main/java/vazkii/botania/common/item/ItemCacophonium.java
+++ b/src/main/java/vazkii/botania/common/item/ItemCacophonium.java
@@ -124,7 +124,7 @@ public class ItemCacophonium extends ItemMod {
 	@Nonnull
 	@Override
 	public EnumAction getItemUseAction(ItemStack par1ItemStack) {
-		return EnumAction.BLOCK;
+		return EnumAction.NONE;
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemWaterRing.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemWaterRing.java
@@ -58,7 +58,7 @@ public class ItemWaterRing extends ItemBauble implements IManaUsingItem {
 
 			PotionEffect effect = player.getActivePotionEffect(MobEffects.NIGHT_VISION);
 			if(effect == null) {
-				PotionEffect neweffect = new PotionEffect(MobEffects.NIGHT_VISION, 10, -42, true, true);
+				PotionEffect neweffect = new PotionEffect(MobEffects.NIGHT_VISION, 600, -42, true, true);
 				player.addPotionEffect(neweffect);
 			}
 

--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemWaterRing.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemWaterRing.java
@@ -58,7 +58,7 @@ public class ItemWaterRing extends ItemBauble implements IManaUsingItem {
 
 			PotionEffect effect = player.getActivePotionEffect(MobEffects.NIGHT_VISION);
 			if(effect == null) {
-				PotionEffect neweffect = new PotionEffect(MobEffects.NIGHT_VISION, Integer.MAX_VALUE, -42, true, true);
+				PotionEffect neweffect = new PotionEffect(MobEffects.NIGHT_VISION, 10, -42, true, true);
 				player.addPotionEffect(neweffect);
 			}
 


### PR DESCRIPTION
For #2804 : Since the ring checks **every tick** for the working conditions we can give night vision for a small amount of time instead of giving an infinite effect. This way Night Vision can still expire when leaving the water and not get stuck by quitting the game.

For #2945 : Was that intended to also work as a shield?

---

Not big bugs but a little fix does not hurt anybody.