### PR TITLE
Add some block tags for compatibility

### DIFF
--- a/src/main/resources/data/forge/tags/blocks/storage_blocks.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:ingots/manasteel",
+    "#forge:ingots/terrasteel",
+    "#forge:ingots/elementium"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks.json
@@ -1,8 +1,8 @@
 {
   "replace": false,
   "values": [
-    "#forge:ingots/manasteel",
-    "#forge:ingots/terrasteel",
-    "#forge:ingots/elementium"
+    "#forge:storage_blocks/manasteel",
+    "#forge:storage_blocks/terrasteel",
+    "#forge:storage_blocks/elementium"
   ]
 }

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/elementium.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/elementium.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "botania:elementium_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/manasteel.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/manasteel.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "botania:manasteel_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/quartz.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/quartz.json
@@ -1,0 +1,12 @@
+{
+  "replace": false,
+  "values": [
+    "botania:dark_quartz",
+    "botania:mana_quartz",
+    "botania:blaze_quartz",
+    "botania:lavender_quartz",
+    "botania:red_quartz",
+    "botania:elven_quartz",
+    "botania:sunny_quartz"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/quartz.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/quartz.json
@@ -6,7 +6,7 @@
     "botania:blaze_quartz",
     "botania:lavender_quartz",
     "botania:red_quartz",
-    "botania:elven_quartz",
+    "botania:elf_quartz",
     "botania:sunny_quartz"
   ]
 }

--- a/src/main/resources/data/forge/tags/blocks/storage_blocks/terrasteel.json
+++ b/src/main/resources/data/forge/tags/blocks/storage_blocks/terrasteel.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "botania:terrasteel_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:ingots/manasteel",
+    "#forge:ingots/terrasteel",
+    "#forge:ingots/elementium"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks.json
@@ -1,8 +1,8 @@
 {
   "replace": false,
   "values": [
-    "#forge:ingots/manasteel",
-    "#forge:ingots/terrasteel",
-    "#forge:ingots/elementium"
+    "#forge:storage_blocks/manasteel",
+    "#forge:storage_blocks/terrasteel",
+    "#forge:storage_blocks/elementium"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/storage_blocks/elementium.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/elementium.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "botania:elementium_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/manasteel.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/manasteel.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "botania:manasteel_block"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/quartz.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/quartz.json
@@ -1,0 +1,12 @@
+{
+  "replace": false,
+  "values": [
+    "botania:dark_quartz",
+    "botania:mana_quartz",
+    "botania:blaze_quartz",
+    "botania:lavender_quartz",
+    "botania:red_quartz",
+    "botania:elven_quartz",
+    "botania:sunny_quartz"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/storage_blocks/quartz.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/quartz.json
@@ -6,7 +6,7 @@
     "botania:blaze_quartz",
     "botania:lavender_quartz",
     "botania:red_quartz",
-    "botania:elven_quartz",
+    "botania:elf_quartz",
     "botania:sunny_quartz"
   ]
 }

--- a/src/main/resources/data/forge/tags/items/storage_blocks/terrasteel.json
+++ b/src/main/resources/data/forge/tags/items/storage_blocks/terrasteel.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "botania:terrasteel_block"
+  ]
+}


### PR DESCRIPTION
Add Terrasteel, Manasteel and Elementium Blocks to their own storage_blocks tag and the quartz variant blocks to forge:storageblocks/quartz.