### PR TITLE
Ability to disable petal planting 

### DIFF
--- a/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
+++ b/src/main/java/vazkii/botania/common/core/handler/ConfigHandler.java
@@ -75,6 +75,7 @@ public final class ConfigHandler {
 	public static int spreaderTraceTime = 400;
 	public static boolean flowerForceCheck = true;
 	public static boolean enderPickpocketEnabled = true;
+	public static boolean petalPlantingEnabled = true;
 
 	public static boolean fallenKanadeEnabled = true;
 	public static boolean darkQuartzEnabled = true;
@@ -212,6 +213,9 @@ public final class ConfigHandler {
 
 		desc = "Set to false to disable the ability for the Hand of Ender to pickpocket other players' ender chests.";
 		enderPickpocketEnabled = loadPropBool("enderPickpocket.enabled", desc, enderPickpocketEnabled);
+
+		desc = "Set to false to disable the ability multiply Mystical Petals by planting it and grow it by bone meal (this will increase game difficult).";
+		petalPlantingEnabled = loadPropBool("petalPlantingEnabled.enabled", desc, petalPlantingEnabled);
 
 		desc = "Set this to false to disable the Fallen Kanade flower (gives Regeneration). This config option is here for those using Blood Magic. Note: Turning this off will not remove ones already in the world, it'll simply prevent the crafting.";
 		fallenKanadeEnabled = loadPropBool("fallenKanade.enabled", desc, fallenKanadeEnabled);

--- a/src/main/java/vazkii/botania/common/item/material/ItemPetal.java
+++ b/src/main/java/vazkii/botania/common/item/material/ItemPetal.java
@@ -25,6 +25,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import vazkii.botania.api.item.IPetalApothecary;
 import vazkii.botania.api.recipe.IFlowerComponent;
+import vazkii.botania.common.core.handler.ConfigHandler;
 import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.item.Item16Colors;
 import vazkii.botania.common.lib.LibItemNames;
@@ -41,6 +42,11 @@ public class ItemPetal extends Item16Colors implements IFlowerComponent {
 	@Override
 	public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing facing, float hitX, float hitY, float hitZ) {
 		// Copy of ItemBlock.onItemUse
+		if(!ConfigHandler.petalPlantingEnabled)
+		{
+			return EnumActionResult.FAIL;
+		}
+
 		IBlockState iblockstate = world.getBlockState(pos);
 		Block block = iblockstate.getBlock();
 


### PR DESCRIPTION
I added ability to disable planting petal in the configuration file (it is still enabled by default). I think this option will be useful for hardcore mods-pack. Maybe this change looks small, but ability to copy instead of searching or growing random mystical flowers reduces difficulty.
Another option that I see is to add more similar changes to increase the complexity of the game and add one option in the configuration file "hardcore.enabled = false" to control all changes.