### PR TITLE
Fix gaia guardian hardmode advancement and cacophonium recipe

### DIFF
--- a/src/main/resources/data/botania/advancements/challenge/gaia_guardian_hardmode.json
+++ b/src/main/resources/data/botania/advancements/challenge/gaia_guardian_hardmode.json
@@ -13,11 +13,12 @@
   },
   "parent": "botania:challenge/root",
   "criteria": {
-    "dice": {
-      "trigger": "botania:relic_bind",
+    "guardian": {
+      "trigger": "minecraft:player_killed_entity",
       "conditions": {
-        "relic": {
-          "item": "botania:dice"
+        "entity": {
+          "type": "botania:doppleganger",
+          "nbt": "{hardMode:1b}"
         }
       }
     }

--- a/src/main/resources/data/botania/recipes/cacophonium.json
+++ b/src/main/resources/data/botania/recipes/cacophonium.json
@@ -1,24 +1,60 @@
 {
-  "result": {
-    "item": "botania:cacophonium"
-  },
-  "pattern": [
-    " G ",
-    "GNG",
-    "GG "
-  ],
-  "type": "minecraft:crafting_shaped",
-  "key": {
-    "G": [
-      {
-        "tag": "forge:ingots/gold"
-      },
-      {
-        "tag": "forge:ingots/brass"
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "type": "forge:tag_empty",
+          "tag": "forge:ingots/brass"
+        }
+      ],
+      "recipe": {
+        "result": {
+          "item": "botania:cacophonium"
+        },
+        "pattern": [
+          " G ",
+          "GNG",
+          "GG "
+        ],
+        "type": "minecraft:crafting_shaped",
+        "key": {
+          "G": [
+            {
+              "tag": "forge:ingots/gold"
+            }
+          ],
+          "N": {
+            "item": "minecraft:note_block"
+          }
+        }
       }
-    ],
-    "N": {
-      "item": "minecraft:note_block"
+    },
+    {
+      "recipe": {
+        "result": {
+          "item": "botania:cacophonium"
+        },
+        "pattern": [
+          " G ",
+          "GNG",
+          "GG "
+        ],
+        "type": "minecraft:crafting_shaped",
+        "key": {
+          "G": [
+            {
+              "tag": "forge:ingots/gold"
+            },
+            {
+              "tag": "forge:ingots/brass"
+            }
+          ],
+          "N": {
+            "item": "minecraft:note_block"
+          }
+        }
+      }
     }
-  }
+  ]
 }


### PR DESCRIPTION
* Cacophonium recipe now no longer tries to make use of brass if that's not available.
* GG2 advancement now checks killing it instead of binding dice that didn't work outside of cheating dice in.