### PR TITLE
Move exoflame heatable to a cap, convert furnace part to use it

### DIFF
--- a/src/main/java/vazkii/botania/api/BotaniaAPI.java
+++ b/src/main/java/vazkii/botania/api/BotaniaAPI.java
@@ -29,6 +29,7 @@ import net.minecraftforge.registries.IRegistryDelegate;
 import vazkii.botania.api.brew.Brew;
 import vazkii.botania.api.internal.DummyMethodHandler;
 import vazkii.botania.api.internal.IInternalMethodHandler;
+import vazkii.botania.api.item.IExoflameHeatable;
 import vazkii.botania.api.item.IFloatingFlower;
 import vazkii.botania.api.recipe.RecipeBrew;
 import vazkii.botania.api.recipe.RecipeElvenTrade;
@@ -46,6 +47,9 @@ import java.util.function.Function;
 public final class BotaniaAPI {
 	@CapabilityInject(IFloatingFlower.class)
 	public static Capability<IFloatingFlower> FLOATING_FLOWER_CAP;
+
+	@CapabilityInject(IExoflameHeatable.class)
+	public static Capability<IExoflameHeatable> EXOFLAME_HEATABLE_CAP;
 
 	public static final Map<String, Brew> brewMap = new LinkedHashMap<>();
 

--- a/src/main/java/vazkii/botania/api/item/IExoflameHeatable.java
+++ b/src/main/java/vazkii/botania/api/item/IExoflameHeatable.java
@@ -11,7 +11,7 @@
 package vazkii.botania.api.item;
 
 /**
- * A TileEntity that implements this can be heated by an Exoflame flower.
+ * A TileEntity that has this capability can be heated by an Exoflame flower.
  */
 public interface IExoflameHeatable {
 
@@ -19,25 +19,25 @@ public interface IExoflameHeatable {
 	 * Can this TileEntity smelt its contents. If true, the Exoflame is allowed
 	 * to fuel it.
 	 */
-	public boolean canSmelt();
+	boolean canSmelt();
 
 	/**
 	 * Gets the amount of ticks left for the fuel. If below 2, the exoflame
 	 * will call boostBurnTime.
 	 */
-	public int getBurnTime();
+	int getBurnTime();
 
 	/**
 	 * Called to increase the amount of time this furnace should be burning
 	 * the fuel for. Even if it doesn't have any fuel.
 	 */
-	public void boostBurnTime();
+	void boostBurnTime();
 
 	/**
 	 * Called once every two ticks to increase the speed of the furnace. Feel
 	 * free to not do anything if all you want is to allow the exoflame to feed
 	 * it, not make it faster.
 	 */
-	public void boostCookTime();
+	void boostCookTime();
 
 }

--- a/src/main/java/vazkii/botania/common/Botania.java
+++ b/src/main/java/vazkii/botania/common/Botania.java
@@ -34,6 +34,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.capability.FloatingFlowerImpl;
+import vazkii.botania.api.item.IExoflameHeatable;
 import vazkii.botania.api.item.IFloatingFlower;
 import vazkii.botania.client.core.proxy.ClientProxy;
 import vazkii.botania.common.advancements.AlfPortalTrigger;
@@ -48,6 +49,8 @@ import vazkii.botania.common.block.tile.TileEnchanter;
 import vazkii.botania.common.block.tile.TileTerraPlate;
 import vazkii.botania.common.block.tile.corporea.TileCorporeaIndex;
 import vazkii.botania.common.brew.ModBrews;
+import vazkii.botania.common.capability.NoopExoflameHeatable;
+import vazkii.botania.common.capability.NoopCapStorage;
 import vazkii.botania.common.core.command.CommandSkyblockSpread;
 import vazkii.botania.common.core.handler.ConfigHandler;
 import vazkii.botania.common.core.handler.EquipmentHandler;
@@ -64,7 +67,6 @@ import vazkii.botania.common.core.proxy.ServerProxy;
 import vazkii.botania.common.crafting.FluxfieldCondition;
 import vazkii.botania.common.crafting.SyncHandler;
 import vazkii.botania.common.lib.LibMisc;
-import vazkii.botania.common.lib.ModTags;
 import vazkii.botania.common.network.PacketHandler;
 import vazkii.botania.common.world.ModFeatures;
 import vazkii.botania.common.world.SkyblockWorldEvents;
@@ -108,6 +110,8 @@ public class Botania {
 
 	private void commonSetup(FMLCommonSetupEvent event) {
 		CapabilityManager.INSTANCE.register(IFloatingFlower.class, new IFloatingFlower.Storage(), FloatingFlowerImpl::new);
+		CapabilityManager.INSTANCE.register(IExoflameHeatable.class, new NoopCapStorage<>(), NoopExoflameHeatable::new);
+
 		gardenOfGlassLoaded = ModList.get().isLoaded("gardenofglass");
 		thaumcraftLoaded = ModList.get().isLoaded("thaumcraft");
 		bcApiLoaded = ModList.get().isLoaded("buildcraftlib");

--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileExoflame.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileExoflame.java
@@ -10,33 +10,16 @@
  */
 package vazkii.botania.common.block.subtile.functional;
 
-import com.mojang.datafixers.util.Pair;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.AbstractCookingRecipe;
-import net.minecraft.item.crafting.IRecipe;
-import net.minecraft.item.crafting.IRecipeType;
-import net.minecraft.state.properties.BlockStateProperties;
-import net.minecraft.tileentity.AbstractFurnaceTileEntity;
-import net.minecraft.tileentity.FurnaceTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.math.BlockPos;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.registries.ObjectHolder;
+import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.item.IExoflameHeatable;
 import vazkii.botania.api.subtile.RadiusDescriptor;
 import vazkii.botania.api.subtile.TileEntityFunctionalFlower;
-import vazkii.botania.common.Botania;
 import vazkii.botania.common.lib.LibMisc;
-
-import javax.annotation.Nullable;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Optional;
 
 public class SubTileExoflame extends TileEntityFunctionalFlower {
 	@ObjectHolder(LibMisc.MOD_ID + ":exoflame")
@@ -45,8 +28,6 @@ public class SubTileExoflame extends TileEntityFunctionalFlower {
 	private static final int RANGE = 5;
 	private static final int RANGE_Y = 2;
 	private static final int COST = 300;
-	private static final Field RECIPE_TYPE = ObfuscationReflectionHelper.findField(AbstractFurnaceTileEntity.class, "field_214014_c");
-	private static final Method CAN_SMELT = ObfuscationReflectionHelper.findMethod(AbstractFurnaceTileEntity.class, "func_214008_b", IRecipe.class);
 
 	public SubTileExoflame() {
 		super(TYPE);
@@ -56,7 +37,7 @@ public class SubTileExoflame extends TileEntityFunctionalFlower {
 	public void tickFlower() {
 		super.tickFlower();
 
-		if(getWorld().isRemote)
+		if(getWorld().isRemote || getMana() <= 2)
 			return;
 
 		boolean did = false;
@@ -64,67 +45,31 @@ public class SubTileExoflame extends TileEntityFunctionalFlower {
 		for(BlockPos pos : BlockPos.getAllInBoxMutable(getPos().add(-RANGE, -RANGE_Y, -RANGE),
 				getPos().add(RANGE, RANGE_Y, RANGE))) {
 			TileEntity tile = getWorld().getTileEntity(pos);
-			BlockState state = getWorld().getBlockState(pos);
-			if(tile instanceof AbstractFurnaceTileEntity) {
-				AbstractFurnaceTileEntity furnace = (AbstractFurnaceTileEntity) tile;
-				Pair<AbstractCookingRecipe, Boolean> p = canSmelt(furnace);
-				if(p == null)
-					continue;
-				AbstractCookingRecipe recipe = p.getFirst();
-				boolean canSmelt = p.getSecond();
+			if(tile != null) {
+				LazyOptional<IExoflameHeatable> cap = tile.getCapability(BotaniaAPI.EXOFLAME_HEATABLE_CAP);
+				if(cap.isPresent()) {
+					IExoflameHeatable heatable = cap.orElseThrow(NullPointerException::new);
 
-				if(canSmelt && getMana() > 2) {
-					if(furnace.burnTime < 2) {
-						if(furnace.burnTime == 0)
-							getWorld().setBlockState(pos, state.with(BlockStateProperties.LIT, true));
-						furnace.burnTime = 200;
-						addMana(-COST);
+					if(heatable.canSmelt() && getMana() > 2) {
+						if(heatable.getBurnTime() < 2) {
+							heatable.boostBurnTime();
+							addMana(-COST);
+							did = true;
+						}
+
+						if(ticksExisted % 2 == 0)
+							heatable.boostCookTime();
+
+						if(getMana() <= 0)
+							break;
 					}
-					if(ticksExisted % 2 == 0)
-						furnace.cookTime = Math.min(recipe.getCookTime() - 1, furnace.cookTime + 1);
-
-					did = true;
-
-					if(getMana() <= 0)
-						break;
-				}
-			} else if(tile instanceof IExoflameHeatable) {
-				IExoflameHeatable heatable = (IExoflameHeatable) tile;
-
-				if(heatable.canSmelt() && getMana() > 2) {
-					if(heatable.getBurnTime() == 0) {
-						heatable.boostBurnTime();
-						addMana(-COST);
-					}
-
-					if(ticksExisted % 2 == 0)
-						heatable.boostCookTime();
-
-					if(getMana() <= 0)
-						break;
 				}
 			}
-		}
-
-		if(did)
-			sync();
-	}
-
-	@Nullable
-	public static Pair<AbstractCookingRecipe, Boolean> canSmelt(AbstractFurnaceTileEntity furnace) {
-		IRecipeType<AbstractCookingRecipe> rt;
-		AbstractCookingRecipe recipe;
-		boolean canSmelt;
-		try {
-			rt = (IRecipeType<AbstractCookingRecipe>) RECIPE_TYPE.get(furnace);
-			recipe = furnace.getWorld().getRecipeManager().getRecipe(rt, furnace, furnace.getWorld()).orElse(null);
-			canSmelt = (Boolean) CAN_SMELT.invoke(furnace, recipe);
-			return Pair.of(recipe, canSmelt);
-		} catch (InvocationTargetException | IllegalAccessException e) {
-			Botania.LOGGER.error("Failed to reflect furnace", e);
-			return null;
+			if(did)
+				sync();
 		}
 	}
+
 
 	@Override
 	public RadiusDescriptor getRadius() {

--- a/src/main/java/vazkii/botania/common/capability/NoopCapStorage.java
+++ b/src/main/java/vazkii/botania/common/capability/NoopCapStorage.java
@@ -1,0 +1,29 @@
+/**
+ * This class was created by <Hubry>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ *
+ * File Created @ [Dec 23, 2019, 18:50]
+ */
+package vazkii.botania.common.capability;
+
+import net.minecraft.nbt.INBT;
+import net.minecraft.util.Direction;
+import net.minecraftforge.common.capabilities.Capability;
+
+import javax.annotation.Nullable;
+
+public class NoopCapStorage<T> implements Capability.IStorage<T> {
+	@Nullable
+	@Override
+	public INBT writeNBT(Capability<T> capability, T instance, Direction side) {
+		return null;
+	}
+
+	@Override
+	public void readNBT(Capability<T> capability, T instance, Direction side, INBT nbt) {
+	}
+}

--- a/src/main/java/vazkii/botania/common/capability/NoopExoflameHeatable.java
+++ b/src/main/java/vazkii/botania/common/capability/NoopExoflameHeatable.java
@@ -1,0 +1,33 @@
+/**
+ * This class was created by <Hubry>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ *
+ * File Created @ [Dec 23, 2019, 18:51]
+ */
+package vazkii.botania.common.capability;
+
+import vazkii.botania.api.item.IExoflameHeatable;
+
+public class NoopExoflameHeatable implements IExoflameHeatable {
+	@Override
+	public boolean canSmelt() {
+		return false;
+	}
+
+	@Override
+	public int getBurnTime() {
+		return 0;
+	}
+
+	@Override
+	public void boostBurnTime() {
+	}
+
+	@Override
+	public void boostCookTime() {
+	}
+}

--- a/src/main/java/vazkii/botania/common/capability/SimpleCapProvider.java
+++ b/src/main/java/vazkii/botania/common/capability/SimpleCapProvider.java
@@ -1,0 +1,46 @@
+/**
+ * This class was created by <Hubry>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ *
+ * File Created @ [Dec 23, 2019, 16:41]
+ */
+package vazkii.botania.common.capability;
+
+import net.minecraft.util.Direction;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class SimpleCapProvider<C> implements ICapabilityProvider {
+	private final C capInstance;
+	private final LazyOptional<C> capOptional;
+	
+	private final Capability<C> capability;
+	
+	public SimpleCapProvider(Capability<C> capability, C capInstance) {
+		this.capability = capability;
+		this.capInstance = capInstance;
+		this.capOptional = LazyOptional.of(() -> this.capInstance);
+	}
+
+	@Nonnull
+	@Override
+	public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction side) {
+		return capability.orEmpty(cap, capOptional);
+	}
+
+	public static <C> void attach(AttachCapabilitiesEvent<?> event, ResourceLocation key, Capability<C> cap, C capInstance) {
+		SimpleCapProvider<C> provider = new SimpleCapProvider<>(cap, capInstance);
+		event.addCapability(key, provider);
+		event.addListener(provider.capOptional::invalidate);
+	}
+}

--- a/src/main/java/vazkii/botania/common/core/handler/ExoflameFurnaceHandler.java
+++ b/src/main/java/vazkii/botania/common/core/handler/ExoflameFurnaceHandler.java
@@ -1,0 +1,126 @@
+/**
+ * This class was created by <Hubry>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ *
+ * File Created @ [Dec 23, 2019, 15:42]
+ */
+package vazkii.botania.common.core.handler;
+
+import net.minecraft.item.crafting.AbstractCookingRecipe;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeType;
+import net.minecraft.state.properties.BlockStateProperties;
+import net.minecraft.tileentity.AbstractFurnaceTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.event.AttachCapabilitiesEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
+import vazkii.botania.api.BotaniaAPI;
+import vazkii.botania.api.item.IExoflameHeatable;
+import vazkii.botania.common.Botania;
+import vazkii.botania.common.capability.SimpleCapProvider;
+import vazkii.botania.common.lib.LibMisc;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+@Mod.EventBusSubscriber(modid = LibMisc.MOD_ID)
+public class ExoflameFurnaceHandler {
+
+	public static final ResourceLocation ID = new ResourceLocation(LibMisc.MOD_ID, "exoflame_heatable");
+
+	private static final MethodHandle CAN_SMELT;
+	private static final MethodHandle RECIPE_TYPE;
+
+	static {
+		try {
+			Field recipeType = ObfuscationReflectionHelper.findField(AbstractFurnaceTileEntity.class, "field_214014_c");
+			RECIPE_TYPE = MethodHandles.lookup().unreflectGetter(recipeType);
+			Method canSmelt = ObfuscationReflectionHelper.findMethod(AbstractFurnaceTileEntity.class, "func_214008_b", IRecipe.class);
+			CAN_SMELT = MethodHandles.lookup().unreflect(canSmelt);
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to reflect furnace");
+		}
+	}
+
+	@SubscribeEvent
+	public static void attachFurnaceCapability(AttachCapabilitiesEvent<TileEntity> event) {
+		TileEntity te = event.getObject();
+		if(te instanceof AbstractFurnaceTileEntity) {
+			AbstractFurnaceTileEntity furnace = (AbstractFurnaceTileEntity) te;
+			SimpleCapProvider.attach(event, ID, BotaniaAPI.EXOFLAME_HEATABLE_CAP, new FurnaceExoflameHeatable(furnace));
+		}
+	}
+
+	public static boolean canSmelt(AbstractFurnaceTileEntity furnace, IRecipe<?> recipe) throws Throwable {
+		return (boolean) CAN_SMELT.invokeExact((AbstractFurnaceTileEntity) furnace, recipe);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static IRecipeType<? extends AbstractCookingRecipe> getRecipeType(AbstractFurnaceTileEntity furnace) throws Throwable {
+		return (IRecipeType<? extends AbstractCookingRecipe>) RECIPE_TYPE.invokeExact(furnace);
+	}
+
+	private static class FurnaceExoflameHeatable implements IExoflameHeatable {
+		private final AbstractFurnaceTileEntity furnace;
+
+		private IRecipeType<? extends AbstractCookingRecipe> recipeType;
+		private AbstractCookingRecipe currentRecipe;
+
+		FurnaceExoflameHeatable(AbstractFurnaceTileEntity furnace) {
+			this.furnace = furnace;
+		}
+
+		@Override
+		public boolean canSmelt() {
+			if(furnace.getStackInSlot(0).isEmpty()) {
+				return false;
+			}
+			try {
+				if (recipeType == null) {
+					this.recipeType = ExoflameFurnaceHandler.getRecipeType(furnace);
+				}
+				if (currentRecipe != null) { // This is already more caching than Mojang does
+					if(ExoflameFurnaceHandler.canSmelt(furnace, currentRecipe)) {
+						return true;
+					}
+				}
+				currentRecipe = furnace.getWorld().getRecipeManager().getRecipe(recipeType, furnace, furnace.getWorld()).orElse(null);
+				return ExoflameFurnaceHandler.canSmelt(furnace, currentRecipe);
+			} catch (Throwable t) {
+				Botania.LOGGER.error("Failed to determine if furnace TE can smelt", t);
+				return false;
+			}
+		}
+
+		@Override
+		public int getBurnTime() {
+			return furnace.burnTime;
+		}
+
+		@Override
+		public void boostBurnTime() {
+			if(getBurnTime() == 0) {
+				World world = furnace.getWorld();
+				BlockPos pos = furnace.getPos();
+				world.setBlockState(pos, world.getBlockState(pos).with(BlockStateProperties.LIT, true));
+			}
+			furnace.burnTime += 200;
+		}
+
+		@Override
+		public void boostCookTime() {
+			furnace.cookTime = Math.min(currentRecipe.getCookTime() - 1, furnace.cookTime + 1);
+		}
+	}
+}

--- a/src/main/java/vazkii/botania/common/integration/curios/CurioIntegration.java
+++ b/src/main/java/vazkii/botania/common/integration/curios/CurioIntegration.java
@@ -19,6 +19,7 @@ import top.theillusivec4.curios.api.CuriosAPI;
 import top.theillusivec4.curios.api.capability.CuriosCapability;
 import top.theillusivec4.curios.api.capability.ICurio;
 import top.theillusivec4.curios.api.imc.CurioIMCMessage;
+import vazkii.botania.common.capability.SimpleCapProvider;
 import vazkii.botania.common.core.handler.EquipmentHandler;
 import vazkii.botania.common.core.handler.ModSounds;
 import vazkii.botania.common.item.equipment.bauble.ItemBauble;
@@ -29,22 +30,6 @@ import java.util.function.Predicate;
 
 // Classloading-safe way to attach curio behaviour to our items
 public class CurioIntegration extends EquipmentHandler {
-
-	private static class Provider implements ICapabilityProvider {
-		private final ICurio curio;
-		private final LazyOptional<ICurio> curioCap;
-
-		Provider(ICurio curio) {
-			this.curio = curio;
-			curioCap = LazyOptional.of(() -> this.curio);
-		}
-
-		@Nonnull
-		@Override
-		public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction side) {
-			return CuriosCapability.ITEM.orEmpty(cap, curioCap);
-		}
-	}
 
 	@SubscribeEvent
 	public static void sendImc(InterModEnqueueEvent evt) {
@@ -80,7 +65,7 @@ public class CurioIntegration extends EquipmentHandler {
 
 	@Override
 	protected ICapabilityProvider initCap(ItemStack stack) {
-		return new Provider(new Wrapper(stack));
+		return new SimpleCapProvider<>(CuriosCapability.ITEM, new Wrapper(stack));
 	}
 
 	@Override


### PR DESCRIPTION
* Added a simple cap provider, and moved the curio integration to use that.
* Converted exoflame heating to a cap, and furnace heating is now an implementation of that cap.
* Converted the code to use method handles. Seems like a very easy performance improvement, gave me like 4 times better tick times on exoflame tick, going from ~700 microseconds to ~150. Also caching the last recipe for the cap, something that I am amazed Mojang didn't do. 
* Moved the one furnace-specific method used by bellows into there, adjusted to use method handles instead of reflection.