### PR TITLE
Change some Recipes to use Tags

### DIFF
--- a/src/main/resources/data/botania/recipes/brewery.json
+++ b/src/main/resources/data/botania/recipes/brewery.json
@@ -19,7 +19,7 @@
       "item": "minecraft:brewing_stand"
     },
     "M": {
-      "item": "botania:manasteel_block"
+      "tag": "forge:storage_blocks/manasteel"
     }
   }
 }

--- a/src/main/resources/data/botania/recipes/conversions/elementium_block_deconstruct.json
+++ b/src/main/resources/data/botania/recipes/conversions/elementium_block_deconstruct.json
@@ -5,7 +5,7 @@
   },
   "ingredients": [
     {
-      "item": "botania:elementium_block"
+      "tag": "forge:storage_blocks/elementium"
     }
   ],
   "type": "minecraft:crafting_shapeless"

--- a/src/main/resources/data/botania/recipes/conversions/manasteel_block_deconstruct.json
+++ b/src/main/resources/data/botania/recipes/conversions/manasteel_block_deconstruct.json
@@ -5,7 +5,7 @@
   },
   "ingredients": [
     {
-      "item": "botania:manasteel_block"
+      "tag": "forge:storage_blocks/manasteel"
     }
   ],
   "type": "minecraft:crafting_shapeless"

--- a/src/main/resources/data/botania/recipes/conversions/terrasteel_block_deconstruct.json
+++ b/src/main/resources/data/botania/recipes/conversions/terrasteel_block_deconstruct.json
@@ -5,7 +5,7 @@
   },
   "ingredients": [
     {
-      "item": "botania:terrasteel_block"
+      "tag": "forge:storage_blocks/terrasteel"
     }
   ],
   "type": "minecraft:crafting_shapeless"

--- a/src/main/resources/data/botania/recipes/spawner_claw.json
+++ b/src/main/resources/data/botania/recipes/spawner_claw.json
@@ -22,7 +22,7 @@
       "item": "botania:ender_air_bottle"
     },
     "M": {
-      "item": "botania:manasteel_block"
+      "tag": "forge:storage_blocks/manasteel"
     }
   }
 }

--- a/src/main/resources/data/botania/recipes/terra_pick.json
+++ b/src/main/resources/data/botania/recipes/terra_pick.json
@@ -13,8 +13,7 @@
       "item": "botania:mana_tablet"
     },
     "I": {
-      "__comment": "TODO tag",
-      "item": "botania:terrasteel_ingot"
+      "tag": "forge:ingots/terrasteel"
     },
     "L": {
       "item": "botania:livingwood_twig"

--- a/src/main/resources/data/botania/recipes/terra_plate.json
+++ b/src/main/resources/data/botania/recipes/terra_plate.json
@@ -28,7 +28,7 @@
       "tag": "forge:storage_blocks/lapis"
     },
     "M": {
-      "item": "botania:manasteel_block"
+      "tag": "forge:storage_blocks/manasteel"
     }
   }
 }

--- a/src/main/resources/data/botania/recipes/terrasteel_boots.json
+++ b/src/main/resources/data/botania/recipes/terrasteel_boots.json
@@ -14,7 +14,7 @@
       "item": "botania:livingwood_twig"
     },
     "S": {
-      "item": "botania:terrasteel_ingot"
+      "tag": "forge:ingots/terrasteel"
     },
     "R": {
       "tag": "botania:runes/winter"

--- a/src/main/resources/data/botania/recipes/terrasteel_chestplate.json
+++ b/src/main/resources/data/botania/recipes/terrasteel_chestplate.json
@@ -14,7 +14,7 @@
       "item": "botania:livingwood_twig"
     },
     "S": {
-      "item": "botania:terrasteel_ingot"
+      "tag": "forge:ingots/terrasteel"
     },
     "R": {
       "tag": "botania:runes/summer"

--- a/src/main/resources/data/botania/recipes/terrasteel_helmet.json
+++ b/src/main/resources/data/botania/recipes/terrasteel_helmet.json
@@ -14,7 +14,7 @@
       "item": "botania:livingwood_twig"
     },
     "S": {
-      "item": "botania:terrasteel_ingot"
+      "tag": "forge:ingots/terrasteel"
     },
     "R": {
       "tag": "botania:runes/spring"

--- a/src/main/resources/data/botania/recipes/terrasteel_helmet_revealing.json
+++ b/src/main/resources/data/botania/recipes/terrasteel_helmet_revealing.json
@@ -14,7 +14,7 @@
       "item": "botania:livingwood_twig"
     },
     "S": {
-      "item": "botania:terrasteel_ingot"
+      "tag": "forge:ingots/terrasteel"
     },
     "R": {
       "tag": "botania:runes/spring"

--- a/src/main/resources/data/botania/recipes/terrasteel_leggings.json
+++ b/src/main/resources/data/botania/recipes/terrasteel_leggings.json
@@ -14,7 +14,7 @@
       "item": "botania:livingwood_twig"
     },
     "S": {
-      "item": "botania:terrasteel_ingot"
+      "tag": "forge:ingots/terrasteel"
     },
     "R": {
       "tag": "botania:runes/autumn"


### PR DESCRIPTION
Change the Terrasteel armor recipes to use the Terrasteel ingot tag instead of the item,
and change some recipes to use the Block tags from #3079