### PR TITLE
Don't reduce stack size when re-adding previous recipe in creative.

### DIFF
--- a/src/main/java/vazkii/botania/common/block/tile/TileAltar.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileAltar.java
@@ -224,7 +224,7 @@ public class TileAltar extends TileSimpleInventory implements IPetalApothecary, 
 			for(int i = 0; i < player.inventory.getSizeInventory(); i++) {
 				ItemStack pstack = player.inventory.getStackInSlot(i);
 				if(!pstack.isEmpty() && pstack.isItemEqual(stack) && ItemStack.areItemStackTagsEqual(stack, pstack)) {
-					inv.setStackInSlot(index, pstack.split(1));
+					inv.setStackInSlot(index, (player.isCreative() ? pstack.copy() : pstack).split(1));
 					didAny = true;
 					index++;
 					break;

--- a/src/main/java/vazkii/botania/common/block/tile/TileAltar.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileAltar.java
@@ -223,8 +223,8 @@ public class TileAltar extends TileSimpleInventory implements IPetalApothecary, 
 
 			for(int i = 0; i < player.inventory.getSizeInventory(); i++) {
 				ItemStack pstack = player.inventory.getStackInSlot(i);
-				if(!pstack.isEmpty() && pstack.isItemEqual(stack) && ItemStack.areItemStackTagsEqual(stack, pstack)) {
-					inv.setStackInSlot(index, (player.isCreative() ? pstack.copy() : pstack).split(1));
+				if(player.isCreative() || (!pstack.isEmpty() && pstack.isItemEqual(stack) && ItemStack.areItemStackTagsEqual(stack, pstack))) {
+					inv.setStackInSlot(index, player.isCreative() ? stack.copy() : pstack.split(1));
 					didAny = true;
 					index++;
 					break;


### PR DESCRIPTION
I came across this earlier today and was thoroughly annoyed when attempting to recraft in creative proved more difficult that it should be. Curretnly, reinserting a recipe required and removed the items from the player's inventory, creative mode or not. With this change, reinserting a recipe, while still requiring at least one of each item, no longer removes those items from the inventory.

![Runic Altar](https://user-images.githubusercontent.com/11538216/75280829-14c93480-5806-11ea-92ad-818d642da718.gif)
![Runic Altar 2](https://user-images.githubusercontent.com/11538216/75281261-dc762600-5806-11ea-9a2f-103b06019dc4.gif)
![Petal Apothecary](https://user-images.githubusercontent.com/11538216/75281307-f0218c80-5806-11ea-9919-33734804d127.gif)

Should reinserting a recipe from creative mode instead not require even the presence of materials?