### PR TITLE
Fix the "bleeding-edge lang file" link

### DIFF
--- a/web/module/lexicon.php
+++ b/web/module/lexicon.php
@@ -6,7 +6,7 @@
 <div class='warning-txt'>
 	<ul>
 		<li>This page is a verbatim copy of the Lexica Botania you can craft ingame by combining a Book with any type of Sapling. It, however, does not contain any recipes or images. Usage of the ingame guide is encouraged.</li>
-		<li>The contents of this page are fed from the <a href="https://github.com/Vazkii/Botania/blob/master/src/main/resources/assets/botania/lang/en_US.lang"> bleeding-edge lang file</a> and may be ahead of the Botania version currently out.</li>
+		<li>The contents of this page are fed from the <a href="https://github.com/Vazkii/Botania/blob/master/src/main/resources/assets/botania/lang/en_us.json"> bleeding-edge lang file</a> and may be ahead of the Botania version currently out.</li>
 		<li>This page contains spoilers for unlockables!</li>
 	</ul>
 </div>


### PR DESCRIPTION
Fix the website lexicon page "bleeding-edge lang file" link to the github lang file, as it still linkes to a not existing en_US.lang one.