### PR TITLE
Improve Corporea Index keybind requests to not use chat

### DIFF
--- a/src/main/java/vazkii/botania/api/corporea/CorporeaIndexRequestEvent.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaIndexRequestEvent.java
@@ -20,11 +20,11 @@ import net.minecraftforge.eventbus.api.Event;
 @Cancelable
 public class CorporeaIndexRequestEvent extends Event {
 	public final ServerPlayerEntity requester;
-	public String request;
+	public ICorporeaRequestMatcher request;
 	public int requestCount;
 	public ICorporeaSpark indexSpark;
 	
-	public CorporeaIndexRequestEvent(ServerPlayerEntity requester, String request, int requestCount, ICorporeaSpark indexSpark) {
+	public CorporeaIndexRequestEvent(ServerPlayerEntity requester, ICorporeaRequestMatcher request, int requestCount, ICorporeaSpark indexSpark) {
 		this.requester = requester;
 		this.request = request;
 		this.requestCount = requestCount;

--- a/src/main/java/vazkii/botania/api/corporea/CorporeaRequestDefaultMatchers.java
+++ b/src/main/java/vazkii/botania/api/corporea/CorporeaRequestDefaultMatchers.java
@@ -12,8 +12,11 @@ package vazkii.botania.api.corporea;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
+import org.apache.commons.lang3.text.WordUtils;
+import vazkii.botania.common.core.helper.ItemNBTHelper;
 
-import java.util.function.Function;
 import java.util.regex.Pattern;
 
 /**
@@ -79,6 +82,12 @@ public final class CorporeaRequestDefaultMatchers {
 			tag.putBoolean(TAG_REQUEST_CONTAINS, contains);
 		}
 
+		@Override
+		@SuppressWarnings("deprecation")
+		public ITextComponent getRequestName() {
+			return new StringTextComponent(WordUtils.capitalizeFully(expression));
+		}
+
 		private boolean equalOrContain(String str) {
 			return contains ? str.contains(expression) : str.equals(expression);
 		}
@@ -103,7 +112,7 @@ public final class CorporeaRequestDefaultMatchers {
 
 		@Override
 		public boolean isStackValid(ItemStack stack) {
-			return !stack.isEmpty() && !match.isEmpty() && stack.isItemEqual(match) && (!checkNBT || ItemStack.areItemStackTagsEqual(stack, match));
+			return !stack.isEmpty() && !match.isEmpty() && stack.isItemEqual(match) && (!checkNBT || ItemNBTHelper.matchTag(match.getTag(), stack.getTag()));
 		}
 
 		public static ICorporeaRequestMatcher createFromNBT(CompoundNBT tag) {
@@ -115,6 +124,11 @@ public final class CorporeaRequestDefaultMatchers {
 			CompoundNBT cmp = match.write(new CompoundNBT());
 			tag.put(TAG_REQUEST_STACK, cmp);
 			tag.putBoolean(TAG_REQUEST_CHECK_NBT, checkNBT);
+		}
+
+		@Override
+		public ITextComponent getRequestName() {
+			return match.getDisplayName();
 		}
 	}
 

--- a/src/main/java/vazkii/botania/api/corporea/ICorporeaRequestMatcher.java
+++ b/src/main/java/vazkii/botania/api/corporea/ICorporeaRequestMatcher.java
@@ -12,8 +12,7 @@ package vazkii.botania.api.corporea;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
-
-import java.util.function.Function;
+import net.minecraft.util.text.ITextComponent;
 
 /**
  * An interface for a Corporea Request matcher. Accepts an ItemStack and returns whether it fulfills the request.
@@ -31,4 +30,9 @@ public interface ICorporeaRequestMatcher {
 	 * Serialize to NBT data, for the Corporea Retainer's benefit.
 	 */
 	void writeToNBT(CompoundNBT tag);
+
+	/**
+	 * Returns the pretty name of the requested item, for printing request feedback on Corporea Indexes.
+	 */
+	ITextComponent getRequestName();
 }

--- a/src/main/java/vazkii/botania/common/lib/LibObfuscation.java
+++ b/src/main/java/vazkii/botania/common/lib/LibObfuscation.java
@@ -13,4 +13,10 @@ package vazkii.botania.common.lib;
 public final class LibObfuscation {
 	// EntityLiving
 	public static final String GET_LIVING_SOUND = "func_184639_G";
+	
+	// RecipeBookGui
+	public static final String RECIPE_BOOK_PAGE = "field_193022_s";
+	
+	// RecipeBookPage
+	public static final String HOVERED_BUTTON = "field_194201_b";
 }

--- a/src/main/java/vazkii/botania/common/network/PacketHandler.java
+++ b/src/main/java/vazkii/botania/common/network/PacketHandler.java
@@ -14,7 +14,7 @@ import net.minecraftforge.fml.network.simple.SimpleChannel;
 import vazkii.botania.common.lib.LibMisc;
 
 public final class PacketHandler {
-	private static final String PROTOCOL = "1";
+	private static final String PROTOCOL = "2";
 	public static final SimpleChannel HANDLER = NetworkRegistry.newSimpleChannel(
 			new ResourceLocation(LibMisc.MOD_ID, "chan"),
 			() -> PROTOCOL,
@@ -30,6 +30,7 @@ public final class PacketHandler {
 		HANDLER.registerMessage(id++, PacketJump.class, PacketJump::encode, PacketJump::decode, PacketJump::handle);
 		HANDLER.registerMessage(id++, PacketItemAge.class, PacketItemAge::encode, PacketItemAge::decode, PacketItemAge::handle);
 		HANDLER.registerMessage(id++, PacketSyncRecipes.class, PacketSyncRecipes::encode, PacketSyncRecipes::decode, PacketSyncRecipes::handle);
+		HANDLER.registerMessage(id++, PacketIndexKeybindRequest.class, PacketIndexKeybindRequest::encode, PacketIndexKeybindRequest::decode, PacketIndexKeybindRequest::handle);
 	}
 
 	/**

--- a/src/main/java/vazkii/botania/common/network/PacketIndexKeybindRequest.java
+++ b/src/main/java/vazkii/botania/common/network/PacketIndexKeybindRequest.java
@@ -1,0 +1,52 @@
+/**
+ * This class was created by <Hubry>. It's distributed as
+ * part of the Botania Mod. Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ *
+ * File Created @ [gru 25 2019, 19:33]
+ */
+package vazkii.botania.common.network;
+
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketBuffer;
+import net.minecraftforge.fml.network.NetworkEvent;
+import vazkii.botania.api.corporea.CorporeaHelper;
+import vazkii.botania.common.block.tile.corporea.TileCorporeaIndex;
+
+import java.util.function.Supplier;
+
+public class PacketIndexKeybindRequest {
+	private final ItemStack stack;
+
+	public PacketIndexKeybindRequest(ItemStack stack) {
+		this.stack = stack;
+	}
+
+	public static PacketIndexKeybindRequest decode(PacketBuffer buf) {
+		return new PacketIndexKeybindRequest(buf.readItemStack());
+	}
+
+	public static void encode(PacketIndexKeybindRequest msg, PacketBuffer buf) {
+		buf.writeItemStack(msg.stack);
+	}
+
+	public static void handle(PacketIndexKeybindRequest message, Supplier<NetworkEvent.Context> ctx) {
+		ctx.get().enqueueWork(() -> {
+			ServerPlayerEntity player = ctx.get().getSender();
+			if (player.isSpectator())
+				return;
+
+			boolean checkNBT = message.stack.getTag() != null && !message.stack.getTag().isEmpty();
+			for (TileCorporeaIndex index : TileCorporeaIndex.InputHandler.getNearbyIndexes(player)) {
+				if (index.getSpark() != null) {
+					index.performPlayerRequest(player, CorporeaHelper.createMatcher(message.stack, checkNBT), message.stack.getCount());
+				}
+			}
+		});
+		ctx.get().setPacketHandled(true);
+	}
+}


### PR DESCRIPTION
One issue I always had with Corporea Index requesting is that it often ends up requesting an item that has the same name, but isn't actually the same thing. Nether bricks, mushrooms, enchanted books are all good examples of it in 1.12. This PR makes keybind requests send an item stack.

* Keybind requests now send an itemstack instead of the item name. Items in inventories ignore their own NBT, JEI/recipe book items don't. The NBT matching was made less strict. (is full strictness desirable sometimes? This uses the logic from #2881.)
* Chat is no longer touched by keybind requests, fixes #2942.
* Recipe book buttons can now be a source of keybind requests, fixes #3052. 
* Keybind requests work again with shift and ctrl.
* Matchers are in charge of their index request formatting.
* Index event now uses a matcher (this and previous change break api).
* Indexes ignore spectators now.