### PR TITLE
[1.12] Fix shedding page NPE, fix entity render making the world fullbright

### DIFF
--- a/src/main/java/vazkii/botania/common/lexicon/page/PageEntity.java
+++ b/src/main/java/vazkii/botania/common/lexicon/page/PageEntity.java
@@ -32,14 +32,14 @@ public class PageEntity extends LexiconPage{
 	int relativeMouseX, relativeMouseY;
 	boolean tooltipEntity;
 	final int size;
-	Constructor entityConstructor;
+	private Constructor<? extends Entity> entityConstructor;
 
 	public PageEntity(String unlocalizedName, String entity, int size) {
 		super(unlocalizedName);
-		Class EntityClass = ForgeRegistries.ENTITIES.getValue(new ResourceLocation(entity)).getEntityClass();
+		Class<? extends Entity> entityClass = ForgeRegistries.ENTITIES.getValue(new ResourceLocation(entity)).getEntityClass();
 		this.size = size;
 		try {
-			entityConstructor = EntityClass.getConstructor(World.class);
+			entityConstructor = entityClass.getConstructor(World.class);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -79,7 +79,7 @@ public class PageEntity extends LexiconPage{
 
 	@SideOnly(Side.CLIENT)
 	public void renderEntity(IGuiLexiconEntry gui, Entity entity, int x, int y, int scale, float rotation) {
-		dummyEntity.world = Minecraft.getMinecraft() != null ? Minecraft.getMinecraft().world : null;
+		dummyEntity.world = Minecraft.getMinecraft().world;
 
 		GlStateManager.enableColorMaterial();
 		GlStateManager.pushMatrix();
@@ -93,9 +93,9 @@ public class PageEntity extends LexiconPage{
 		GlStateManager.popMatrix();
 		RenderHelper.disableStandardItemLighting();
 		GlStateManager.disableRescaleNormal();
-		OpenGlHelper.setActiveTexture(OpenGlHelper.lightmapTexUnit);
+		GlStateManager.setActiveTexture(OpenGlHelper.lightmapTexUnit);
 		GlStateManager.disableTexture2D();
-		OpenGlHelper.setActiveTexture(OpenGlHelper.defaultTexUnit);
+		GlStateManager.setActiveTexture(OpenGlHelper.defaultTexUnit);
 
 		if(relativeMouseX >= x - dummyEntity.width * scale / 2 - 10  && relativeMouseY >= y - dummyEntity.height * scale - 20 && relativeMouseX <= x + dummyEntity.width * scale / 2 + 10 && relativeMouseY <= y + 20)
 			tooltipEntity = true;

--- a/src/main/java/vazkii/botania/common/lexicon/page/PageShedding.java
+++ b/src/main/java/vazkii/botania/common/lexicon/page/PageShedding.java
@@ -41,11 +41,11 @@ public class PageShedding extends PageEntity {
 
 	private static final ResourceLocation sheddingOverlay = new ResourceLocation(LibResources.GUI_SHEDDING_OVERLAY);
 
-	final ItemStack shedStack;
-	ItemStack tooltipStack;
-	boolean tooltipEntry;
+	private final ItemStack shedStack;
+	private ItemStack tooltipStack = ItemStack.EMPTY;
+	private boolean tooltipEntry;
 
-	static boolean mouseDownLastTick = false;
+	private static boolean mouseDownLastTick = false;
 
 	public PageShedding(String unlocalizedName, String entity, int size, ItemStack shedStack) {
 		super(unlocalizedName, entity, size);
@@ -103,7 +103,7 @@ public class PageShedding extends PageEntity {
 			vazkii.botania.client.core.helper.RenderHelper.renderTooltip(mx, my, parsedTooltip);
 		}
 
-		tooltipStack = null;
+		tooltipStack = ItemStack.EMPTY;
 		tooltipEntry = tooltipEntity = false;
 		GlStateManager.disableBlend();
 		mouseDownLastTick = Mouse.isButtonDown(0);


### PR DESCRIPTION
Fixes #2631, fixes #2909, fixes #3036. Null item stacks, 3 years after the release of 1.11. 
As for the second part, I had to compare the code with Patchouli... OpenGlHelper vs GlStateManager, who would win?

Includes some minor cleanups that won't matter in a week, like rawtypes on the entity page construction.