### PR TITLE
Allow force relays to store their bound blocks on other dimensions

### DIFF
--- a/src/main/java/vazkii/botania/common/block/BlockPistonRelay.java
+++ b/src/main/java/vazkii/botania/common/block/BlockPistonRelay.java
@@ -139,13 +139,13 @@ public class BlockPistonRelay extends BlockMod implements IWandable {
 
 	@SubscribeEvent
 	public void onWorldLoad(WorldEvent.Load event) {
-		if(!event.getWorld().getWorld().isRemote && event.getWorld().getDimension().getType() == DimensionType.OVERWORLD)
+		if(!event.getWorld().getWorld().isRemote)
 			WorldData.get(event.getWorld().getWorld());
 	}
 
 	@SubscribeEvent
 	public void onWorldUnload(WorldEvent.Unload event) {
-		if(!event.getWorld().getWorld().isRemote && event.getWorld().getDimension().getType() == DimensionType.OVERWORLD)
+		if(!event.getWorld().getWorld().isRemote)
 			WorldData.get(event.getWorld().getWorld()).markDirty();
 	}
 


### PR DESCRIPTION
See https://github.com/Vazkii/Botania/issues/3180

Turns out the problem lied in the fact that only the OW state was being saved, and other dimensions', modded or vanilla, wasn't.