### PR TITLE
Overhaul Corporea to pass around CorporeaRequestMatchers instead of Objects

### DIFF
--- a/src/main/java/vazkii/botania/api/corporea/CorporeaHelper.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaHelper.java
@@ -78,7 +78,7 @@ public final class CorporeaHelper {
 	 * The higher level functions that use a List< IInventory > or a Map< IInventory, Integer > should be
 	 * called instead if the context for those exists to avoid having to get the values again.
 	 */
-	public static int getCountInNetwork(CorporeaRequestMatcher matcher, ICorporeaSpark spark) {
+	public static int getCountInNetwork(ICorporeaRequestMatcher matcher, ICorporeaSpark spark) {
 		List<InvWithLocation> inventories = getInventoriesOnNetwork(spark);
 		return getCountInNetwork(matcher, inventories);
 	}
@@ -88,7 +88,7 @@ public final class CorporeaHelper {
 	 * The higher level function that use a Map< IInventory, Integer > should be
 	 * called instead if the context for this exists to avoid having to get the value again.
 	 */
-	public static int getCountInNetwork(CorporeaRequestMatcher matcher, List<InvWithLocation> inventories) {
+	public static int getCountInNetwork(ICorporeaRequestMatcher matcher, List<InvWithLocation> inventories) {
 		Map<InvWithLocation, Integer> map = getInventoriesWithMatchInNetwork(matcher, inventories);
 		return getCountInNetwork(matcher, map);
 	}
@@ -96,7 +96,7 @@ public final class CorporeaHelper {
 	/**
 	 * Gets the amount of available items in the network of the type passed in, checking NBT or not.
 	 */
-	public static int getCountInNetwork(CorporeaRequestMatcher matcher, Map<InvWithLocation, Integer> inventories) {
+	public static int getCountInNetwork(ICorporeaRequestMatcher matcher, Map<InvWithLocation, Integer> inventories) {
 		int count = 0;
 
 		for(int value : inventories.values())
@@ -110,7 +110,7 @@ public final class CorporeaHelper {
 	 * The higher level function that use a List< IInventory > should be
 	 * called instead if the context for this exists to avoid having to get the value again.
 	 */
-	public static Map<InvWithLocation, Integer> getInventoriesWithMatchInNetwork(CorporeaRequestMatcher matcher, ICorporeaSpark spark) {
+	public static Map<InvWithLocation, Integer> getInventoriesWithMatchInNetwork(ICorporeaRequestMatcher matcher, ICorporeaSpark spark) {
 		List<InvWithLocation> inventories = getInventoriesOnNetwork(spark);
 		return getInventoriesWithMatchInNetwork(matcher, inventories);
 	}
@@ -120,7 +120,7 @@ public final class CorporeaHelper {
 	 * The deeper level function that use a List< IInventory > should be
 	 * called instead if the context for this exists to avoid having to get the value again.
 	 */
-	public static Map<InvWithLocation, Integer> getInventoriesWithMatchInNetwork(CorporeaRequestMatcher matcher, List<InvWithLocation> inventories) {
+	public static Map<InvWithLocation, Integer> getInventoriesWithMatchInNetwork(ICorporeaRequestMatcher matcher, List<InvWithLocation> inventories) {
 		Map<InvWithLocation, Integer> countMap = new HashMap<>();
 		List<IWrappedInventory> wrappedInventories = BotaniaAPI.internalHandler.wrapInventory(inventories);
 		for (IWrappedInventory inv : wrappedInventories) {
@@ -135,16 +135,16 @@ public final class CorporeaHelper {
 	}
 
 	/**
-	 * Create a CorporeaRequestMatcher from an ItemStack and NBT-checkness.
+	 * Create a ICorporeaRequestMatcher from an ItemStack and NBT-checkness.
 	 */
-	public static CorporeaRequestMatcher createMatcher(ItemStack stack, boolean checkNBT) {
+	public static ICorporeaRequestMatcher createMatcher(ItemStack stack, boolean checkNBT) {
 		return new CorporeaItemStackMatcher(stack, checkNBT);
 	}
 
 	/**
-	 * Create a CorporeaRequestMatcher from a String.
+	 * Create a ICorporeaRequestMatcher from a String.
 	 */
-	public static CorporeaRequestMatcher createMatcher(String name) {
+	public static ICorporeaRequestMatcher createMatcher(String name) {
 		return new CorporeaStringMatcher(name);
 	}
 
@@ -175,7 +175,7 @@ public final class CorporeaHelper {
 	 * When requesting counting of items, individual stacks may exceed maxStackSize for
 	 * purposes of counting huge amounts.
 	 */
-	public static List<ItemStack> requestItem(CorporeaRequestMatcher matcher, int itemCount, ICorporeaSpark spark, boolean doit) {
+	public static List<ItemStack> requestItem(ICorporeaRequestMatcher matcher, int itemCount, ICorporeaSpark spark, boolean doit) {
 		List<ItemStack> stacks = new ArrayList<>();
 		CorporeaRequestEvent event = new CorporeaRequestEvent(matcher, itemCount, spark, doit);
 		if(MinecraftForge.EVENT_BUS.post(event))

--- a/src/main/java/vazkii/botania/api/corporea/CorporeaHelper.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaHelper.java
@@ -20,6 +20,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
+import static vazkii.botania.api.corporea.CorporeaRequestDefaultMatchers.*;
 import vazkii.botania.api.BotaniaAPI;
 
 import java.util.ArrayList;
@@ -27,16 +28,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
-import java.util.regex.Pattern;
 
 public final class CorporeaHelper {
 
 	private static final List<InvWithLocation> empty = ImmutableList.of();
 	private static final WeakHashMap<List<ICorporeaSpark>, List<InvWithLocation>> cachedNetworks = new WeakHashMap<>();
-
-	private static final Pattern patternControlCode = Pattern.compile("(?i)\\u00A7[0-9A-FK-OR]");
-
-	public static final String[] WILDCARD_STRINGS = { "...", "~", "+", "?" , "*" };
 
 	/**
 	 * How many items were matched in the last request. If java had "out" params like C# this wouldn't be needed :V
@@ -77,57 +73,57 @@ public final class CorporeaHelper {
 	}
 
 	/**
-	 * Gets the amount of available items in the network of the type passed in, checking NBT or not.
+	 * Gets the number of available items in the network satisfying the given matcher.
 	 * The higher level functions that use a List< IInventory > or a Map< IInventory, Integer > should be
 	 * called instead if the context for those exists to avoid having to get the values again.
 	 */
-	public static int getCountInNetwork(ItemStack stack, ICorporeaSpark spark, boolean checkNBT) {
+	public static int getCountInNetwork(CorporeaRequestMatcher matcher, ICorporeaSpark spark) {
 		List<InvWithLocation> inventories = getInventoriesOnNetwork(spark);
-		return getCountInNetwork(stack, inventories, checkNBT);
+		return getCountInNetwork(matcher, inventories);
 	}
 
 	/**
-	 * Gets the amount of available items in the network of the type passed in, checking NBT or not.
+	 * Gets the number of available items in the network satisfying the given matcher.
 	 * The higher level function that use a Map< IInventory, Integer > should be
 	 * called instead if the context for this exists to avoid having to get the value again.
 	 */
-	public static int getCountInNetwork(ItemStack stack, List<InvWithLocation> inventories, boolean checkNBT) {
-		Map<InvWithLocation, Integer> map = getInventoriesWithItemInNetwork(stack, inventories, checkNBT);
-		return getCountInNetwork(stack, map, checkNBT);
+	public static int getCountInNetwork(CorporeaRequestMatcher matcher, List<InvWithLocation> inventories) {
+		Map<InvWithLocation, Integer> map = getInventoriesWithMatchInNetwork(matcher, inventories);
+		return getCountInNetwork(matcher, map);
 	}
 
 	/**
 	 * Gets the amount of available items in the network of the type passed in, checking NBT or not.
 	 */
-	public static int getCountInNetwork(ItemStack stack, Map<InvWithLocation, Integer> inventories, boolean checkNBT) {
+	public static int getCountInNetwork(CorporeaRequestMatcher matcher, Map<InvWithLocation, Integer> inventories) {
 		int count = 0;
 
-		for(InvWithLocation inv : inventories.keySet())
-			count += inventories.get(inv);
+		for(int value: inventories.values())
+			count += value;
 
 		return count;
 	}
 
 	/**
-	 * Gets a Map mapping IInventories to the amount of items of the type passed in that exist
+	 * Gets a Map mapping IInventories to the number of matching items.
 	 * The higher level function that use a List< IInventory > should be
 	 * called instead if the context for this exists to avoid having to get the value again.
 	 */
-	public static Map<InvWithLocation, Integer> getInventoriesWithItemInNetwork(ItemStack stack, ICorporeaSpark spark, boolean checkNBT) {
+	public static Map<InvWithLocation, Integer> getInventoriesWithMatchInNetwork(CorporeaRequestMatcher matcher, ICorporeaSpark spark) {
 		List<InvWithLocation> inventories = getInventoriesOnNetwork(spark);
-		return getInventoriesWithItemInNetwork(stack, inventories, checkNBT);
+		return getInventoriesWithMatchInNetwork(matcher, inventories);
 	}
 
 	/**
-	 * Gets a Map mapping IInventories to the amount of items of the type passed in that exist
+	 * Gets a Map mapping IInventories to the number of matching items.
 	 * The deeper level function that use a List< IInventory > should be
 	 * called instead if the context for this exists to avoid having to get the value again.
 	 */
-	public static Map<InvWithLocation, Integer> getInventoriesWithItemInNetwork(ItemStack stack, List<InvWithLocation> inventories, boolean checkNBT) {
+	public static Map<InvWithLocation, Integer> getInventoriesWithMatchInNetwork(CorporeaRequestMatcher matcher, List<InvWithLocation> inventories) {
 		Map<InvWithLocation, Integer> countMap = new HashMap<>();
 		List<IWrappedInventory> wrappedInventories = BotaniaAPI.internalHandler.wrapInventory(inventories);
 		for (IWrappedInventory inv : wrappedInventories) {
-			CorporeaRequest request = new CorporeaRequest(stack, checkNBT, -1);
+			CorporeaRequest request = new CorporeaRequest(matcher, -1);
 			inv.countItems(request);
 			if (request.foundItems > 0) {
 				countMap.put(inv.getWrappedObject(), request.foundItems);
@@ -138,17 +134,31 @@ public final class CorporeaHelper {
 	}
 
 	/**
+	 * Create a CorporeaRequestMatcher from an ItemStack and NBT-checkness.
+	 */
+	public static CorporeaRequestMatcher createMatcher(ItemStack stack, boolean checkNBT) {
+		return new CorporeaItemStackMatcher(stack, checkNBT);
+	}
+
+	/**
+	 * Create a CorporeaRequestMatcher from a String.
+	 */
+	public static CorporeaRequestMatcher createMatcher(String name) {
+		return new CorporeaStringMatcher(name);
+	}
+
+	/**
 	 * Bridge for requestItem() using an ItemStack.
 	 */
 	public static List<ItemStack> requestItem(ItemStack stack, ICorporeaSpark spark, boolean checkNBT, boolean doit) {
-		return requestItem(stack, stack.getCount(), spark, checkNBT, doit);
+		return requestItem(createMatcher(stack, checkNBT), stack.getCount(), spark, doit);
 	}
 
 	/**
 	 * Bridge for requestItem() using a String and an item count.
 	 */
 	public static List<ItemStack> requestItem(String name, int count, ICorporeaSpark spark, boolean doit) {
-		return requestItem(name, count, spark, false, doit);
+		return requestItem(createMatcher(name), count, spark, doit);
 	}
 
 	/**
@@ -164,9 +174,9 @@ public final class CorporeaHelper {
 	 * When requesting counting of items, individual stacks may exceed maxStackSize for
 	 * purposes of counting huge amounts.
 	 */
-	public static List<ItemStack> requestItem(Object matcher, int itemCount, ICorporeaSpark spark, boolean checkNBT, boolean doit) {
+	public static List<ItemStack> requestItem(CorporeaRequestMatcher matcher, int itemCount, ICorporeaSpark spark, boolean doit) {
 		List<ItemStack> stacks = new ArrayList<>();
-		CorporeaRequestEvent event = new CorporeaRequestEvent(matcher, itemCount, spark, checkNBT, doit);
+		CorporeaRequestEvent event = new CorporeaRequestEvent(matcher, itemCount, spark, doit);
 		if(MinecraftForge.EVENT_BUS.post(event))
 			return stacks;
 
@@ -175,7 +185,7 @@ public final class CorporeaHelper {
 		List<IWrappedInventory> inventoriesW = BotaniaAPI.internalHandler.wrapInventory(inventories);
 		Map<ICorporeaInterceptor, ICorporeaSpark> interceptors = new HashMap<ICorporeaInterceptor, ICorporeaSpark>();
 
-		CorporeaRequest request = new CorporeaRequest(matcher, checkNBT, itemCount);
+		CorporeaRequest request = new CorporeaRequest(matcher, itemCount);
 		for(IWrappedInventory inv : inventoriesW) {
 			ICorporeaSpark invSpark = inv.getSpark();
 
@@ -228,57 +238,11 @@ public final class CorporeaHelper {
 	}
 
 	/**
-	 * Gets if two stacks match.
-	 */
-	public static boolean stacksMatch(ItemStack stack1, ItemStack stack2, boolean checkNBT) {
-		return !stack1.isEmpty() && !stack2.isEmpty() && stack1.isItemEqual(stack2) && (!checkNBT || ItemStack.areItemStackTagsEqual(stack1, stack2));
-	}
-
-	/**
-	 * Gets if the name of a stack matches the string passed in.
-	 */
-	public static boolean stacksMatch(ItemStack stack, String s) {
-		if(stack.isEmpty())
-			return false;
-
-		boolean contains = false;
-		for(String wc : WILDCARD_STRINGS) {
-			if(s.endsWith(wc)) {
-				contains = true;
-				s = s.substring(0, s.length() - wc.length());
-			}
-			else if(s.startsWith(wc)) {
-				contains = true;
-				s = s.substring(wc.length());
-			}
-
-			if(contains)
-				break;
-		}
-
-
-		String name = stripControlCodes(stack.getDisplayName().getString().toLowerCase().trim());
-		return equalOrContain(name, s, contains) || equalOrContain(name + "s", s, contains) || equalOrContain(name + "es", s, contains) || name.endsWith("y") && equalOrContain(name.substring(0, name.length() - 1) + "ies", s, contains);
-	}
-
-	/**
 	 * Clears the cached networks, called once per tick, should not be called outside
 	 * of the botania code.
 	 */
 	public static void clearCache() {
 		cachedNetworks.clear();
-	}
-
-	/**
-	 * Helper method to make stacksMatch() less messy.
-	 */
-	public static boolean equalOrContain(String s1, String s2, boolean contain) {
-		return contain ? s1.contains(s2) : s1.equals(s2);
-	}
-
-	// Copy from StringUtils
-	public static String stripControlCodes(String str) {
-		return patternControlCode.matcher(str).replaceAll("");
 	}
 	
 	/** 

--- a/src/main/java/vazkii/botania/api/corporea/CorporeaHelper.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaHelper.java
@@ -20,7 +20,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
-import static vazkii.botania.api.corporea.CorporeaRequestDefaultMatchers.*;
 import vazkii.botania.api.BotaniaAPI;
 
 import java.util.ArrayList;
@@ -28,6 +27,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
+
+import static vazkii.botania.api.corporea.CorporeaRequestDefaultMatchers.*;
 
 public final class CorporeaHelper {
 
@@ -98,7 +99,7 @@ public final class CorporeaHelper {
 	public static int getCountInNetwork(CorporeaRequestMatcher matcher, Map<InvWithLocation, Integer> inventories) {
 		int count = 0;
 
-		for(int value: inventories.values())
+		for(int value : inventories.values())
 			count += value;
 
 		return count;

--- a/src/main/java/vazkii/botania/api/corporea/CorporeaRequest.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaRequest.java
@@ -10,12 +10,12 @@
 package vazkii.botania.api.corporea;
 
 public class CorporeaRequest {
-	public final CorporeaRequestMatcher matcher;
+	public final ICorporeaRequestMatcher matcher;
 	public int count;
 	public int foundItems = 0;
 	public int extractedItems = 0;
 
-	public CorporeaRequest(CorporeaRequestMatcher matcher, int count) {
+	public CorporeaRequest(ICorporeaRequestMatcher matcher, int count) {
 		super();
 		this.matcher = matcher;
 		this.count = count;

--- a/src/main/java/vazkii/botania/api/corporea/CorporeaRequest.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaRequest.java
@@ -10,16 +10,14 @@
 package vazkii.botania.api.corporea;
 
 public class CorporeaRequest {
-	public final Object matcher;
-	public final boolean checkNBT;
+	public final CorporeaRequestMatcher matcher;
 	public int count;
 	public int foundItems = 0;
 	public int extractedItems = 0;
 
-	public CorporeaRequest(Object matcher, boolean checkNBT, int count) {
+	public CorporeaRequest(CorporeaRequestMatcher matcher, int count) {
 		super();
 		this.matcher = matcher;
-		this.checkNBT = checkNBT;
 		this.count = count;
 	}
 

--- a/src/main/java/vazkii/botania/api/corporea/CorporeaRequestDefaultMatchers.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaRequestDefaultMatchers.java
@@ -1,0 +1,121 @@
+/**
+ * This class was created by <Alwinfy>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ *
+ * File Created @ [Dec 22, 2019, 11:13:14 PM (GMT)]
+ */
+package vazkii.botania.api.corporea;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+
+import java.util.regex.Pattern;
+
+/**
+ * An interface for a Corporea Request matcher. Accepts an ItemStack and returns whether it fulfills the request.
+ * Needs to be registered over in {@link vazkii.botania.common.block.tile.corporea.TileCorporeaRetainer.corporeaMatchers}.
+ */
+public final class CorporeaRequestDefaultMatchers {
+
+	public static class CorporeaStringMatcher extends CorporeaRequestMatcher {
+
+		private static final Pattern patternControlCode = Pattern.compile("(?i)\\u00A7[0-9A-FK-OR]");
+		public static final String[] WILDCARD_STRINGS = { "...", "~", "+", "?" , "*" };
+		private static final String TAG_REQUEST_CONTENTS = "requestContents";
+		private static final String TAG_REQUEST_CONTAINS = "requestContains";
+
+		private final String expression;
+		private final boolean contains;
+
+		public CorporeaStringMatcher(String expression) {
+			boolean contains = false;
+			for(String wc : WILDCARD_STRINGS) {
+				if(expression.endsWith(wc)) {
+					contains = true;
+					expression = expression.substring(0, expression.length() - wc.length());
+				}
+				else if(expression.startsWith(wc)) {
+					contains = true;
+					expression = expression.substring(wc.length());
+				}
+
+				if(contains)
+					break;
+			}
+			this.expression = expression;
+			this.contains = contains;
+		}
+		private CorporeaStringMatcher(String expression, boolean contains) {
+			this.expression = expression;
+			this.contains = contains;
+		}
+
+		@Override
+		public boolean isStackValid(ItemStack stack) {
+			if(stack.isEmpty())
+				return false;
+
+			String name = stripControlCodes(stack.getDisplayName().getString().toLowerCase().trim());
+			return equalOrContain(name)
+				|| equalOrContain(name + "s")
+				|| equalOrContain(name + "es")
+				|| name.endsWith("y") && equalOrContain(name.substring(0, name.length() - 1) + "ies");
+		}
+
+		public static CorporeaRequestMatcher createFromNBT(CompoundNBT tag) {
+			String expression = tag.getString(TAG_REQUEST_CONTENTS);
+			boolean contains = tag.getBoolean(TAG_REQUEST_CONTAINS);
+			return new CorporeaStringMatcher(expression, contains);
+		}
+
+		@Override
+		public void writeToNBT(CompoundNBT tag) {
+			tag.putString(TAG_REQUEST_CONTENTS, expression);
+			tag.putBoolean(TAG_REQUEST_CONTAINS, contains);
+		}
+
+		public boolean equalOrContain(String str) {
+			return contains ? str.contains(expression) : str.equals(expression);
+		}
+
+		// Copy from StringUtils
+		public static String stripControlCodes(String str) {
+			return patternControlCode.matcher(str).replaceAll("");
+		}
+	}
+
+	public static class CorporeaItemStackMatcher extends CorporeaRequestMatcher {
+		private static final String TAG_REQUEST_STACK = "requestStack";
+		private static final String TAG_REQUEST_CHECK_NBT = "requestCheckNBT";
+		
+		private final ItemStack match;
+		private final boolean checkNBT;
+
+		public CorporeaItemStackMatcher(ItemStack match, boolean checkNBT) {
+			this.match = match;
+			this.checkNBT = checkNBT;
+		}
+
+		@Override
+		public boolean isStackValid(ItemStack stack) {
+			return !stack.isEmpty() && !match.isEmpty() && stack.isItemEqual(match) && (!checkNBT || ItemStack.areItemStackTagsEqual(stack, match));
+		}
+
+		public static CorporeaRequestMatcher createFromNBT(CompoundNBT tag) {
+			return new CorporeaItemStackMatcher(ItemStack.read(tag.getCompound(TAG_REQUEST_STACK)), tag.getBoolean(TAG_REQUEST_CHECK_NBT));
+		}
+
+		@Override
+		public void writeToNBT(CompoundNBT tag) {
+			CompoundNBT cmp = match.write(new CompoundNBT());
+			tag.put(TAG_REQUEST_STACK, cmp);
+			tag.putBoolean(TAG_REQUEST_CHECK_NBT, checkNBT);
+		}
+	}
+
+	private CorporeaRequestDefaultMatchers() {}
+}

--- a/src/main/java/vazkii/botania/api/corporea/CorporeaRequestDefaultMatchers.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaRequestDefaultMatchers.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
  */
 public final class CorporeaRequestDefaultMatchers {
 
-	public static class CorporeaStringMatcher extends CorporeaRequestMatcher {
+	public static class CorporeaStringMatcher implements ICorporeaRequestMatcher {
 
 		private static final Pattern patternControlCode = Pattern.compile("(?i)\\u00A7[0-9A-FK-OR]");
 		public static final String[] WILDCARD_STRINGS = { "...", "~", "+", "?" , "*" };
@@ -66,7 +66,7 @@ public final class CorporeaRequestDefaultMatchers {
 				|| name.endsWith("y") && equalOrContain(name.substring(0, name.length() - 1) + "ies");
 		}
 
-		public static CorporeaRequestMatcher createFromNBT(CompoundNBT tag) {
+		public static ICorporeaRequestMatcher createFromNBT(CompoundNBT tag) {
 			String expression = tag.getString(TAG_REQUEST_CONTENTS);
 			boolean contains = tag.getBoolean(TAG_REQUEST_CONTAINS);
 			return new CorporeaStringMatcher(expression, contains);
@@ -88,10 +88,10 @@ public final class CorporeaRequestDefaultMatchers {
 		}
 	}
 
-	public static class CorporeaItemStackMatcher extends CorporeaRequestMatcher {
+	public static class CorporeaItemStackMatcher implements ICorporeaRequestMatcher {
 		private static final String TAG_REQUEST_STACK = "requestStack";
 		private static final String TAG_REQUEST_CHECK_NBT = "requestCheckNBT";
-		
+
 		private final ItemStack match;
 		private final boolean checkNBT;
 
@@ -105,7 +105,7 @@ public final class CorporeaRequestDefaultMatchers {
 			return !stack.isEmpty() && !match.isEmpty() && stack.isItemEqual(match) && (!checkNBT || ItemStack.areItemStackTagsEqual(stack, match));
 		}
 
-		public static CorporeaRequestMatcher createFromNBT(CompoundNBT tag) {
+		public static ICorporeaRequestMatcher createFromNBT(CompoundNBT tag) {
 			return new CorporeaItemStackMatcher(ItemStack.read(tag.getCompound(TAG_REQUEST_STACK)), tag.getBoolean(TAG_REQUEST_CHECK_NBT));
 		}
 

--- a/src/main/java/vazkii/botania/api/corporea/CorporeaRequestEvent.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaRequestEvent.java
@@ -19,20 +19,18 @@ import net.minecraftforge.eventbus.api.Event;
 @Cancelable
 public class CorporeaRequestEvent extends Event {
 
-	public final Object request;
+	public final CorporeaRequestMatcher request;
 	public final int count;
 	public final ICorporeaSpark spark;
-	public final boolean checkNBT;
 	/**
 	 * If false then items won't be pulled.
 	 */
 	public final boolean realRequest;
 
-	public CorporeaRequestEvent(Object request, int count, ICorporeaSpark spark, boolean nbt, boolean real) {
+	public CorporeaRequestEvent(CorporeaRequestMatcher request, int count, ICorporeaSpark spark, boolean real) {
 		this.request = request;
 		this.count = count;
 		this.spark = spark;
-		checkNBT = nbt;
 		realRequest = real;
 	}
 

--- a/src/main/java/vazkii/botania/api/corporea/CorporeaRequestEvent.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaRequestEvent.java
@@ -19,7 +19,7 @@ import net.minecraftforge.eventbus.api.Event;
 @Cancelable
 public class CorporeaRequestEvent extends Event {
 
-	public final CorporeaRequestMatcher request;
+	public final ICorporeaRequestMatcher request;
 	public final int count;
 	public final ICorporeaSpark spark;
 	/**
@@ -27,7 +27,7 @@ public class CorporeaRequestEvent extends Event {
 	 */
 	public final boolean realRequest;
 
-	public CorporeaRequestEvent(CorporeaRequestMatcher request, int count, ICorporeaSpark spark, boolean real) {
+	public CorporeaRequestEvent(ICorporeaRequestMatcher request, int count, ICorporeaSpark spark, boolean real) {
 		this.request = request;
 		this.count = count;
 		this.spark = spark;

--- a/src/main/java/vazkii/botania/api/corporea/CorporeaRequestMatcher.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaRequestMatcher.java
@@ -1,0 +1,36 @@
+/**
+ * This class was created by <Alwinfy>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ *
+ * File Created @ [Dec 22, 2019, 11:13:14 PM (GMT)]
+ */
+package vazkii.botania.api.corporea;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+
+/**
+ * An interface for a Corporea Request matcher. Accepts an ItemStack and returns whether it fulfills the request.
+ * Needs to be registered over in {@link vazkii.botania.common.block.tile.corporea.TileCorporeaRetainer.corporeaMatchers}.
+ * Needs one additional [static] method for deserialization, which can't really go here because Java doesn't like static abstract's.
+ */
+public abstract class CorporeaRequestMatcher {
+
+	/**
+	 * Returns whether the given stack matches the request's criteria.
+	 * Will always return false; subclasses should override.
+	 */
+	public boolean isStackValid(ItemStack stack) {
+		return false;
+	}
+
+	/**
+	 * Serialize to NBT data, for the Corporea Retainer's benefit.
+	 * No-op; should be overridden by subclasses.
+	 */
+	public void writeToNBT(CompoundNBT tag) {}
+}

--- a/src/main/java/vazkii/botania/api/corporea/ICorporeaInterceptor.java
+++ b/src/main/java/vazkii/botania/api/corporea/ICorporeaInterceptor.java
@@ -25,13 +25,13 @@ public interface ICorporeaInterceptor {
 	 * at this point, but the list of stacks is not complete. The request parameter can
 	 * be either a String or ItemStack.
 	 */
-	public void interceptRequest(CorporeaRequestMatcher request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit);
+	public void interceptRequest(ICorporeaRequestMatcher request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit);
 
 	/**
 	 * Intercepts a request after all the stacks have been found and processed. Both the
 	 * list of inventories and stacks is complete at this point. The request parameter can
 	 * be either a String or ItemStack.
 	 */
-	public void interceptRequestLast(CorporeaRequestMatcher request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit);
+	public void interceptRequestLast(ICorporeaRequestMatcher request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit);
 
 }

--- a/src/main/java/vazkii/botania/api/corporea/ICorporeaInterceptor.java
+++ b/src/main/java/vazkii/botania/api/corporea/ICorporeaInterceptor.java
@@ -25,13 +25,13 @@ public interface ICorporeaInterceptor {
 	 * at this point, but the list of stacks is not complete. The request parameter can
 	 * be either a String or ItemStack.
 	 */
-	public void interceptRequest(Object request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit);
+	public void interceptRequest(CorporeaRequestMatcher request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit);
 
 	/**
 	 * Intercepts a request after all the stacks have been found and processed. Both the
 	 * list of inventories and stacks is complete at this point. The request parameter can
 	 * be either a String or ItemStack.
 	 */
-	public void interceptRequestLast(Object request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit);
+	public void interceptRequestLast(CorporeaRequestMatcher request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit);
 
 }

--- a/src/main/java/vazkii/botania/api/corporea/ICorporeaRequestMatcher.java
+++ b/src/main/java/vazkii/botania/api/corporea/ICorporeaRequestMatcher.java
@@ -16,21 +16,17 @@ import net.minecraft.nbt.CompoundNBT;
 /**
  * An interface for a Corporea Request matcher. Accepts an ItemStack and returns whether it fulfills the request.
  * Needs to be registered over in {@link vazkii.botania.common.block.tile.corporea.TileCorporeaRetainer.corporeaMatchers}.
- * Needs one additional [static] method for deserialization, which can't really go here because Java doesn't like static abstract's.
+ * Needs one additional (static) method for deserialization, which can't really go here because Java doesn't like static abstract's.
  */
-public abstract class CorporeaRequestMatcher {
+public interface ICorporeaRequestMatcher {
 
 	/**
 	 * Returns whether the given stack matches the request's criteria.
-	 * Will always return false; subclasses should override.
 	 */
-	public boolean isStackValid(ItemStack stack) {
-		return false;
-	}
+	public boolean isStackValid(ItemStack stack);
 
 	/**
 	 * Serialize to NBT data, for the Corporea Retainer's benefit.
-	 * No-op; should be overridden by subclasses.
 	 */
-	public void writeToNBT(CompoundNBT tag) {}
+	public void writeToNBT(CompoundNBT tag);
 }

--- a/src/main/java/vazkii/botania/api/corporea/ICorporeaRequestor.java
+++ b/src/main/java/vazkii/botania/api/corporea/ICorporeaRequestor.java
@@ -20,6 +20,6 @@ public interface ICorporeaRequestor {
 	/*
 	 * Executes the passed in request.
 	 */
-	public void doCorporeaRequest(CorporeaRequestMatcher request, int count, ICorporeaSpark spark);
+	public void doCorporeaRequest(ICorporeaRequestMatcher request, int count, ICorporeaSpark spark);
 
 }

--- a/src/main/java/vazkii/botania/api/corporea/ICorporeaRequestor.java
+++ b/src/main/java/vazkii/botania/api/corporea/ICorporeaRequestor.java
@@ -20,6 +20,6 @@ public interface ICorporeaRequestor {
 	/*
 	 * Executes the passed in request.
 	 */
-	public void doCorporeaRequest(Object request, int count, ICorporeaSpark spark);
+	public void doCorporeaRequest(CorporeaRequestMatcher request, int count, ICorporeaSpark spark);
 
 }

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaCrystalCube.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaCrystalCube.java
@@ -18,6 +18,7 @@ import net.minecraft.tileentity.TileEntityType;
 import net.minecraftforge.registries.ObjectHolder;
 import vazkii.botania.api.corporea.CorporeaHelper;
 import vazkii.botania.api.corporea.ICorporeaRequestor;
+import vazkii.botania.api.corporea.CorporeaRequestMatcher;
 import vazkii.botania.api.corporea.ICorporeaSpark;
 import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.common.lib.LibBlockNames;
@@ -76,7 +77,7 @@ public class TileCorporeaCrystalCube extends TileCorporeaBase implements ICorpor
 		ICorporeaSpark spark = getSpark();
 		if(spark != null && spark.getMaster() != null && requestTarget != null) {
 			int count = fullStack ? requestTarget.getMaxStackSize() : 1;
-			doCorporeaRequest(requestTarget, count, spark);
+			doCorporeaRequest(CorporeaHelper.createMatcher(requestTarget, true), count, spark);
 		}
 	}
 
@@ -88,7 +89,7 @@ public class TileCorporeaCrystalCube extends TileCorporeaBase implements ICorpor
 		itemCount = 0;
 		ICorporeaSpark spark = getSpark();
 		if(spark != null && spark.getMaster() != null && requestTarget != null) {
-			List<ItemStack> stacks = CorporeaHelper.requestItem(requestTarget, -1, spark, true, false);
+			List<ItemStack> stacks = CorporeaHelper.requestItem(CorporeaHelper.createMatcher(requestTarget, true), -1, spark, false);
 			for(ItemStack stack : stacks)
 				itemCount += stack.getCount();
 		}
@@ -131,11 +132,8 @@ public class TileCorporeaCrystalCube extends TileCorporeaBase implements ICorpor
 	}
 
 	@Override
-	public void doCorporeaRequest(Object request, int count, ICorporeaSpark spark) {
-		if(!(request instanceof ItemStack))
-			return;
-
-		List<ItemStack> stacks = CorporeaHelper.requestItem(request, count, spark, true, true);
+	public void doCorporeaRequest(CorporeaRequestMatcher request, int count, ICorporeaSpark spark) {
+		List<ItemStack> stacks = CorporeaHelper.requestItem(request, count, spark, true);
 		spark.onItemsRequested(stacks);
 		boolean did = false;
 		for(ItemStack reqStack : stacks)

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaCrystalCube.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaCrystalCube.java
@@ -18,7 +18,7 @@ import net.minecraft.tileentity.TileEntityType;
 import net.minecraftforge.registries.ObjectHolder;
 import vazkii.botania.api.corporea.CorporeaHelper;
 import vazkii.botania.api.corporea.ICorporeaRequestor;
-import vazkii.botania.api.corporea.CorporeaRequestMatcher;
+import vazkii.botania.api.corporea.ICorporeaRequestMatcher;
 import vazkii.botania.api.corporea.ICorporeaSpark;
 import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.common.lib.LibBlockNames;
@@ -132,7 +132,7 @@ public class TileCorporeaCrystalCube extends TileCorporeaBase implements ICorpor
 	}
 
 	@Override
-	public void doCorporeaRequest(CorporeaRequestMatcher request, int count, ICorporeaSpark spark) {
+	public void doCorporeaRequest(ICorporeaRequestMatcher request, int count, ICorporeaSpark spark) {
 		List<ItemStack> stacks = CorporeaHelper.requestItem(request, count, spark, true);
 		spark.onItemsRequested(stacks);
 		boolean did = false;

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaFunnel.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaFunnel.java
@@ -21,7 +21,7 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.registries.ObjectHolder;
 import vazkii.botania.api.corporea.CorporeaHelper;
-import vazkii.botania.api.corporea.CorporeaRequestMatcher;
+import vazkii.botania.api.corporea.ICorporeaRequestMatcher;
 import vazkii.botania.api.corporea.ICorporeaRequestor;
 import vazkii.botania.api.corporea.ICorporeaSpark;
 import vazkii.botania.common.core.helper.InventoryHelper;
@@ -79,7 +79,7 @@ public class TileCorporeaFunnel extends TileCorporeaBase implements ICorporeaReq
 	}
 
 	@Override
-	public void doCorporeaRequest(CorporeaRequestMatcher request, int count, ICorporeaSpark spark) {
+	public void doCorporeaRequest(ICorporeaRequestMatcher request, int count, ICorporeaSpark spark) {
 		IItemHandler inv = getInv();
 
 		List<ItemStack> stacks = CorporeaHelper.requestItem(request, count, spark, true);

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaFunnel.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaFunnel.java
@@ -21,6 +21,7 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.registries.ObjectHolder;
 import vazkii.botania.api.corporea.CorporeaHelper;
+import vazkii.botania.api.corporea.CorporeaRequestMatcher;
 import vazkii.botania.api.corporea.ICorporeaRequestor;
 import vazkii.botania.api.corporea.ICorporeaSpark;
 import vazkii.botania.common.core.helper.InventoryHelper;
@@ -47,7 +48,7 @@ public class TileCorporeaFunnel extends TileCorporeaBase implements ICorporeaReq
 				ItemStack stack = filter.get(world.rand.nextInt(filter.size()));
 
 				if(!stack.isEmpty())
-					doCorporeaRequest(stack, stack.getCount(), spark);
+					doCorporeaRequest(CorporeaHelper.createMatcher(stack, true), stack.getCount(), spark);
 			}
 		}
 	}
@@ -78,13 +79,10 @@ public class TileCorporeaFunnel extends TileCorporeaBase implements ICorporeaReq
 	}
 
 	@Override
-	public void doCorporeaRequest(Object request, int count, ICorporeaSpark spark) {
-		if(!(request instanceof ItemStack))
-			return;
-
+	public void doCorporeaRequest(CorporeaRequestMatcher request, int count, ICorporeaSpark spark) {
 		IItemHandler inv = getInv();
 
-		List<ItemStack> stacks = CorporeaHelper.requestItem(request, count, spark, true, true);
+		List<ItemStack> stacks = CorporeaHelper.requestItem(request, count, spark, true);
 		spark.onItemsRequested(stacks);
 		for(ItemStack reqStack : stacks) {
 			if(inv != null && ItemHandlerHelper.insertItemStacked(inv, reqStack, true).isEmpty())

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaIndex.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaIndex.java
@@ -30,7 +30,7 @@ import net.minecraftforge.registries.ObjectHolder;
 import org.apache.commons.lang3.text.WordUtils;
 import vazkii.botania.api.corporea.CorporeaHelper;
 import vazkii.botania.api.corporea.CorporeaIndexRequestEvent;
-import vazkii.botania.api.corporea.CorporeaRequestMatcher;
+import vazkii.botania.api.corporea.ICorporeaRequestMatcher;
 import vazkii.botania.api.corporea.ICorporeaRequestor;
 import vazkii.botania.api.corporea.ICorporeaSpark;
 import vazkii.botania.common.advancements.CorporeaRequestTrigger;
@@ -212,7 +212,7 @@ public class TileCorporeaIndex extends TileCorporeaBase implements ICorporeaRequ
 	}
 
 	@Override
-	public void doCorporeaRequest(CorporeaRequestMatcher request, int count, ICorporeaSpark spark) {
+	public void doCorporeaRequest(ICorporeaRequestMatcher request, int count, ICorporeaSpark spark) {
 		List<ItemStack> stacks = CorporeaHelper.requestItem(request, count, spark, true);
 		spark.onItemsRequested(stacks);
 		for(ItemStack stack : stacks)

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaIndex.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaIndex.java
@@ -30,6 +30,7 @@ import net.minecraftforge.registries.ObjectHolder;
 import org.apache.commons.lang3.text.WordUtils;
 import vazkii.botania.api.corporea.CorporeaHelper;
 import vazkii.botania.api.corporea.CorporeaIndexRequestEvent;
+import vazkii.botania.api.corporea.CorporeaRequestMatcher;
 import vazkii.botania.api.corporea.ICorporeaRequestor;
 import vazkii.botania.api.corporea.ICorporeaSpark;
 import vazkii.botania.common.advancements.CorporeaRequestTrigger;
@@ -211,11 +212,8 @@ public class TileCorporeaIndex extends TileCorporeaBase implements ICorporeaRequ
 	}
 
 	@Override
-	public void doCorporeaRequest(Object request, int count, ICorporeaSpark spark) {
-		if(!(request instanceof String))
-			return;
-
-		List<ItemStack> stacks = CorporeaHelper.requestItem((String) request, count, spark, true);
+	public void doCorporeaRequest(CorporeaRequestMatcher request, int count, ICorporeaSpark spark) {
+		List<ItemStack> stacks = CorporeaHelper.requestItem(request, count, spark, true);
 		spark.onItemsRequested(stacks);
 		for(ItemStack stack : stacks)
 			if(!stack.isEmpty()) {
@@ -286,7 +284,7 @@ public class TileCorporeaIndex extends TileCorporeaBase implements ICorporeaRequ
 						
 						CorporeaIndexRequestEvent indexReqEvent = new CorporeaIndexRequestEvent(event.getPlayer(), name, count, spark);
 						if(!MinecraftForge.EVENT_BUS.post(indexReqEvent)) {
-							index.doCorporeaRequest(name, count, spark);
+							index.doCorporeaRequest(CorporeaHelper.createMatcher(name), count, spark);
 							
 							event.getPlayer().sendMessage(new TranslationTextComponent("botaniamisc.requestMsg", count, WordUtils.capitalizeFully(name), CorporeaHelper.lastRequestMatches, CorporeaHelper.lastRequestExtractions).setStyle(new Style().setColor(TextFormatting.LIGHT_PURPLE)));
 							CorporeaRequestTrigger.INSTANCE.trigger(event.getPlayer(), event.getPlayer().getServerWorld(), index.getPos(), CorporeaHelper.lastRequestExtractions);

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaInterceptor.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaInterceptor.java
@@ -19,7 +19,7 @@ import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraftforge.registries.ObjectHolder;
 import vazkii.botania.api.corporea.CorporeaHelper;
 import vazkii.botania.api.corporea.ICorporeaInterceptor;
-import vazkii.botania.api.corporea.CorporeaRequestMatcher;
+import vazkii.botania.api.corporea.ICorporeaRequestMatcher;
 import vazkii.botania.api.corporea.ICorporeaSpark;
 import vazkii.botania.api.corporea.InvWithLocation;
 import vazkii.botania.api.state.BotaniaStateProps;
@@ -38,10 +38,10 @@ public class TileCorporeaInterceptor extends TileCorporeaBase implements ICorpor
 	}
 
 	@Override
-	public void interceptRequest(CorporeaRequestMatcher request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit) {}
+	public void interceptRequest(ICorporeaRequestMatcher request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit) {}
 
 	@Override
-	public void interceptRequestLast(CorporeaRequestMatcher request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit) {
+	public void interceptRequestLast(ICorporeaRequestMatcher request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit) {
 		List<ItemStack> filter = getFilter();
 		for(ItemStack stack : filter)
 			if(request.isStackValid(stack)) {

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaInterceptor.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaInterceptor.java
@@ -19,6 +19,7 @@ import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraftforge.registries.ObjectHolder;
 import vazkii.botania.api.corporea.CorporeaHelper;
 import vazkii.botania.api.corporea.ICorporeaInterceptor;
+import vazkii.botania.api.corporea.CorporeaRequestMatcher;
 import vazkii.botania.api.corporea.ICorporeaSpark;
 import vazkii.botania.api.corporea.InvWithLocation;
 import vazkii.botania.api.state.BotaniaStateProps;
@@ -37,13 +38,13 @@ public class TileCorporeaInterceptor extends TileCorporeaBase implements ICorpor
 	}
 
 	@Override
-	public void interceptRequest(Object request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit) {}
+	public void interceptRequest(CorporeaRequestMatcher request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit) {}
 
 	@Override
-	public void interceptRequestLast(Object request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit) {
+	public void interceptRequestLast(CorporeaRequestMatcher request, int count, ICorporeaSpark spark, ICorporeaSpark source, List<ItemStack> stacks, List<InvWithLocation> inventories, boolean doit) {
 		List<ItemStack> filter = getFilter();
 		for(ItemStack stack : filter)
-			if(requestMatches(request, stack)) {
+			if(request.isStackValid(stack)) {
 				int missing = count;
 				for(ItemStack stack_ : stacks)
 					missing -= stack_.getCount();
@@ -63,19 +64,6 @@ public class TileCorporeaInterceptor extends TileCorporeaBase implements ICorpor
 				}
 			}
 
-	}
-
-	public boolean requestMatches(Object request, ItemStack filter) {
-		if(filter.isEmpty())
-			return false;
-
-		if(request instanceof ItemStack) {
-			ItemStack stack = (ItemStack) request;
-			return !stack.isEmpty() && stack.isItemEqual(filter) && ItemStack.areItemStackTagsEqual(filter, stack);
-		}
-
-		String name = (String) request;
-		return CorporeaHelper.stacksMatch(filter, name);
 	}
 
 	public List<ItemStack> getFilter() {

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaRetainer.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaRetainer.java
@@ -17,7 +17,6 @@ import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.registries.ObjectHolder;
 import vazkii.botania.api.corporea.CorporeaHelper;
-import static vazkii.botania.api.corporea.CorporeaRequestDefaultMatchers.*;
 import vazkii.botania.api.corporea.CorporeaRequestMatcher;
 import vazkii.botania.api.corporea.ICorporeaRequestor;
 import vazkii.botania.api.corporea.ICorporeaSpark;
@@ -29,6 +28,8 @@ import vazkii.botania.common.lib.LibMisc;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
+
+import static vazkii.botania.api.corporea.CorporeaRequestDefaultMatchers.*;
 
 public class TileCorporeaRetainer extends TileMod {
 	@ObjectHolder(LibMisc.MOD_ID + ":" + LibBlockNames.CORPOREA_RETAINER)

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaRetainer.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaRetainer.java
@@ -17,7 +17,7 @@ import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.registries.ObjectHolder;
 import vazkii.botania.api.corporea.CorporeaHelper;
-import vazkii.botania.api.corporea.CorporeaRequestMatcher;
+import vazkii.botania.api.corporea.ICorporeaRequestMatcher;
 import vazkii.botania.api.corporea.ICorporeaRequestor;
 import vazkii.botania.api.corporea.ICorporeaSpark;
 import vazkii.botania.api.corporea.InvWithLocation;
@@ -42,15 +42,15 @@ public class TileCorporeaRetainer extends TileMod {
 	private static final String TAG_REQUEST_CONTENTS = "requestContents";
 	private static final String TAG_REQUEST_COUNT = "requestCount";
 
-	public static final Map<String, Function<CompoundNBT, CorporeaRequestMatcher>> corporeaMatcherDeserializers = new HashMap<>();
+	public static final Map<String, Function<CompoundNBT, ICorporeaRequestMatcher>> corporeaMatcherDeserializers = new HashMap<>();
 	public static final Map<Class<?>, String> corporeaMatcherSerializers = new HashMap<>();
 
 	private boolean pendingRequest = false;
 	private BlockPos requestPos = BlockPos.ZERO;
-	private CorporeaRequestMatcher request;
+	private ICorporeaRequestMatcher request;
 	private int requestCount;
 	private int compValue;
-	
+
 	static {
 		addCorporeaRequestMatcher("string", CorporeaStringMatcher.class,CorporeaStringMatcher::createFromNBT);
 		addCorporeaRequestMatcher("item_stack", CorporeaItemStackMatcher.class, CorporeaItemStackMatcher::createFromNBT);
@@ -60,7 +60,7 @@ public class TileCorporeaRetainer extends TileMod {
 		super(TYPE);
 	}
 
-	public void setPendingRequest(BlockPos pos, CorporeaRequestMatcher request, int requestCount) {
+	public void setPendingRequest(BlockPos pos, ICorporeaRequestMatcher request, int requestCount) {
 		if(pendingRequest)
 			return;
 
@@ -135,7 +135,7 @@ public class TileCorporeaRetainer extends TileMod {
 		requestCount = cmp.getInt(TAG_REQUEST_COUNT);
 	}
 	
-	public static void addCorporeaRequestMatcher(String type, Class<?> clazz, Function<CompoundNBT, CorporeaRequestMatcher> deserializer) {
+	public static void addCorporeaRequestMatcher(String type, Class<?> clazz, Function<CompoundNBT, ICorporeaRequestMatcher> deserializer) {
 		corporeaMatcherSerializers.put(clazz, type);
 		corporeaMatcherDeserializers.put(type, deserializer);
 	} 

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaRetainer.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaRetainer.java
@@ -52,7 +52,7 @@ public class TileCorporeaRetainer extends TileMod {
 	private int compValue;
 
 	static {
-		addCorporeaRequestMatcher("string", CorporeaStringMatcher.class,CorporeaStringMatcher::createFromNBT);
+		addCorporeaRequestMatcher("string", CorporeaStringMatcher.class, CorporeaStringMatcher::createFromNBT);
 		addCorporeaRequestMatcher("item_stack", CorporeaItemStackMatcher.class, CorporeaItemStackMatcher::createFromNBT);
 	}
 

--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaRetainer.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaRetainer.java
@@ -10,18 +10,25 @@
  */
 package vazkii.botania.common.block.tile.corporea;
 
+import com.google.common.collect.HashBiMap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.registries.ObjectHolder;
 import vazkii.botania.api.corporea.CorporeaHelper;
+import static vazkii.botania.api.corporea.CorporeaRequestDefaultMatchers.*;
+import vazkii.botania.api.corporea.CorporeaRequestMatcher;
 import vazkii.botania.api.corporea.ICorporeaRequestor;
 import vazkii.botania.api.corporea.ICorporeaSpark;
 import vazkii.botania.api.corporea.InvWithLocation;
 import vazkii.botania.common.block.tile.TileMod;
 import vazkii.botania.common.lib.LibBlockNames;
 import vazkii.botania.common.lib.LibMisc;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 
 public class TileCorporeaRetainer extends TileMod {
 	@ObjectHolder(LibMisc.MOD_ID + ":" + LibBlockNames.CORPOREA_RETAINER)
@@ -30,26 +37,29 @@ public class TileCorporeaRetainer extends TileMod {
 	private static final String TAG_REQUEST_X = "requestX";
 	private static final String TAG_REQUEST_Y = "requestY";
 	private static final String TAG_REQUEST_Z = "requestZ";
-	private static final String TAG_REQUEST_TYPE = "requestType";
+	private static final String TAG_REQUEST_TYPE = "requestType_";
 	private static final String TAG_REQUEST_CONTENTS = "requestContents";
-	private static final String TAG_REQUEST_STACK = "requestStack";
 	private static final String TAG_REQUEST_COUNT = "requestCount";
 
-	private static final int REQUEST_NULL = 0;
-	private static final int REQUEST_ITEMSTACK = 1;
-	private static final int REQUEST_STRING = 2;
+	public static final Map<String, Function<CompoundNBT, CorporeaRequestMatcher>> corporeaMatcherDeserializers = new HashMap<>();
+	public static final Map<Class<?>, String> corporeaMatcherSerializers = new HashMap<>();
 
 	private boolean pendingRequest = false;
 	private BlockPos requestPos = BlockPos.ZERO;
-	private Object request;
+	private CorporeaRequestMatcher request;
 	private int requestCount;
 	private int compValue;
+	
+	static {
+		addCorporeaRequestMatcher("string", CorporeaStringMatcher.class,CorporeaStringMatcher::createFromNBT);
+		addCorporeaRequestMatcher("item_stack", CorporeaItemStackMatcher.class, CorporeaItemStackMatcher::createFromNBT);
+	}
 
 	public TileCorporeaRetainer() {
 		super(TYPE);
 	}
 
-	public void setPendingRequest(BlockPos pos, Object request, int requestCount) {
+	public void setPendingRequest(BlockPos pos, CorporeaRequestMatcher request, int requestCount) {
 		if(pendingRequest)
 			return;
 
@@ -97,21 +107,12 @@ public class TileCorporeaRetainer extends TileMod {
 		cmp.putInt(TAG_REQUEST_Y, requestPos.getY());
 		cmp.putInt(TAG_REQUEST_Z, requestPos.getZ());
 
-		int reqType = REQUEST_NULL;
-		if(request != null)
-			reqType = request instanceof String ? REQUEST_STRING : REQUEST_ITEMSTACK;
-		cmp.putInt(TAG_REQUEST_TYPE, reqType);
+		String reqType = request != null ? corporeaMatcherSerializers.getOrDefault(request.getClass(), "") : "";
 
-		switch (reqType) {
-		case REQUEST_STRING:
-			cmp.putString(TAG_REQUEST_CONTENTS, (String) request);
-			break;
-		case REQUEST_ITEMSTACK:
-			CompoundNBT cmp1 = ((ItemStack) request).write(new CompoundNBT());
-			cmp.put(TAG_REQUEST_STACK, cmp1);
-			break;
-		default: break;
-		}
+		cmp.putString(TAG_REQUEST_TYPE, reqType);
+
+		if(reqType.length() > 0)
+			request.writeToNBT(cmp);
 		cmp.putInt(TAG_REQUEST_COUNT, requestCount);
 	}
 
@@ -125,18 +126,17 @@ public class TileCorporeaRetainer extends TileMod {
 		int z = cmp.getInt(TAG_REQUEST_Z);
 		requestPos = new BlockPos(x, y, z);
 
-		int reqType = cmp.getInt(TAG_REQUEST_TYPE);
-		switch (reqType) {
-		case REQUEST_STRING:
-			request = cmp.getString(TAG_REQUEST_CONTENTS);
-			break;
-		case REQUEST_ITEMSTACK:
-			CompoundNBT cmp1 = cmp.getCompound(TAG_REQUEST_STACK);
-			request = ItemStack.read(cmp1);
-			break;
-		default: break;
-		}
+		String reqType = cmp.getString(TAG_REQUEST_TYPE);
+		if(corporeaMatcherDeserializers.containsKey(reqType))
+			request = corporeaMatcherDeserializers.get(reqType).apply(cmp);
+		else
+			request = null;
 		requestCount = cmp.getInt(TAG_REQUEST_COUNT);
 	}
+	
+	public static void addCorporeaRequestMatcher(String type, Class<?> clazz, Function<CompoundNBT, CorporeaRequestMatcher> deserializer) {
+		corporeaMatcherSerializers.put(clazz, type);
+		corporeaMatcherDeserializers.put(type, deserializer);
+	} 
 
 }

--- a/src/main/java/vazkii/botania/common/integration/corporea/WrappedIInventory.java
+++ b/src/main/java/vazkii/botania/common/integration/corporea/WrappedIInventory.java
@@ -49,7 +49,7 @@ public class WrappedIInventory extends WrappedInventoryBase {
 			ItemStack stackAt = inv.handler.getStackInSlot(i);
 			// WARNING: this code is very similar in all implementations of
 			// IWrappedInventory - keep it synch
-			if(isMatchingItemStack(request.matcher, request.checkNBT, stackAt)) {
+			if(request.matcher.isStackValid(stackAt)) {
 				int rem = Math.min(stackAt.getCount(), request.count == -1 ? stackAt.getCount() : request.count);
 				request.foundItems += stackAt.getCount();
 

--- a/src/main/java/vazkii/botania/common/integration/corporea/WrappedInventoryBase.java
+++ b/src/main/java/vazkii/botania/common/integration/corporea/WrappedInventoryBase.java
@@ -11,7 +11,7 @@ package vazkii.botania.common.integration.corporea;
 
 import net.minecraft.item.ItemStack;
 import vazkii.botania.api.corporea.CorporeaHelper;
-import vazkii.botania.api.corporea.CorporeaRequestMatcher;
+import vazkii.botania.api.corporea.ICorporeaRequestMatcher;
 import vazkii.botania.api.corporea.ICorporeaSpark;
 import vazkii.botania.api.corporea.IWrappedInventory;
 

--- a/src/main/java/vazkii/botania/common/integration/corporea/WrappedInventoryBase.java
+++ b/src/main/java/vazkii/botania/common/integration/corporea/WrappedInventoryBase.java
@@ -11,6 +11,7 @@ package vazkii.botania.common.integration.corporea;
 
 import net.minecraft.item.ItemStack;
 import vazkii.botania.api.corporea.CorporeaHelper;
+import vazkii.botania.api.corporea.CorporeaRequestMatcher;
 import vazkii.botania.api.corporea.ICorporeaSpark;
 import vazkii.botania.api.corporea.IWrappedInventory;
 
@@ -29,11 +30,6 @@ public abstract class WrappedInventoryBase implements IWrappedInventory {
 	@Override
 	public ICorporeaSpark getSpark() {
 		return spark;
-	}
-
-	protected boolean isMatchingItemStack(Object matcher, boolean checkNBT, ItemStack stackAt) {
-		return matcher instanceof ItemStack ? CorporeaHelper.stacksMatch((ItemStack) matcher, stackAt, checkNBT)
-				: matcher instanceof String ? CorporeaHelper.stacksMatch(stackAt, (String) matcher) : false;
 	}
 
 	protected Collection<? extends ItemStack> breakDownBigStack(ItemStack stack) {


### PR DESCRIPTION
Notes:
 - This breaks some API stuff (sorry, getInventoriesWithItemInNetwork), but that's OK because nobody's written a 1.14 addon for Botania anyway
 - This also makes existing Retainers lose their currently-remembered requests (but AFAIK they're broken on HEAD rn anyway)
 - I put the current matchers in static subclasses CorporeaRequestDefaultMatchers for the sake of compactness and `import static` them; if this style isn't OK I can split them up too
 - Yes, I know the serialization mechanic for TileCorporeaRetainer is clunky. But it works, I'm pretty sure. (Couldn't test; see above note about them being broken)