### PR TITLE
Fix injected loot pool being unnamed, fixes #3066

### DIFF
--- a/src/main/java/vazkii/botania/common/core/loot/LootHandler.java
+++ b/src/main/java/vazkii/botania/common/core/loot/LootHandler.java
@@ -36,6 +36,7 @@ public final class LootHandler {
 		return LootPool.builder()
 				.addEntry(getInjectEntry(entryName, 1))
 				.bonusRolls(0, 1)
+				.name("botania_inject")
 				.build();
 	}
 


### PR DESCRIPTION
After a quick consultation, turns out loot pools need to be named and no one tells you about it. Thanks Nooby <3
Fixes #3066.