### PR TITLE
Un-specialcase elven lexicon recipe, improve elven trade api

### DIFF
--- a/src/main/java/vazkii/botania/api/recipe/RecipeElvenTrade.java
+++ b/src/main/java/vazkii/botania/api/recipe/RecipeElvenTrade.java
@@ -8,6 +8,7 @@ import net.minecraft.util.ResourceLocation;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class RecipeElvenTrade {
 	private final ResourceLocation id;
@@ -24,7 +25,12 @@ public class RecipeElvenTrade {
 		this.inputs = ImmutableList.copyOf(inputs);
 	}
 
-	public boolean matches(List<ItemStack> stacks, boolean remove) {
+	/**
+	 * Attempts to match the recipe
+	 * @param stacks Entire contents of the portal's buffer 
+	 * @return {@link Optional#empty()} if recipe doesn't match, Optional with a set of items used by recipe otherwise
+	 */
+	public Optional<List<ItemStack>> match(List<ItemStack> stacks) {
 		List<Ingredient> inputsMissing = new ArrayList<>(inputs);
 		List<ItemStack> stacksToRemove = new ArrayList<>();
 
@@ -51,11 +57,19 @@ public class RecipeElvenTrade {
 				inputsMissing.remove(stackIndex);
 		}
 
-		if(remove)
-			for(ItemStack r : stacksToRemove)
-				stacks.remove(r);
+		return inputsMissing.isEmpty() ? Optional.of(stacksToRemove) : Optional.empty();
+	}
 
-		return inputsMissing.isEmpty();
+	/**
+	 * If the recipe does not contain the item, it will be destroyed upon entering the portal.
+	 */
+	public boolean containsItem(ItemStack stack) {
+		for(Ingredient input : inputs) {
+			if(input.test(stack)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public ResourceLocation getId() {
@@ -68,6 +82,10 @@ public class RecipeElvenTrade {
 
 	public List<ItemStack> getOutputs() {
 		return outputs;
+	}
+
+	public List<ItemStack> getOutputs(List<ItemStack> inputs) {
+		return getOutputs();
 	}
 
 	public void write(PacketBuffer buf) {

--- a/src/main/java/vazkii/botania/client/integration/jei/JEIBotaniaPlugin.java
+++ b/src/main/java/vazkii/botania/client/integration/jei/JEIBotaniaPlugin.java
@@ -76,7 +76,7 @@ public class JEIBotaniaPlugin implements IModPlugin {
 
 		registry.registerSubtypeInterpreter(ModItems.twigWand, stack -> ItemTwigWand.getColor1(stack) + "_" + ItemTwigWand.getColor2(stack));
 		registry.registerSubtypeInterpreter(ModItems.flightTiara, stack -> String.valueOf(ItemFlightTiara.getVariant(stack)));
-		registry.registerSubtypeInterpreter(ModItems.lexicon, stack -> String.valueOf(ItemNBTHelper.getBoolean(stack, ItemLexicon.TAG_ELVEN_UNLOCK, true)));
+		registry.registerSubtypeInterpreter(ModItems.lexicon, stack -> String.valueOf(ItemNBTHelper.getBoolean(stack, ItemLexicon.TAG_ELVEN_UNLOCK, false)));
 		registry.registerSubtypeInterpreter(ModItems.laputaShard, stack -> String.valueOf(ItemLaputaShard.getShardLevel(stack)));
 		
 		for(Item item : new Item[]{ModItems.manaTablet, ModItems.manaRing, ModItems.manaRingGreater, ModItems.terraPick}) {
@@ -181,7 +181,7 @@ public class JEIBotaniaPlugin implements IModPlugin {
 		for(RecipeElvenTrade recipe : BotaniaAPI.elvenTradeRecipes.values()) {
 			List<Ingredient> inputs = recipe.getInputs();
 			List<ItemStack> outputs = recipe.getOutputs();
-			if(inputs.size() == 1 && outputs.size() == 1 && inputs.get(0).test(outputs.get(0))) {
+			if(inputs.size() == 1 && outputs.size() == 1 && recipe.containsItem(outputs.get(0))) {
 				recipeRegistry.hideRecipe(recipe, ElvenTradeRecipeCategory.UID);
 			}
 		}

--- a/src/main/java/vazkii/botania/common/crafting/ModElvenTradeRecipes.java
+++ b/src/main/java/vazkii/botania/common/crafting/ModElvenTradeRecipes.java
@@ -4,14 +4,21 @@ import net.minecraft.block.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import vazkii.botania.api.recipe.RecipeElvenTrade;
 import vazkii.botania.api.recipe.RegisterRecipesEvent;
 import vazkii.botania.common.block.ModBlocks;
+import vazkii.botania.common.core.helper.ItemNBTHelper;
+import vazkii.botania.common.item.ItemLexicon;
 import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.lib.LibMisc;
 import vazkii.botania.common.lib.ModTags;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 import static vazkii.botania.common.lib.ResourceLocationHelper.prefix;
 
@@ -40,6 +47,34 @@ public class ModElvenTradeRecipes {
 		evt.elvenTrade().accept(new RecipeElvenTrade(prefix("ender_pearl_return"), new ItemStack(Items.ENDER_PEARL), Ingredient.fromItems(Items.ENDER_PEARL)));
 		evt.elvenTrade().accept(new RecipeElvenTrade(prefix("diamond_return"), new ItemStack(Items.DIAMOND), Ingredient.fromItems(Items.DIAMOND)));
 		evt.elvenTrade().accept(new RecipeElvenTrade(prefix("diamond_block_return"), new ItemStack(Blocks.DIAMOND_BLOCK), Ingredient.fromItems(Blocks.DIAMOND_BLOCK)));
+
+		ItemStack elvenLexicon = new ItemStack(ModItems.lexicon);
+		elvenLexicon.getOrCreateTag().putBoolean(ItemLexicon.TAG_ELVEN_UNLOCK, true);
+		evt.elvenTrade().accept(new RecipeLexicon(prefix("elven_lexicon"), elvenLexicon, Ingredient.fromStacks(new ItemStack(ModItems.lexicon))));
 	}
 
+	private static class RecipeLexicon extends RecipeElvenTrade {
+		RecipeLexicon(ResourceLocation id, ItemStack output, Ingredient input) {
+			super(id, output, input);
+		}
+
+		@Override
+		public boolean containsItem(ItemStack stack) {
+			return super.containsItem(stack) && !ItemNBTHelper.getBoolean(stack, ItemLexicon.TAG_ELVEN_UNLOCK, false);
+		}
+
+		@Override
+		public Optional<List<ItemStack>> match(List<ItemStack> stacks) {
+			if(stacks.size() == 1 && !ItemNBTHelper.getBoolean(stacks.get(0), ItemLexicon.TAG_ELVEN_UNLOCK, false))
+				return super.match(stacks);
+			return Optional.empty();
+		}
+
+		@Override
+		public List<ItemStack> getOutputs(List<ItemStack> inputs) {
+			ItemStack stack = inputs.get(0).copy();
+			stack.getOrCreateTag().putBoolean(ItemLexicon.TAG_ELVEN_UNLOCK, true);
+			return Collections.singletonList(stack);
+		}
+	}
 }


### PR DESCRIPTION
The lexicon recipe is now a normal recipe, it displays in JEI too. Elven trades can now modify their outputs based on the inputs, and define if the item is used in the recipe for the early entry check. Also portals won't try to match items at all if they are empty.