### PR TITLE
Various 1.14 work

### DIFF
--- a/src/main/java/vazkii/botania/client/core/handler/ContributorFancinessHandler.java
+++ b/src/main/java/vazkii/botania/client/core/handler/ContributorFancinessHandler.java
@@ -10,29 +10,33 @@
  */
 package vazkii.botania.client.core.handler;
 
-import net.minecraft.client.Minecraft;
+import com.google.common.collect.ImmutableMap;
 import com.mojang.blaze3d.platform.GlStateManager;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.player.AbstractClientPlayerEntity;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.IEntityRenderer;
 import net.minecraft.client.renderer.entity.layers.LayerRenderer;
 import net.minecraft.client.renderer.entity.model.PlayerModel;
 import net.minecraft.client.renderer.model.ItemCameraTransforms;
-import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.AtlasTexture;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerModelPart;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.DyeColor;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.tags.ItemTags;
+import net.minecraft.tags.Tag;
+import net.minecraft.util.DefaultUncaughtExceptionHandler;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.registries.ForgeRegistries;
 import vazkii.botania.api.item.AccessoryRenderHelper;
 import vazkii.botania.client.core.helper.IconHelper;
 import vazkii.botania.client.core.helper.ShaderHelper;
 import vazkii.botania.common.Botania;
 import vazkii.botania.common.block.ModBlocks;
+import vazkii.botania.common.lib.LibBlockNames;
 import vazkii.botania.common.lib.LibMisc;
 
 import javax.annotation.Nonnull;
@@ -40,6 +44,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 
@@ -47,6 +52,16 @@ public final class ContributorFancinessHandler extends LayerRenderer<AbstractCli
 
 	public static final Map<String, ItemStack> flowerMap = new HashMap<>();
 	private static boolean startedLoading = false;
+
+	private static final Tag<Item> FLOWERS = new ItemTags.Wrapper(new ResourceLocation(LibMisc.MOD_ID, "special_flowers"));
+	private static final ImmutableMap<String, String> LEGACY_FLOWER_NAMES = ImmutableMap.<String, String>builder()
+			.put("puredaisy", LibBlockNames.SUBTILE_PUREDAISY.getPath())
+			.put("fallenkanade", LibBlockNames.SUBTILE_FALLEN_KANADE.getPath())
+			.put("heiseidream", LibBlockNames.SUBTILE_HEISEI_DREAM.getPath())
+			.put("arcanerose", LibBlockNames.SUBTILE_ARCANE_ROSE.getPath())
+			.put("jadedamaranthus", LibBlockNames.SUBTILE_JADED_AMARANTHUS.getPath())
+			.put("orechidignem", LibBlockNames.SUBTILE_ORECHID_IGNEM.getPath())
+			.build();
 
 	public ContributorFancinessHandler(IEntityRenderer<AbstractClientPlayerEntity, PlayerModel<AbstractClientPlayerEntity>> renderer) {
 		super(renderer);
@@ -99,9 +114,13 @@ public final class ContributorFancinessHandler extends LayerRenderer<AbstractCli
 				if(i < 0 || i >= 16)
 					throw new NumberFormatException();
 				flowerMap.put(key, new ItemStack(ModBlocks.getFlower(DyeColor.byId(i))));
-			} catch(NumberFormatException e) {
-				// todo 1.13 backward compat for camelCase names
-				Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(LibMisc.MOD_ID, value));
+			} catch (NumberFormatException e) {
+				String rawName = value.toLowerCase(Locale.ROOT);
+				String flowerName = LEGACY_FLOWER_NAMES.getOrDefault(rawName, rawName);
+
+				Item item = FLOWERS.getAllElements().stream()
+						.filter(flower -> flower.getRegistryName().getPath().equals(flowerName))
+						.findFirst().orElse(Items.POPPY);
 				flowerMap.put(key, new ItemStack(item));
 			}
 		}
@@ -144,6 +163,7 @@ public final class ContributorFancinessHandler extends LayerRenderer<AbstractCli
 		public ThreadContributorListLoader() {
 			setName("Botania Contributor Fanciness Thread");
 			setDaemon(true);
+			setUncaughtExceptionHandler(new DefaultUncaughtExceptionHandler(Botania.LOGGER));
 			start();
 		}
 

--- a/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexiconIndex.java
+++ b/src/main/java/vazkii/botania/client/gui/lexicon/GuiLexiconIndex.java
@@ -64,6 +64,11 @@ public class GuiLexiconIndex extends GuiLexicon implements IParented {
 		this.parent = new GuiLexicon();
 	}
 
+	// No-arg constructor for bookmark serialization
+	public GuiLexiconIndex() {
+		this(BotaniaAPI.categoryBasics);
+	}
+
 	@Override
 	boolean isMainPage() {
 		return false;

--- a/src/main/java/vazkii/botania/client/integration/jei/runicaltar/RunicAltarRecipeCategory.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/runicaltar/RunicAltarRecipeCategory.java
@@ -85,7 +85,6 @@ public class RunicAltarRecipeCategory implements IRecipeCategory<RecipeRuneAltar
 		for(Ingredient ingr : recipe.getInputs()) {
 			list.add(Arrays.asList(ingr.getMatchingStacks()));
 		}
-		System.out.println(list);
 		iIngredients.setInputLists(VanillaTypes.ITEM, list);
 		iIngredients.setOutput(VanillaTypes.ITEM, recipe.getOutput());
 	}

--- a/src/main/java/vazkii/botania/common/Botania.java
+++ b/src/main/java/vazkii/botania/common/Botania.java
@@ -11,17 +11,6 @@
 package vazkii.botania.common;
 
 import net.minecraft.advancements.CriteriaTriggers;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.boss.WitherEntity;
-import net.minecraft.entity.boss.dragon.EnderDragonEntity;
-import net.minecraft.entity.boss.WitherEntity;
-import net.minecraft.entity.boss.dragon.EnderDragonPartEntity;
-import net.minecraft.entity.item.EnderCrystalEntity;
-import net.minecraft.entity.item.EnderCrystalEntity;
-import net.minecraft.entity.item.ItemFrameEntity;
-import net.minecraft.entity.item.PaintingEntity;
-import net.minecraft.entity.item.ItemFrameEntity;
-import net.minecraft.entity.item.PaintingEntity;
 import net.minecraft.world.storage.loot.conditions.LootConditionManager;
 import net.minecraft.world.storage.loot.functions.LootFunctionManager;
 import net.minecraftforge.common.MinecraftForge;
@@ -52,7 +41,6 @@ import vazkii.botania.common.advancements.*;
 import vazkii.botania.common.block.ModBanners;
 import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.block.ModMultiblocks;
-import vazkii.botania.common.block.tile.TileLightRelay;
 import vazkii.botania.common.block.tile.corporea.TileCorporeaIndex;
 import vazkii.botania.common.brew.ModBrews;
 import vazkii.botania.common.core.command.CommandOpen;
@@ -71,22 +59,10 @@ import vazkii.botania.common.core.loot.TrueGuardianKiller;
 import vazkii.botania.common.core.proxy.IProxy;
 import vazkii.botania.common.core.proxy.ServerProxy;
 import vazkii.botania.common.crafting.FluxfieldConditionFactory;
-import vazkii.botania.common.crafting.ModCraftingRecipes;
-import vazkii.botania.common.crafting.ModPetalRecipes;
-import vazkii.botania.common.crafting.ModRuneRecipes;
 import vazkii.botania.common.crafting.ReloadListener;
-import vazkii.botania.common.entity.EntityCorporeaSpark;
-import vazkii.botania.common.entity.EntityDoppleganger;
-import vazkii.botania.common.entity.EntityFlameRing;
-import vazkii.botania.common.entity.EntityMagicLandmine;
-import vazkii.botania.common.entity.EntityMagicMissile;
-import vazkii.botania.common.entity.EntityManaBurst;
-import vazkii.botania.common.entity.EntityPinkWither;
-import vazkii.botania.common.entity.EntitySignalFlare;
-import vazkii.botania.common.entity.EntitySpark;
-import vazkii.botania.common.lexicon.LexiconData;
 import vazkii.botania.common.lib.LibMisc;
 import vazkii.botania.common.network.PacketHandler;
+import vazkii.botania.common.world.ModFeatures;
 import vazkii.botania.common.world.SkyblockWorldEvents;
 import vazkii.botania.common.world.WorldTypeSkyblock;
 
@@ -119,7 +95,6 @@ public class Botania {
 		MinecraftForge.EVENT_BUS.addListener(this::serverAboutToStart);
 		MinecraftForge.EVENT_BUS.addListener(this::serverStarting);
 		MinecraftForge.EVENT_BUS.addListener(this::serverStopping);
-//		MinecraftForge.EVENT_BUS.addListener(LexiconData::reload);
 	}
 
 	private void commonSetup(FMLCommonSetupEvent event) {
@@ -172,6 +147,8 @@ public class Botania {
 			CraftingHelper.register(FluxfieldConditionFactory.KEY, new FluxfieldConditionFactory());
 
 			ModBlocks.addDispenserBehaviours();
+
+			ModFeatures.addWorldgen();
 		});
 	}
 

--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileAgricarnation.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileAgricarnation.java
@@ -93,7 +93,7 @@ public class SubTileAgricarnation extends TileEntityFunctionalFlower {
 	private boolean isPlant(BlockPos pos) {
 		BlockState state = getWorld().getBlockState(pos);
 		Block block = state.getBlock();
-		if(block == Blocks.GRASS || BlockTags.LEAVES.contains(block) || block instanceof BushBlock && !(block instanceof CropsBlock) && !(block instanceof SaplingBlock))
+		if(block == Blocks.GRASS_BLOCK || BlockTags.LEAVES.contains(block) || block instanceof BushBlock && !(block instanceof CropsBlock) && !(block instanceof SaplingBlock))
 			return false;
 
 		Material mat = state.getMaterial();

--- a/src/main/java/vazkii/botania/common/item/ItemGrassSeeds.java
+++ b/src/main/java/vazkii/botania/common/item/ItemGrassSeeds.java
@@ -86,7 +86,7 @@ public class ItemGrassSeeds extends ItemMod implements IFloatingFlowerVariant {
 		BlockState state = world.getBlockState(pos);
 		ItemStack stack = ctx.getItem();
 
-		if(state.getBlock() == Blocks.DIRT || state.getBlock() == Blocks.GRASS && type != IslandType.GRASS) {
+		if(state.getBlock() == Blocks.DIRT || state.getBlock() == Blocks.GRASS_BLOCK && type != IslandType.GRASS) {
 			if(!world.isRemote) {
 				BlockSwapper swapper = addBlockSwapper(world, pos, type);
 				world.setBlockState(pos, swapper.stateToSet);
@@ -168,7 +168,7 @@ public class ItemGrassSeeds extends ItemMod implements IFloatingFlowerVariant {
 			return ModBlocks.infusedGrass.getDefaultState();
 		else if(type == IslandType.MUTATED)
 			return ModBlocks.mutatedGrass.getDefaultState();
-		else return Blocks.GRASS.getDefaultState();
+		else return Blocks.GRASS_BLOCK.getDefaultState();
 	}
 
 	/**
@@ -274,7 +274,7 @@ public class ItemGrassSeeds extends ItemMod implements IFloatingFlowerVariant {
 			// The major rule is that a block which reduces light
 			// levels by 2 or more blocks grass growth.
 
-			return (block == Blocks.DIRT || block == Blocks.GRASS)
+			return (block == Blocks.DIRT || block == Blocks.GRASS_BLOCK)
 					&& world.getBlockState(pos.up()).getOpacity(world, pos.up()) <= 1;
 		}
 	}

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/manasteel/ItemManasteelShovel.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/manasteel/ItemManasteelShovel.java
@@ -99,7 +99,7 @@ public class ItemManasteelShovel extends ShovelItem implements IManaUsingItem, I
 
 			Block block = world.getBlockState(pos).getBlock();
 
-			if(ctx.getFace() != Direction.DOWN && world.getBlockState(pos.up()).getBlock().isAir(world.getBlockState(pos.up()), world, pos.up()) && (block == Blocks.GRASS || block == Blocks.DIRT || block == Blocks.GRASS_PATH)) {
+			if(ctx.getFace() != Direction.DOWN && world.getBlockState(pos.up()).getBlock().isAir(world.getBlockState(pos.up()), world, pos.up()) && (block == Blocks.GRASS_BLOCK || block == Blocks.DIRT || block == Blocks.GRASS_PATH)) {
 				Block block1 = Blocks.GRASS_PATH;
 				if(block == block1)
 					block1 = Blocks.FARMLAND;

--- a/src/main/java/vazkii/botania/common/lexicon/page/PageCraftingRecipe.java
+++ b/src/main/java/vazkii/botania/common/lexicon/page/PageCraftingRecipe.java
@@ -181,6 +181,21 @@ public class PageCraftingRecipe extends PageRecipe {
 		if(list.isEmpty()) {
 			Botania.LOGGER.info("Could not find mana infusion recipes for items {}, using dummy", (Object) this.outputItems);
 			return DUMMY;
+		} else {
+			list.sort((r1, r2) -> {
+				Item output1 = r1.getRecipeOutput().getItem();
+				Item output2 = r2.getRecipeOutput().getItem();
+				if(output1 == output2)
+					return 0;
+				for(Item outputItem : outputItems) {
+					if(outputItem == output1) {
+						return -1;
+					} else if(outputItem == output2) {
+						return 1;
+					}
+				}
+				return 0;
+			});
 		}
 		return list;
 	}

--- a/src/main/java/vazkii/botania/common/lexicon/page/PageElvenRecipe.java
+++ b/src/main/java/vazkii/botania/common/lexicon/page/PageElvenRecipe.java
@@ -140,6 +140,22 @@ public class PageElvenRecipe extends PageRecipe {
 		if(list.isEmpty()) {
 			Botania.LOGGER.warn("Could not find elven trade recipes for item {}, using dummy", (Object) outputItems);
 			return DUMMY;
+		} else {
+			list.sort((r1, r2) -> {
+				for(Item outputItem : outputItems) {
+					for(ItemStack stack : r1.getOutputs()) {
+						if(stack.getItem() == outputItem) {
+							return -1;
+						}
+					}
+					for(ItemStack stack : r2.getOutputs()) {
+						if(stack.getItem() == outputItem) {
+							return 1;
+						}
+					}
+				}
+				return 0;
+			});
 		}
 		return list;
 	}

--- a/src/main/java/vazkii/botania/common/lexicon/page/PageManaInfusionRecipe.java
+++ b/src/main/java/vazkii/botania/common/lexicon/page/PageManaInfusionRecipe.java
@@ -191,6 +191,21 @@ public class PageManaInfusionRecipe extends PageRecipe {
 		if(list.isEmpty()) {
 			Botania.LOGGER.warn("Could not find mana infusion recipes for items {}, using dummy", (Object) outputItems);
 			return DUMMY;
+		} else {
+			list.sort((r1, r2) -> {
+				Item output1 = r1.getOutput().getItem();
+				Item output2 = r2.getOutput().getItem();
+				if(output1 == output2)
+					return 0;
+				for(Item outputItem : outputItems) {
+					if(outputItem == output1) {
+						return -1;
+					} else if(outputItem == output2) {
+						return 1;
+					}
+				}
+				return 0;
+			});
 		}
 		return list;
 	}

--- a/src/main/java/vazkii/botania/common/lexicon/page/PageModRecipe.java
+++ b/src/main/java/vazkii/botania/common/lexicon/page/PageModRecipe.java
@@ -168,6 +168,21 @@ public abstract class PageModRecipe<T extends IModRecipe> extends PageRecipe {
 				}
 			}
 			recipes = list;
+			
+			list.sort((r1, r2) -> {
+				Item output1 = r1.getOutput().getItem();
+				Item output2 = r2.getOutput().getItem();
+				if(output1 == output2)
+					return 0;
+				for(Item outputItem : outputItems) {
+					if(outputItem == output1) {
+						return -1;
+					} else if(outputItem == output2) {
+						return 1;
+					}
+				}
+				return 0;
+			});
 			return list;
 		}
 		return recipes;

--- a/src/main/java/vazkii/botania/common/world/ModFeatures.java
+++ b/src/main/java/vazkii/botania/common/world/ModFeatures.java
@@ -1,0 +1,43 @@
+/**
+ * This class was created by <Hubry>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ *
+ * File Created @ [sie 16 2019, 19:17]
+ */
+package vazkii.botania.common.world;
+
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.GenerationStage;
+import net.minecraft.world.gen.feature.Feature;
+import net.minecraft.world.gen.placement.IPlacementConfig;
+import net.minecraft.world.gen.placement.Placement;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.IForgeRegistry;
+import vazkii.botania.common.lib.LibMisc;
+
+import static vazkii.botania.common.block.ModBlocks.register;
+
+@Mod.EventBusSubscriber(modid = LibMisc.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
+public class ModFeatures {
+	public static final Feature<MysticalFlowerConfig> MYSTICAL_FLOWERS = new MysticalFlowerFeature(MysticalFlowerConfig::deserialize);
+
+	@SubscribeEvent
+	public static void registerFeatures(RegistryEvent.Register<Feature<?>> event) {
+		IForgeRegistry<Feature<?>> r = event.getRegistry();
+
+		register(r, MYSTICAL_FLOWERS, "mystical_flowers");
+	}
+	
+	public static void addWorldgen() {
+		for(Biome biome : ForgeRegistries.BIOMES) { //todo should this be more specific?
+			biome.addFeature(GenerationStage.Decoration.VEGETAL_DECORATION, Biome.createDecoratedFeature(MYSTICAL_FLOWERS, new MysticalFlowerConfig(), Placement.NOPE, IPlacementConfig.NO_PLACEMENT_CONFIG));
+		}
+	}
+}

--- a/src/main/java/vazkii/botania/common/world/MysticalFlowerConfig.java
+++ b/src/main/java/vazkii/botania/common/world/MysticalFlowerConfig.java
@@ -38,4 +38,8 @@ public class MysticalFlowerConfig implements IFeatureConfig {
         // todo 1.14
         return new Dynamic<>(ops);
     }
+
+    public static MysticalFlowerConfig deserialize(Dynamic<?> dynamic) {
+        return new MysticalFlowerConfig();
+    }
 }

--- a/src/main/java/vazkii/botania/common/world/MysticalFlowerFeature.java
+++ b/src/main/java/vazkii/botania/common/world/MysticalFlowerFeature.java
@@ -2,16 +2,14 @@ package vazkii.botania.common.world;
 
 import com.mojang.datafixers.Dynamic;
 import net.minecraft.block.Block;
-import net.minecraft.block.DoublePlantBlock;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.DoublePlantBlock;
 import net.minecraft.item.DyeColor;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.gen.ChunkGenerator;
 import net.minecraft.world.gen.GenerationSettings;
 import net.minecraft.world.gen.Heightmap;
-import net.minecraft.world.gen.GenerationSettings;
-import net.minecraft.world.gen.ChunkGenerator;
 import net.minecraft.world.gen.feature.Feature;
 import vazkii.botania.api.item.IFlowerlessBiome;
 import vazkii.botania.api.item.IFlowerlessWorld;
@@ -41,9 +39,9 @@ public class MysticalFlowerFeature extends Feature<MysticalFlowerConfig> {
         int dist = Math.min(8, Math.max(1, config.getPatchSize()));
         for(int i = 0; i < config.getPatchCount(); i++) {
             if(rand.nextInt(config.getPatchChance()) == 0) {
-                int x = pos.getX() + rand.nextInt(16) + 8;
-                int z = pos.getZ() + rand.nextInt(16) + 8;
-                int y = world.getHeight(Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, pos).getY();
+                int x = pos.getX() + rand.nextInt(16);
+                int z = pos.getZ() + rand.nextInt(16);
+                int y = world.getHeight(Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, x, z);
 
                 DyeColor color = DyeColor.byId(rand.nextInt(16));
                 BlockState flower = ModBlocks.getFlower(color).getDefaultState();

--- a/src/main/java/vazkii/botania/common/world/SkyblockWorldEvents.java
+++ b/src/main/java/vazkii/botania/common/world/SkyblockWorldEvents.java
@@ -70,6 +70,10 @@ public final class SkyblockWorldEvents {
 				World world = player.world;
 				if(WorldTypeSkyblock.isWorldSkyblock(world)) {
 					BlockPos coords = world.getSpawnPoint();
+					if(coords.getY() <= 0) {
+						coords = new BlockPos(coords.getX(), 64, coords.getZ());
+						world.setSpawnPoint(coords);
+					}
 					if(world.getBlockState(coords.down(4)).getBlock() != Blocks.BEDROCK && world == overworld)
 						spawnPlayer(player, coords, false);
 				}

--- a/src/main/java/vazkii/botania/common/world/SkyblockWorldEvents.java
+++ b/src/main/java/vazkii/botania/common/world/SkyblockWorldEvents.java
@@ -184,7 +184,7 @@ public final class SkyblockWorldEvents {
 		for(int i = 0; i < 3; i++)
 			for(int j = 0; j < 4; j++)
 				for(int k = 0; k < 3; k++)
-					world.setBlockState(pos.add(-1 + i, -1 - j, -1 + k), j == 0 ? Blocks.GRASS.getDefaultState() : Blocks.DIRT.getDefaultState());
+					world.setBlockState(pos.add(-1 + i, -1 - j, -1 + k), j == 0 ? Blocks.GRASS_BLOCK.getDefaultState() : Blocks.DIRT.getDefaultState());
 		world.setBlockState(pos.add(-1, -2, 0), Blocks.WATER.getDefaultState());
 		world.setBlockState(pos.add(1, 2, 1), ModBlocks.manaFlame.getDefaultState());
 		((TileManaFlame) world.getTileEntity(pos.add(1, 2, 1))).setColor(new Color(70 + world.rand.nextInt(185), 70 + world.rand.nextInt(185), 70 + world.rand.nextInt(185)).getRGB());

--- a/src/main/java/vazkii/botania/common/world/SkyblockWorldEvents.java
+++ b/src/main/java/vazkii/botania/common/world/SkyblockWorldEvents.java
@@ -88,10 +88,11 @@ public final class SkyblockWorldEvents {
 	public static void onPlayerInteract(PlayerInteractEvent.RightClickBlock event) {
 		if(Botania.gardenOfGlassLoaded) {
 			ItemStack equipped = event.getItemStack();
-			if(equipped.isEmpty() && event.getEntityPlayer().isSneaking()) {
+			PlayerEntity player = event.getPlayer();
+
+			if(equipped.isEmpty() && player.isSneaking()) {
 				BlockState state = event.getWorld().getBlockState(event.getPos());
 				Block block = state.getBlock();
-				PlayerEntity player = event.getEntityPlayer();
 
 				if(PEBBLE_SOURCES.contains(block)) {
 					SoundType st = state.getSoundType(event.getWorld(), event.getPos(), player);
@@ -100,23 +101,23 @@ public final class SkyblockWorldEvents {
 					if(event.getWorld().isRemote)
 						player.swingArm(event.getHand());
 					else if(Math.random() < 0.8)
-						event.getEntityPlayer().dropItem(new ItemStack(ModItems.pebble), false);
+						player.dropItem(new ItemStack(ModItems.pebble), false);
 
 					event.setCanceled(true);
 					event.setCancellationResult(ActionResultType.SUCCESS);
 				}
 			} else if(!equipped.isEmpty() && equipped.getItem() == Items.BOWL) {
-				RayTraceResult rtr = ToolCommons.raytraceFromEntity(event.getWorld(), event.getEntityPlayer(),
+				BlockRayTraceResult rtr = ToolCommons.raytraceFromEntity(event.getWorld(), player,
 						RayTraceContext.FluidMode.SOURCE_ONLY, 4.5F);
 				if(rtr.getType() == RayTraceResult.Type.BLOCK) {
-					BlockPos pos = ((BlockRayTraceResult) rtr).getPos();
+					BlockPos pos = rtr.getPos();
 					if(event.getWorld().getBlockState(pos).getMaterial() == Material.WATER) {
 						if(!event.getWorld().isRemote) {
 							equipped.shrink(1);
 
 							if(equipped.isEmpty())
-								event.getEntityPlayer().setHeldItem(event.getHand(), new ItemStack(ModItems.waterBowl));
-							else ItemHandlerHelper.giveItemToPlayer(event.getEntityPlayer(), new ItemStack(ModItems.waterBowl));
+								player.setHeldItem(event.getHand(), new ItemStack(ModItems.waterBowl));
+							else ItemHandlerHelper.giveItemToPlayer(player, new ItemStack(ModItems.waterBowl));
 						}
 
 						event.setCanceled(true);

--- a/src/main/resources/data/botania/recipes/world_seed.json
+++ b/src/main/resources/data/botania/recipes/world_seed.json
@@ -17,7 +17,7 @@
       "tag": "forge:gems/dragonstone"
     },
     "G": {
-      "item": "minecraft:grass"
+      "item": "minecraft:grass_block"
     }
   }
 }

--- a/src/main/resources/data/botania/tags/blocks/pebble_sources.json
+++ b/src/main/resources/data/botania/tags/blocks/pebble_sources.json
@@ -2,7 +2,7 @@
   "__comment": "Blocks in this tag provide pebbles in Garden of Glass mode",
   "replace": false,
   "values": [
-    "minecraft:grass",
+    "minecraft:grass_block",
     "minecraft:dirt",
     "minecraft:farmland",
     "minecraft:grass_path",


### PR DESCRIPTION
* Fix GoG islands appearing below world height - world spawn is at y=-1 if there's no ground there.
* Fix tallgrass used over grass blocks. Just a renaming artifact I guess? Brought to my attention by the GoG island fix.
* Hook up flower worldgen again. Spawn rates seem to be in line with 1.12... Should this be refactored to be more like other vanilla worldgen?
* Backwards compatibility for headflowers, using the special flower tag (not a block registry lookup, because addon flowers will not be under Botania) and a map for old names. If a flower isn't found, a poppy is used instead similiarly to 1.12.
* Fix bookmark serialization for the lexicon index (I don't even know why I bookmarked the index, but I saw the exception in the log on next launch)
* Remove the debug print for JEI runic altar, because that works now.
* Switch deprecated getEntityPlayer to getPlayer in GoG event handling - done while I was touching that file anyways, it's like one out of two dozens of other usages that should be changed over.
* Sort recipes on lexicon pages by order of items they have.

By the way your move of lexicon data reloading broke loading it on initial world loading...