### PR TITLE
Fix some subitems not showing up in JEI, rearrange JEI categories to make more sense

### DIFF
--- a/src/main/java/vazkii/botania/client/integration/jei/JEIBotaniaPlugin.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/JEIBotaniaPlugin.java
@@ -22,11 +22,13 @@ import mezz.jei.api.runtime.IJeiRuntime;
 import mezz.jei.api.runtime.IRecipesGui;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screen.inventory.ContainerScreen;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.util.ResourceLocation;
 import vazkii.botania.api.BotaniaAPI;
+import vazkii.botania.api.mana.IManaItem;
 import vazkii.botania.api.recipe.RecipeElvenTrade;
 import vazkii.botania.client.core.handler.CorporeaInputHandler;
 import vazkii.botania.client.gui.crafting.ContainerCraftingHalo;
@@ -45,11 +47,16 @@ import vazkii.botania.client.integration.jei.puredaisy.PureDaisyRecipeCategory;
 import vazkii.botania.client.integration.jei.runicaltar.RunicAltarRecipeCategory;
 import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.block.ModSubtiles;
+import vazkii.botania.common.core.helper.ItemNBTHelper;
 import vazkii.botania.common.crafting.recipe.AncientWillRecipe;
 import vazkii.botania.common.crafting.recipe.CompositeLensRecipe;
 import vazkii.botania.common.crafting.recipe.TerraPickTippingRecipe;
+import vazkii.botania.common.item.ItemLaputaShard;
+import vazkii.botania.common.item.ItemLexicon;
+import vazkii.botania.common.item.ItemTwigWand;
 import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.brew.ItemBrewBase;
+import vazkii.botania.common.item.equipment.bauble.ItemFlightTiara;
 import vazkii.botania.common.lib.LibMisc;
 
 import javax.annotation.Nonnull;
@@ -61,22 +68,31 @@ public class JEIBotaniaPlugin implements IModPlugin {
 	private static final ResourceLocation ID = new ResourceLocation(LibMisc.MOD_ID, "main");
 
 	@Override
-	public void registerItemSubtypes(@Nonnull ISubtypeRegistration subtypeRegistry) {
-		subtypeRegistry.registerSubtypeInterpreter(ModItems.brewVial, ItemBrewBase::getSubtype);
-		subtypeRegistry.registerSubtypeInterpreter(ModItems.brewFlask, ItemBrewBase::getSubtype);
-		subtypeRegistry.registerSubtypeInterpreter(ModItems.incenseStick, ItemBrewBase::getSubtype);
-		subtypeRegistry.registerSubtypeInterpreter(ModItems.bloodPendant, ItemBrewBase::getSubtype);
+	public void registerItemSubtypes(@Nonnull ISubtypeRegistration registry) {
+		registry.registerSubtypeInterpreter(ModItems.brewVial, ItemBrewBase::getSubtype);
+		registry.registerSubtypeInterpreter(ModItems.brewFlask, ItemBrewBase::getSubtype);
+		registry.registerSubtypeInterpreter(ModItems.incenseStick, ItemBrewBase::getSubtype);
+		registry.registerSubtypeInterpreter(ModItems.bloodPendant, ItemBrewBase::getSubtype);
+
+		registry.registerSubtypeInterpreter(ModItems.twigWand, stack -> ItemTwigWand.getColor1(stack) + "_" + ItemTwigWand.getColor2(stack));
+		registry.registerSubtypeInterpreter(ModItems.flightTiara, stack -> String.valueOf(ItemFlightTiara.getVariant(stack)));
+		registry.registerSubtypeInterpreter(ModItems.lexicon, stack -> String.valueOf(ItemNBTHelper.getBoolean(stack, ItemLexicon.TAG_ELVEN_UNLOCK, true)));
+		registry.registerSubtypeInterpreter(ModItems.laputaShard, stack -> String.valueOf(ItemLaputaShard.getShardLevel(stack)));
+		
+		for(Item item : new Item[]{ModItems.manaTablet, ModItems.manaRing, ModItems.manaRingGreater, ModItems.terraPick}) {
+			registry.registerSubtypeInterpreter(item, stack -> String.valueOf(((IManaItem) item).getMana(stack)));
+		}
 	}
 
 	@Override
 	public void registerCategories(IRecipeCategoryRegistration registry) {
 		registry.addRecipeCategories(
-				new BreweryRecipeCategory(registry.getJeiHelpers().getGuiHelper()),
 				new PureDaisyRecipeCategory(registry.getJeiHelpers().getGuiHelper()),
-				new RunicAltarRecipeCategory(registry.getJeiHelpers().getGuiHelper()), // Runic must come before petals. See williewillus/Botania#172
-				new PetalApothecaryRecipeCategory(registry.getJeiHelpers().getGuiHelper()),
-				new ElvenTradeRecipeCategory(registry.getJeiHelpers().getGuiHelper()),
 				new ManaPoolRecipeCategory(registry.getJeiHelpers().getGuiHelper()),
+				new PetalApothecaryRecipeCategory(registry.getJeiHelpers().getGuiHelper()),
+				new RunicAltarRecipeCategory(registry.getJeiHelpers().getGuiHelper()),
+				new ElvenTradeRecipeCategory(registry.getJeiHelpers().getGuiHelper()),
+				new BreweryRecipeCategory(registry.getJeiHelpers().getGuiHelper()),
 				new OrechidRecipeCategory(registry.getJeiHelpers().getGuiHelper()),
 				new OrechidIgnemRecipeCategory(registry.getJeiHelpers().getGuiHelper())
 		);

--- a/src/main/java/vazkii/botania/common/item/ItemLaputaShard.java
+++ b/src/main/java/vazkii/botania/common/item/ItemLaputaShard.java
@@ -88,7 +88,7 @@ public class ItemLaputaShard extends ItemMod implements ILensEffect, ITinyPlanet
 	@OnlyIn(Dist.CLIENT)
 	@Override
 	public void addInformation(ItemStack stack, World world, List<ITextComponent> list, ITooltipFlag flags) {
-		int level = stack.getOrCreateTag().getInt(TAG_LEVEL);
+		int level = getShardLevel(stack);
 		ITextComponent levelLoc = new TranslationTextComponent("botania.roman" + (level + 1));
 		list.add(new TranslationTextComponent("botaniamisc.shardLevel", levelLoc).applyTextStyle(TextFormatting.GRAY));
 	}
@@ -112,7 +112,7 @@ public class ItemLaputaShard extends ItemMod implements ILensEffect, ITinyPlanet
 	}
 
 	public void spawnBurstFirst(World world, BlockPos pos, ItemStack shard) {
-		int range = BASE_RANGE + shard.getOrCreateTag().getInt(TAG_LEVEL);
+		int range = BASE_RANGE + getShardLevel(shard);
 		boolean pointy = world.rand.nextDouble() < 0.25;
 		double heightscale = (world.rand.nextDouble() + 0.5) * ((double)BASE_RANGE / (double)range);
 		spawnBurst(world, pos, shard, pointy, heightscale);
@@ -126,7 +126,7 @@ public class ItemLaputaShard extends ItemMod implements ILensEffect, ITinyPlanet
 	}
 
 	public void spawnBurst(World world, BlockPos pos, ItemStack shard, boolean pointy, double heightscale) {
-		int range = BASE_RANGE + shard.getOrCreateTag().getInt(TAG_LEVEL);
+		int range = BASE_RANGE + getShardLevel(shard);
 
 		int i = ItemNBTHelper.getInt(shard, TAG_ITERATION_I, 0);
 		int j = ItemNBTHelper.getInt(shard, TAG_ITERATION_J, BASE_OFFSET - BASE_RANGE / 2);
@@ -157,7 +157,7 @@ public class ItemLaputaShard extends ItemMod implements ILensEffect, ITinyPlanet
 								world.destroyBlock(pos_, false);
 
 								ItemStack copyLens = new ItemStack(this);
-								copyLens.getOrCreateTag().putInt(TAG_LEVEL, shard.getOrCreateTag().getInt(TAG_LEVEL));
+								copyLens.getOrCreateTag().putInt(TAG_LEVEL, getShardLevel(shard));
 								copyLens.getTag().put(TAG_STATE, NBTUtil.writeBlockState(state));
 								CompoundNBT cmp = new CompoundNBT();
 								if(tile != null)
@@ -184,6 +184,10 @@ public class ItemLaputaShard extends ItemMod implements ILensEffect, ITinyPlanet
 				j = BASE_OFFSET - BASE_RANGE / 2;
 			}
 		}
+	}
+
+	public static int getShardLevel(ItemStack shard) {
+		return shard.getOrCreateTag().getInt(TAG_LEVEL);
 	}
 
 	private boolean inRange(BlockPos pos, BlockPos srcPos, int range, double heightscale, boolean pointy) {

--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemFlightTiara.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemFlightTiara.java
@@ -103,7 +103,7 @@ public class ItemFlightTiara extends ItemBauble implements IManaUsingItem {
 	@Override
 	public void addHiddenTooltip(ItemStack stack, World world, List<ITextComponent> stacks, ITooltipFlag flags) {
 		super.addHiddenTooltip(stack, world, stacks, flags);
-		stacks.add(new TranslationTextComponent("botania.wings" + ItemNBTHelper.getInt(stack, TAG_VARIANT, 0)));
+		stacks.add(new TranslationTextComponent("botania.wings" + getVariant(stack)));
 	}
 
 	private void updatePlayerFlyStatus(LivingUpdateEvent event) {
@@ -128,7 +128,7 @@ public class ItemFlightTiara extends ItemBauble implements IManaUsingItem {
 							float g = 1F;
 							float b = 1F;
 
-							int variant = ItemNBTHelper.getInt(tiara, TAG_VARIANT, 0);
+							int variant = getVariant(tiara);
 							switch(variant) {
 							case 2 : {
 								r = 0.1F;
@@ -231,7 +231,7 @@ public class ItemFlightTiara extends ItemBauble implements IManaUsingItem {
 	@Override
 	public void onEquipped(ItemStack stack, LivingEntity living) {
 		super.onEquipped(stack, living);
-		int variant = ItemNBTHelper.getInt(stack, TAG_VARIANT, 0);
+		int variant = getVariant(stack);
 		if(variant != WING_TYPES && StringObfuscator.matchesHash(stack.getDisplayName().getString(), SUPER_AWESOME_HASH)) {
 			ItemNBTHelper.setInt(stack, TAG_VARIANT, WING_TYPES);
 			stack.clearCustomName();
@@ -302,7 +302,7 @@ public class ItemFlightTiara extends ItemBauble implements IManaUsingItem {
 	@Override
 	@OnlyIn(Dist.CLIENT)
 	public void doRender(ItemStack stack, LivingEntity player, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch, float scale) {
-		int meta = ItemNBTHelper.getInt(stack, TAG_VARIANT, 0);
+		int meta = getVariant(stack);
 		if(meta > 0 && meta <= MiscellaneousIcons.INSTANCE.tiaraWingIcons.length) {
 			TextureAtlasSprite icon = MiscellaneousIcons.INSTANCE.tiaraWingIcons[meta - 1];
 			Minecraft.getInstance().textureManager.bindTexture(AtlasTexture.LOCATION_BLOCKS_TEXTURE);
@@ -472,7 +472,7 @@ public class ItemFlightTiara extends ItemBauble implements IManaUsingItem {
 
 	@OnlyIn(Dist.CLIENT)
 	public static void renderHUD(PlayerEntity player, ItemStack stack) {
-		int u = Math.max(1, ItemNBTHelper.getInt(stack, TAG_VARIANT, 0)) * 9 - 9;
+		int u = Math.max(1, getVariant(stack)) * 9 - 9;
 		int v = 0;
 
 		Minecraft mc = Minecraft.getInstance();
@@ -514,5 +514,9 @@ public class ItemFlightTiara extends ItemBauble implements IManaUsingItem {
 		GlStateManager.enableAlphaTest();
 		GlStateManager.color4f(1F, 1F, 1F, 1F);
 		mc.textureManager.bindTexture(AbstractGui.GUI_ICONS_LOCATION);
+	}
+
+	public static int getVariant(ItemStack stack) {
+		return ItemNBTHelper.getInt(stack, TAG_VARIANT, 0);
 	}
 }


### PR DESCRIPTION
* JEI now seems to require a subtype interpreter for items that use NBT to even show up more than once in its interface. This makes sure that all the subtyped items actually are registered to use that.
  * I added a convenience method in two of the classes where it would be useful.
* Rearranged the JEI categories to match the progression more - the new order is the progression required parts, then the three optional categories.
  * The note that runic altar must be before the petal apothecary has been removed, as it's been obsoleted by both JEI and Botania changes - recipes must be manually added to a category, and rune recipes no longer extend apothecary ones.