### PR TITLE
Add waterlogging support for Botania blocks.

### DIFF
--- a/src/main/java/vazkii/botania/common/block/BlockAlfPortal.java
+++ b/src/main/java/vazkii/botania/common/block/BlockAlfPortal.java
@@ -33,7 +33,7 @@ public class BlockAlfPortal extends BlockMod implements IWandable {
 
 	public BlockAlfPortal(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BotaniaStateProps.ALFPORTAL_STATE, AlfPortalState.OFF));
+		setDefaultState(getDefaultState().with(BotaniaStateProps.ALFPORTAL_STATE, AlfPortalState.OFF));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/BlockAltar.java
+++ b/src/main/java/vazkii/botania/common/block/BlockAltar.java
@@ -45,7 +45,7 @@ import vazkii.botania.common.item.rod.ItemWaterRod;
 
 import javax.annotation.Nonnull;
 
-public class BlockAltar extends BlockMod {
+public class BlockAltar extends BlockModWaterloggable {
 
 	private static final VoxelShape BASE = Block.makeCuboidShape(0, 0, 0, 16, 2, 16);
 	private static final VoxelShape MIDDLE = Block.makeCuboidShape(2, 2, 2, 14, 12, 14);

--- a/src/main/java/vazkii/botania/common/block/BlockAltar.java
+++ b/src/main/java/vazkii/botania/common/block/BlockAltar.java
@@ -45,7 +45,7 @@ import vazkii.botania.common.item.rod.ItemWaterRod;
 
 import javax.annotation.Nonnull;
 
-public class BlockAltar extends BlockModWaterloggable {
+public class BlockAltar extends BlockMod {
 
 	private static final VoxelShape BASE = Block.makeCuboidShape(0, 0, 0, 16, 2, 16);
 	private static final VoxelShape MIDDLE = Block.makeCuboidShape(2, 2, 2, 14, 12, 14);

--- a/src/main/java/vazkii/botania/common/block/BlockAnimatedTorch.java
+++ b/src/main/java/vazkii/botania/common/block/BlockAnimatedTorch.java
@@ -38,7 +38,7 @@ import vazkii.botania.common.block.tile.TileAnimatedTorch;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public class BlockAnimatedTorch extends BlockMod implements IWandable, IManaTrigger, IHourglassTrigger, IWandHUD {
+public class BlockAnimatedTorch extends BlockModWaterloggable implements IWandable, IManaTrigger, IHourglassTrigger, IWandHUD {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(0, 0, 0, 16, 4, 16);
 

--- a/src/main/java/vazkii/botania/common/block/BlockAvatar.java
+++ b/src/main/java/vazkii/botania/common/block/BlockAvatar.java
@@ -17,11 +17,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.state.StateContainer;
 import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.ActionResultType;
-import net.minecraft.util.Direction;
-import net.minecraft.util.Hand;
-import net.minecraft.util.Mirror;
-import net.minecraft.util.Rotation;
+import net.minecraft.util.*;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.shapes.ISelectionContext;
@@ -29,23 +25,21 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraftforge.items.ItemHandlerHelper;
-
 import vazkii.botania.api.item.IAvatarWieldable;
 import vazkii.botania.common.block.tile.TileAvatar;
 import vazkii.botania.common.block.tile.TileSimpleInventory;
 import vazkii.botania.common.core.helper.InventoryHelper;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
-public class BlockAvatar extends BlockMod {
+public class BlockAvatar extends BlockModWaterloggable {
 
 	private static final VoxelShape X_AABB = makeCuboidShape(5, 0, 3.5, 11, 17, 12.5);
 	private static final VoxelShape Z_AABB = makeCuboidShape(3.5, 0, 5, 12.5, 17, 11);
 
 	protected BlockAvatar(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.HORIZONTAL_FACING, Direction.NORTH));
+		setDefaultState(getDefaultState().with(BlockStateProperties.HORIZONTAL_FACING, Direction.NORTH));
 	}
 
 	@Nonnull
@@ -60,6 +54,7 @@ public class BlockAvatar extends BlockMod {
 
 	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		super.fillStateContainer(builder);
 		builder.add(BlockStateProperties.HORIZONTAL_FACING);
 	}
 
@@ -89,10 +84,10 @@ public class BlockAvatar extends BlockMod {
 		}
 	}
 
-	@Nullable
+	@Nonnull
 	@Override
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
-		return getDefaultState().with(BlockStateProperties.HORIZONTAL_FACING, context.getPlacementHorizontalFacing().getOpposite());
+		return super.getStateForPlacement(context).with(BlockStateProperties.HORIZONTAL_FACING, context.getPlacementHorizontalFacing().getOpposite());
 	}
 
 	@Nonnull

--- a/src/main/java/vazkii/botania/common/block/BlockAvatar.java
+++ b/src/main/java/vazkii/botania/common/block/BlockAvatar.java
@@ -25,6 +25,7 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraftforge.items.ItemHandlerHelper;
+
 import vazkii.botania.api.item.IAvatarWieldable;
 import vazkii.botania.common.block.tile.TileAvatar;
 import vazkii.botania.common.block.tile.TileSimpleInventory;

--- a/src/main/java/vazkii/botania/common/block/BlockCacophonium.java
+++ b/src/main/java/vazkii/botania/common/block/BlockCacophonium.java
@@ -25,7 +25,7 @@ import javax.annotation.Nonnull;
 public class BlockCacophonium extends BlockMod {
 	protected BlockCacophonium(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.POWERED, false));
+		setDefaultState(getDefaultState().with(BlockStateProperties.POWERED, false));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/BlockCocoon.java
+++ b/src/main/java/vazkii/botania/common/block/BlockCocoon.java
@@ -34,7 +34,7 @@ import vazkii.botania.common.item.ModItems;
 
 import javax.annotation.Nonnull;
 
-public class BlockCocoon extends BlockMod {
+public class BlockCocoon extends BlockModWaterloggable {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(3, 0, 3, 13, 14, 13);;
 

--- a/src/main/java/vazkii/botania/common/block/BlockCraftyCrate.java
+++ b/src/main/java/vazkii/botania/common/block/BlockCraftyCrate.java
@@ -32,7 +32,7 @@ public class BlockCraftyCrate extends BlockOpenCrate implements IWandHUD {
 
 	public BlockCraftyCrate(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BotaniaStateProps.CRATE_PATTERN, CratePattern.NONE));
+		setDefaultState(getDefaultState().with(BotaniaStateProps.CRATE_PATTERN, CratePattern.NONE));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/BlockEnderEye.java
+++ b/src/main/java/vazkii/botania/common/block/BlockEnderEye.java
@@ -29,7 +29,7 @@ public class BlockEnderEye extends BlockMod {
 
 	protected BlockEnderEye(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.POWERED, false));
+		setDefaultState(getDefaultState().with(BlockStateProperties.POWERED, false));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/BlockFelPumpkin.java
+++ b/src/main/java/vazkii/botania/common/block/BlockFelPumpkin.java
@@ -32,7 +32,7 @@ public class BlockFelPumpkin extends BlockMod {
 
 	public BlockFelPumpkin(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.HORIZONTAL_FACING, Direction.SOUTH));
+		setDefaultState(getDefaultState().with(BlockStateProperties.HORIZONTAL_FACING, Direction.SOUTH));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/BlockForestEye.java
+++ b/src/main/java/vazkii/botania/common/block/BlockForestEye.java
@@ -20,7 +20,7 @@ import vazkii.botania.common.block.tile.TileForestEye;
 
 import javax.annotation.Nonnull;
 
-public class BlockForestEye extends BlockMod {
+public class BlockForestEye extends BlockModWaterloggable {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(4, 4, 4, 12, 12, 12);
 

--- a/src/main/java/vazkii/botania/common/block/BlockGhostRail.java
+++ b/src/main/java/vazkii/botania/common/block/BlockGhostRail.java
@@ -45,7 +45,7 @@ public class BlockGhostRail extends AbstractRailBlock {
 
 	public BlockGhostRail(Properties builder) {
 		super(true, builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.RAIL_SHAPE_STRAIGHT, RailShape.NORTH_SOUTH));
+		setDefaultState(getDefaultState().with(BlockStateProperties.RAIL_SHAPE_STRAIGHT, RailShape.NORTH_SOUTH));
 		MinecraftForge.EVENT_BUS.addListener(this::cartSpawn);
 		MinecraftForge.EVENT_BUS.addListener(this::worldTick);
 	}

--- a/src/main/java/vazkii/botania/common/block/BlockHourglass.java
+++ b/src/main/java/vazkii/botania/common/block/BlockHourglass.java
@@ -47,13 +47,13 @@ import javax.annotation.Nonnull;
 
 import java.util.Random;
 
-public class BlockHourglass extends BlockMod implements IManaTrigger, IWandable, IWandHUD {
+public class BlockHourglass extends BlockModWaterloggable implements IManaTrigger, IWandable, IWandHUD {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(4, 0, 4, 12, 18.4, 12);
 
 	protected BlockHourglass(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.POWERED, false));
+		setDefaultState(getDefaultState().with(BlockStateProperties.POWERED, false));
 	}
 
 	@Nonnull
@@ -64,6 +64,7 @@ public class BlockHourglass extends BlockMod implements IManaTrigger, IWandable,
 
 	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		super.fillStateContainer(builder);
 		builder.add(BlockStateProperties.POWERED);
 	}
 

--- a/src/main/java/vazkii/botania/common/block/BlockIncensePlate.java
+++ b/src/main/java/vazkii/botania/common/block/BlockIncensePlate.java
@@ -27,24 +27,25 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraftforge.items.ItemHandlerHelper;
-
 import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.common.block.tile.TileIncensePlate;
+import vazkii.botania.common.core.helper.InventoryHelper;
 
 import javax.annotation.Nonnull;
 
-public class BlockIncensePlate extends BlockMod {
+public class BlockIncensePlate extends BlockModWaterloggable {
 
 	private static final VoxelShape X_SHAPE = makeCuboidShape(6, 0, 2, 10, 1, 14);
 	private static final VoxelShape Z_SHAPE = makeCuboidShape(2, 0, 6, 14, 1, 10);
 
 	protected BlockIncensePlate(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.HORIZONTAL_FACING, Direction.SOUTH));
+		setDefaultState(getDefaultState().with(BlockStateProperties.HORIZONTAL_FACING, Direction.SOUTH));
 	}
 
 	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		super.fillStateContainer(builder);
 		builder.add(BlockStateProperties.HORIZONTAL_FACING);
 	}
 
@@ -85,7 +86,7 @@ public class BlockIncensePlate extends BlockMod {
 
 	@Override
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
-		return getDefaultState().with(BlockStateProperties.HORIZONTAL_FACING, context.getPlacementHorizontalFacing().getOpposite());
+		return super.getStateForPlacement(context).with(BlockStateProperties.HORIZONTAL_FACING, context.getPlacementHorizontalFacing().getOpposite());
 	}
 
 	@Override
@@ -117,6 +118,17 @@ public class BlockIncensePlate extends BlockMod {
 	@Override
 	public TileEntity createTileEntity(@Nonnull BlockState state, @Nonnull IBlockReader world) {
 		return new TileIncensePlate();
+	}
+
+	@Override
+	public void onReplaced(@Nonnull BlockState state, @Nonnull World world, @Nonnull BlockPos pos, @Nonnull BlockState newState, boolean isMoving) {
+		if (state.getBlock() != newState.getBlock()) {
+			TileIncensePlate plate = (TileIncensePlate) world.getTileEntity(pos);
+			if (plate != null && !plate.burning) {
+				InventoryHelper.dropInventory(plate, world, state, pos);
+			}
+		}
+		super.onReplaced(state, world, pos, newState, isMoving);
 	}
 
 }

--- a/src/main/java/vazkii/botania/common/block/BlockIncensePlate.java
+++ b/src/main/java/vazkii/botania/common/block/BlockIncensePlate.java
@@ -27,6 +27,7 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraftforge.items.ItemHandlerHelper;
+
 import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.common.block.tile.TileIncensePlate;
 import vazkii.botania.common.core.helper.InventoryHelper;
@@ -57,6 +58,13 @@ public class BlockIncensePlate extends BlockModWaterloggable {
 		boolean did = false;
 
 		if (world.isRemote) {
+			if (state.get(BlockStateProperties.WATERLOGGED)
+					&& !plateStack.isEmpty()
+					&& !plate.burning
+					&& !stack.isEmpty()
+					&& stack.getItem() == Items.FLINT_AND_STEEL) {
+				plate.spawnSmokeParticles();
+			}
 			return ActionResultType.SUCCESS;
 		}
 

--- a/src/main/java/vazkii/botania/common/block/BlockLightLauncher.java
+++ b/src/main/java/vazkii/botania/common/block/BlockLightLauncher.java
@@ -31,13 +31,13 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
-public class BlockLightLauncher extends BlockMod {
+public class BlockLightLauncher extends BlockModWaterloggable {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(0, 0, 0, 16, 4, 16);
 
 	public BlockLightLauncher(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.POWERED, false));
+		setDefaultState(getDefaultState().with(BlockStateProperties.POWERED, false));
 	}
 
 	@Nonnull
@@ -48,6 +48,7 @@ public class BlockLightLauncher extends BlockMod {
 
 	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		super.fillStateContainer(builder);
 		builder.add(BlockStateProperties.POWERED);
 	}
 

--- a/src/main/java/vazkii/botania/common/block/BlockLightRelay.java
+++ b/src/main/java/vazkii/botania/common/block/BlockLightRelay.java
@@ -36,7 +36,7 @@ import javax.annotation.Nonnull;
 
 import java.util.Random;
 
-public class BlockLightRelay extends BlockMod implements IWandable {
+public class BlockLightRelay extends BlockModWaterloggable implements IWandable {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(5, 5, 5, 11, 11, 11);
 	public final LuminizerVariant variant;
@@ -44,7 +44,7 @@ public class BlockLightRelay extends BlockMod implements IWandable {
 	protected BlockLightRelay(LuminizerVariant variant, Properties builder) {
 		super(builder);
 		this.variant = variant;
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.POWERED, false));
+		setDefaultState(getDefaultState().with(BlockStateProperties.POWERED, false));
 	}
 
 	@Nonnull
@@ -55,6 +55,7 @@ public class BlockLightRelay extends BlockMod implements IWandable {
 
 	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		super.fillStateContainer(builder);
 		builder.add(BlockStateProperties.POWERED);
 	}
 

--- a/src/main/java/vazkii/botania/common/block/BlockModWaterloggable.java
+++ b/src/main/java/vazkii/botania/common/block/BlockModWaterloggable.java
@@ -1,0 +1,60 @@
+/*
+ * This class is distributed as part of the Botania Mod.
+ * Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ */
+package vazkii.botania.common.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.IWaterLoggable;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.fluid.IFluidState;
+import net.minecraft.item.BlockItemUseContext;
+import net.minecraft.state.StateContainer;
+import net.minecraft.state.properties.BlockStateProperties;
+import net.minecraft.util.Direction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IWorld;
+
+import javax.annotation.Nonnull;
+
+import static net.minecraft.state.properties.BlockStateProperties.WATERLOGGED;
+
+public abstract class BlockModWaterloggable extends BlockMod implements IWaterLoggable {
+
+    public BlockModWaterloggable(Properties builder) {
+        super(builder);
+        setDefaultState(getDefaultState().with(BlockStateProperties.WATERLOGGED, false));
+    }
+
+    @Override
+    protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+        builder.add(WATERLOGGED);
+    }
+
+    @Override
+    public IFluidState getFluidState(BlockState state) {
+        return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : Fluids.EMPTY.getDefaultState();
+    }
+
+    @Nonnull
+    @Override
+    public BlockState getStateForPlacement(BlockItemUseContext context) {
+        IFluidState fluidState = context.getWorld().getFluidState(context.getPos());
+        return this.getDefaultState().with(WATERLOGGED, fluidState.getFluid() == Fluids.WATER);
+    }
+
+    @Override
+    public BlockState updatePostPlacement(BlockState stateIn, Direction side, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
+        if(stateIn.get(WATERLOGGED)) {
+            worldIn.getPendingFluidTicks().scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickRate(worldIn));
+        }
+
+        return stateIn;
+    }
+
+}

--- a/src/main/java/vazkii/botania/common/block/BlockModWaterloggable.java
+++ b/src/main/java/vazkii/botania/common/block/BlockModWaterloggable.java
@@ -26,35 +26,35 @@ import static net.minecraft.state.properties.BlockStateProperties.WATERLOGGED;
 
 public abstract class BlockModWaterloggable extends BlockMod implements IWaterLoggable {
 
-    public BlockModWaterloggable(Properties builder) {
-        super(builder);
-        setDefaultState(getDefaultState().with(BlockStateProperties.WATERLOGGED, false));
-    }
+	public BlockModWaterloggable(Properties builder) {
+		super(builder);
+		setDefaultState(getDefaultState().with(BlockStateProperties.WATERLOGGED, false));
+	}
 
-    @Override
-    protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
-        builder.add(WATERLOGGED);
-    }
+	@Override
+	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		builder.add(WATERLOGGED);
+	}
 
-    @Override
-    public IFluidState getFluidState(BlockState state) {
-        return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : Fluids.EMPTY.getDefaultState();
-    }
+	@Override
+	public IFluidState getFluidState(BlockState state) {
+		return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : Fluids.EMPTY.getDefaultState();
+	}
 
-    @Nonnull
-    @Override
-    public BlockState getStateForPlacement(BlockItemUseContext context) {
-        IFluidState fluidState = context.getWorld().getFluidState(context.getPos());
-        return this.getDefaultState().with(WATERLOGGED, fluidState.getFluid() == Fluids.WATER);
-    }
+	@Nonnull
+	@Override
+	public BlockState getStateForPlacement(BlockItemUseContext context) {
+		IFluidState fluidState = context.getWorld().getFluidState(context.getPos());
+		return this.getDefaultState().with(WATERLOGGED, fluidState.getFluid() == Fluids.WATER);
+	}
 
-    @Override
-    public BlockState updatePostPlacement(BlockState stateIn, Direction side, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
-        if(stateIn.get(WATERLOGGED)) {
-            worldIn.getPendingFluidTicks().scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickRate(worldIn));
-        }
+	@Override
+	public BlockState updatePostPlacement(BlockState stateIn, Direction side, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
+		if (stateIn.get(WATERLOGGED)) {
+			worldIn.getPendingFluidTicks().scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickRate(worldIn));
+		}
 
-        return stateIn;
-    }
+		return stateIn;
+	}
 
 }

--- a/src/main/java/vazkii/botania/common/block/BlockPylon.java
+++ b/src/main/java/vazkii/botania/common/block/BlockPylon.java
@@ -22,7 +22,7 @@ import vazkii.botania.common.block.tile.TilePylon;
 
 import javax.annotation.Nonnull;
 
-public class BlockPylon extends BlockMod {
+public class BlockPylon extends BlockModWaterloggable {
 	private static final VoxelShape SHAPE = Block.makeCuboidShape(2, 0, 2, 14, 21, 14);
 
 	public enum Variant {

--- a/src/main/java/vazkii/botania/common/block/BlockSparkChanger.java
+++ b/src/main/java/vazkii/botania/common/block/BlockSparkChanger.java
@@ -32,13 +32,13 @@ import vazkii.botania.common.item.ItemSparkUpgrade;
 
 import javax.annotation.Nonnull;
 
-public class BlockSparkChanger extends BlockMod {
+public class BlockSparkChanger extends BlockModWaterloggable {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(0, 0, 0, 16, 3, 16);
 
 	public BlockSparkChanger(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.POWERED, true));
+		setDefaultState(getDefaultState().with(BlockStateProperties.POWERED, true));
 	}
 
 	@Nonnull
@@ -49,6 +49,7 @@ public class BlockSparkChanger extends BlockMod {
 
 	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		super.fillStateContainer(builder);
 		builder.add(BlockStateProperties.POWERED);
 	}
 

--- a/src/main/java/vazkii/botania/common/block/BlockTeruTeruBozu.java
+++ b/src/main/java/vazkii/botania/common/block/BlockTeruTeruBozu.java
@@ -24,12 +24,11 @@ import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
-
 import vazkii.botania.common.block.tile.TileTeruTeruBozu;
 
 import javax.annotation.Nonnull;
 
-public class BlockTeruTeruBozu extends BlockMod {
+public class BlockTeruTeruBozu extends BlockModWaterloggable {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(4, 0.16, 4, 12, 15.84, 12);
 

--- a/src/main/java/vazkii/botania/common/block/BlockTeruTeruBozu.java
+++ b/src/main/java/vazkii/botania/common/block/BlockTeruTeruBozu.java
@@ -24,6 +24,7 @@ import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
+
 import vazkii.botania.common.block.tile.TileTeruTeruBozu;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/vazkii/botania/common/block/BlockTinyPlanet.java
+++ b/src/main/java/vazkii/botania/common/block/BlockTinyPlanet.java
@@ -21,7 +21,7 @@ import vazkii.botania.common.block.tile.TileTinyPlanet;
 
 import javax.annotation.Nonnull;
 
-public class BlockTinyPlanet extends BlockMod implements IManaCollisionGhost {
+public class BlockTinyPlanet extends BlockModWaterloggable implements IManaCollisionGhost {
 
 	private static final VoxelShape AABB = makeCuboidShape(3, 3, 3, 13, 13, 13);
 

--- a/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaBaseWaterloggable.java
+++ b/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaBaseWaterloggable.java
@@ -26,35 +26,35 @@ import static net.minecraft.state.properties.BlockStateProperties.WATERLOGGED;
 
 public abstract class BlockCorporeaBaseWaterloggable extends BlockCorporeaBase implements IWaterLoggable {
 
-    public BlockCorporeaBaseWaterloggable(Properties builder) {
-        super(builder);
-        setDefaultState(getDefaultState().with(BlockStateProperties.WATERLOGGED, false));
-    }
+	public BlockCorporeaBaseWaterloggable(Properties builder) {
+		super(builder);
+		setDefaultState(getDefaultState().with(BlockStateProperties.WATERLOGGED, false));
+	}
 
-    @Override
-    protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
-        builder.add(WATERLOGGED);
-    }
+	@Override
+	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		builder.add(WATERLOGGED);
+	}
 
-    @Override
-    public IFluidState getFluidState(BlockState state) {
-        return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : Fluids.EMPTY.getDefaultState();
-    }
+	@Override
+	public IFluidState getFluidState(BlockState state) {
+		return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : Fluids.EMPTY.getDefaultState();
+	}
 
-    @Nonnull
-    @Override
-    public BlockState getStateForPlacement(BlockItemUseContext context) {
-        IFluidState fluidState = context.getWorld().getFluidState(context.getPos());
-        return this.getDefaultState().with(WATERLOGGED, fluidState.getFluid() == Fluids.WATER);
-    }
+	@Nonnull
+	@Override
+	public BlockState getStateForPlacement(BlockItemUseContext context) {
+		IFluidState fluidState = context.getWorld().getFluidState(context.getPos());
+		return this.getDefaultState().with(WATERLOGGED, fluidState.getFluid() == Fluids.WATER);
+	}
 
-    @Override
-    public BlockState updatePostPlacement(BlockState stateIn, Direction side, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
-        if(stateIn.get(WATERLOGGED)) {
-            worldIn.getPendingFluidTicks().scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickRate(worldIn));
-        }
+	@Override
+	public BlockState updatePostPlacement(BlockState stateIn, Direction side, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
+		if (stateIn.get(WATERLOGGED)) {
+			worldIn.getPendingFluidTicks().scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickRate(worldIn));
+		}
 
-        return stateIn;
-    }
+		return stateIn;
+	}
 
 }

--- a/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaBaseWaterloggable.java
+++ b/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaBaseWaterloggable.java
@@ -1,3 +1,11 @@
+/*
+ * This class is distributed as part of the Botania Mod.
+ * Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ */
 package vazkii.botania.common.block.corporea;
 
 import net.minecraft.block.Block;

--- a/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaBaseWaterloggable.java
+++ b/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaBaseWaterloggable.java
@@ -1,0 +1,52 @@
+package vazkii.botania.common.block.corporea;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.IWaterLoggable;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.fluid.IFluidState;
+import net.minecraft.item.BlockItemUseContext;
+import net.minecraft.state.StateContainer;
+import net.minecraft.state.properties.BlockStateProperties;
+import net.minecraft.util.Direction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IWorld;
+
+import javax.annotation.Nonnull;
+
+import static net.minecraft.state.properties.BlockStateProperties.WATERLOGGED;
+
+public abstract class BlockCorporeaBaseWaterloggable extends BlockCorporeaBase implements IWaterLoggable {
+
+    public BlockCorporeaBaseWaterloggable(Properties builder) {
+        super(builder);
+        setDefaultState(getDefaultState().with(BlockStateProperties.WATERLOGGED, false));
+    }
+
+    @Override
+    protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+        builder.add(WATERLOGGED);
+    }
+
+    @Override
+    public IFluidState getFluidState(BlockState state) {
+        return state.get(WATERLOGGED) ? Fluids.WATER.getStillFluidState(false) : Fluids.EMPTY.getDefaultState();
+    }
+
+    @Nonnull
+    @Override
+    public BlockState getStateForPlacement(BlockItemUseContext context) {
+        IFluidState fluidState = context.getWorld().getFluidState(context.getPos());
+        return this.getDefaultState().with(WATERLOGGED, fluidState.getFluid() == Fluids.WATER);
+    }
+
+    @Override
+    public BlockState updatePostPlacement(BlockState stateIn, Direction side, BlockState facingState, IWorld worldIn, BlockPos currentPos, BlockPos facingPos) {
+        if(stateIn.get(WATERLOGGED)) {
+            worldIn.getPendingFluidTicks().scheduleTick(currentPos, Fluids.WATER, Fluids.WATER.getTickRate(worldIn));
+        }
+
+        return stateIn;
+    }
+
+}

--- a/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaCrystalCube.java
+++ b/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaCrystalCube.java
@@ -31,7 +31,7 @@ import vazkii.botania.common.item.ModItems;
 
 import javax.annotation.Nonnull;
 
-public class BlockCorporeaCrystalCube extends BlockCorporeaBase implements IWandable {
+public class BlockCorporeaCrystalCube extends BlockCorporeaBaseWaterloggable implements IWandable {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(3.0, 0, 3.0, 13.0, 16, 13.0);
 

--- a/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaFunnel.java
+++ b/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaFunnel.java
@@ -25,7 +25,7 @@ public class BlockCorporeaFunnel extends BlockCorporeaBase {
 
 	public BlockCorporeaFunnel(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.POWERED, false));
+		setDefaultState(getDefaultState().with(BlockStateProperties.POWERED, false));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaIndex.java
+++ b/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaIndex.java
@@ -18,7 +18,7 @@ import vazkii.botania.common.block.tile.corporea.TileCorporeaIndex;
 
 import javax.annotation.Nonnull;
 
-public class BlockCorporeaIndex extends BlockCorporeaBase {
+public class BlockCorporeaIndex extends BlockCorporeaBaseWaterloggable {
 	public BlockCorporeaIndex(Block.Properties builder) {
 		super(builder);
 	}

--- a/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaInterceptor.java
+++ b/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaInterceptor.java
@@ -29,7 +29,7 @@ public class BlockCorporeaInterceptor extends BlockCorporeaBase {
 
 	public BlockCorporeaInterceptor(Block.Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.POWERED, false));
+		setDefaultState(getDefaultState().with(BlockStateProperties.POWERED, false));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaRetainer.java
+++ b/src/main/java/vazkii/botania/common/block/corporea/BlockCorporeaRetainer.java
@@ -26,7 +26,7 @@ public class BlockCorporeaRetainer extends BlockMod {
 
 	public BlockCorporeaRetainer(Block.Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.POWERED, false));
+		setDefaultState(getDefaultState().with(BlockStateProperties.POWERED, false));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/decor/BlockFloatingFlower.java
+++ b/src/main/java/vazkii/botania/common/block/decor/BlockFloatingFlower.java
@@ -26,22 +26,20 @@ import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
-import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.api.item.IFloatingFlower;
 import vazkii.botania.api.item.IFloatingFlower.IslandType;
 import vazkii.botania.api.subtile.TileEntitySpecialFlower;
 import vazkii.botania.client.fx.SparkleParticleData;
-import vazkii.botania.common.block.BlockMod;
+import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.TileFloatingFlower;
 import vazkii.botania.common.core.handler.ConfigHandler;
 import vazkii.botania.common.item.IFloatingFlowerVariant;
 
 import javax.annotation.Nonnull;
-
 import java.util.Random;
 
-public class BlockFloatingFlower extends BlockMod {
+public class BlockFloatingFlower extends BlockModWaterloggable {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(1.6, 1.6, 1.6, 14.4, 14.4, 14.4);
 	public final DyeColor color;

--- a/src/main/java/vazkii/botania/common/block/decor/BlockFloatingFlower.java
+++ b/src/main/java/vazkii/botania/common/block/decor/BlockFloatingFlower.java
@@ -37,6 +37,7 @@ import vazkii.botania.common.core.handler.ConfigHandler;
 import vazkii.botania.common.item.IFloatingFlowerVariant;
 
 import javax.annotation.Nonnull;
+
 import java.util.Random;
 
 public class BlockFloatingFlower extends BlockModWaterloggable {

--- a/src/main/java/vazkii/botania/common/block/decor/BlockStarfield.java
+++ b/src/main/java/vazkii/botania/common/block/decor/BlockStarfield.java
@@ -14,6 +14,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
+
 import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.TileStarfield;
 

--- a/src/main/java/vazkii/botania/common/block/decor/BlockStarfield.java
+++ b/src/main/java/vazkii/botania/common/block/decor/BlockStarfield.java
@@ -14,13 +14,12 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
-
-import vazkii.botania.common.block.BlockMod;
+import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.TileStarfield;
 
 import javax.annotation.Nonnull;
 
-public class BlockStarfield extends BlockMod {
+public class BlockStarfield extends BlockModWaterloggable {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(0, 0, 0, 16, 4, 16);
 

--- a/src/main/java/vazkii/botania/common/block/decor/BlockTinyPotato.java
+++ b/src/main/java/vazkii/botania/common/block/decor/BlockTinyPotato.java
@@ -30,8 +30,7 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
-
-import vazkii.botania.common.block.BlockMod;
+import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.TileSimpleInventory;
 import vazkii.botania.common.block.tile.TileTinyPotato;
 import vazkii.botania.common.core.helper.InventoryHelper;
@@ -39,18 +38,19 @@ import vazkii.botania.common.core.helper.InventoryHelper;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public class BlockTinyPotato extends BlockMod {
+public class BlockTinyPotato extends BlockModWaterloggable {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(6, 0, 6, 10, 6, 10);
 
 	public BlockTinyPotato(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState()
+		setDefaultState(getDefaultState()
 				.with(BlockStateProperties.HORIZONTAL_FACING, Direction.SOUTH));
 	}
 
 	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		super.fillStateContainer(builder);
 		builder.add(BlockStateProperties.HORIZONTAL_FACING);
 	}
 
@@ -82,9 +82,10 @@ public class BlockTinyPotato extends BlockMod {
 		return ActionResultType.SUCCESS;
 	}
 
+	@Nonnull
 	@Override
 	public BlockState getStateForPlacement(BlockItemUseContext ctx) {
-		return getDefaultState().with(BlockStateProperties.HORIZONTAL_FACING, ctx.getPlacementHorizontalFacing().getOpposite());
+		return super.getStateForPlacement(ctx).with(BlockStateProperties.HORIZONTAL_FACING, ctx.getPlacementHorizontalFacing().getOpposite());
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/decor/BlockTinyPotato.java
+++ b/src/main/java/vazkii/botania/common/block/decor/BlockTinyPotato.java
@@ -30,6 +30,7 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
+
 import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.TileSimpleInventory;
 import vazkii.botania.common.block.tile.TileTinyPotato;

--- a/src/main/java/vazkii/botania/common/block/mana/BlockBellows.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockBellows.java
@@ -25,24 +25,24 @@ import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
-
-import vazkii.botania.common.block.BlockMod;
+import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.mana.TileBellows;
 import vazkii.botania.common.entity.EntityDoppleganger;
 
 import javax.annotation.Nonnull;
 
-public class BlockBellows extends BlockMod {
+public class BlockBellows extends BlockModWaterloggable {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(3, 0, 3, 13, 10.0, 13);
 
 	public BlockBellows(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.HORIZONTAL_FACING, Direction.SOUTH));
+		setDefaultState(getDefaultState().with(BlockStateProperties.HORIZONTAL_FACING, Direction.SOUTH));
 	}
 
 	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		super.fillStateContainer(builder);
 		builder.add(BlockStateProperties.HORIZONTAL_FACING);
 	}
 
@@ -52,9 +52,10 @@ public class BlockBellows extends BlockMod {
 		return SHAPE;
 	}
 
+	@Nonnull
 	@Override
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
-		return getDefaultState().with(BlockStateProperties.HORIZONTAL_FACING, context.getPlacementHorizontalFacing());
+		return super.getStateForPlacement(context).with(BlockStateProperties.HORIZONTAL_FACING, context.getPlacementHorizontalFacing());
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/mana/BlockBellows.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockBellows.java
@@ -25,14 +25,13 @@ import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
-
-import vazkii.botania.common.block.BlockModWaterloggable;
+import vazkii.botania.common.block.BlockMod;
 import vazkii.botania.common.block.tile.mana.TileBellows;
 import vazkii.botania.common.entity.EntityDoppleganger;
 
 import javax.annotation.Nonnull;
 
-public class BlockBellows extends BlockModWaterloggable {
+public class BlockBellows extends BlockMod {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(3, 0, 3, 13, 10.0, 13);
 

--- a/src/main/java/vazkii/botania/common/block/mana/BlockBellows.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockBellows.java
@@ -25,6 +25,7 @@ import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
+
 import vazkii.botania.common.block.BlockMod;
 import vazkii.botania.common.block.tile.mana.TileBellows;
 import vazkii.botania.common.entity.EntityDoppleganger;

--- a/src/main/java/vazkii/botania/common/block/mana/BlockBellows.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockBellows.java
@@ -25,6 +25,7 @@ import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
+
 import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.mana.TileBellows;
 import vazkii.botania.common.entity.EntityDoppleganger;

--- a/src/main/java/vazkii/botania/common/block/mana/BlockBrewery.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockBrewery.java
@@ -27,26 +27,26 @@ import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-
 import vazkii.botania.api.wand.IWandHUD;
-import vazkii.botania.common.block.BlockMod;
+import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.TileBrewery;
 import vazkii.botania.common.block.tile.TileSimpleInventory;
 import vazkii.botania.common.core.helper.InventoryHelper;
 
 import javax.annotation.Nonnull;
 
-public class BlockBrewery extends BlockMod implements IWandHUD {
+public class BlockBrewery extends BlockModWaterloggable implements IWandHUD {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(6, 0.8, 6, 10, 15.2, 10);
 
 	public BlockBrewery(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.POWERED, false));
+		setDefaultState(getDefaultState().with(BlockStateProperties.POWERED, false));
 	}
 
 	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		super.fillStateContainer(builder);
 		builder.add(BlockStateProperties.POWERED);
 	}
 

--- a/src/main/java/vazkii/botania/common/block/mana/BlockBrewery.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockBrewery.java
@@ -27,6 +27,7 @@ import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+
 import vazkii.botania.api.wand.IWandHUD;
 import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.TileBrewery;

--- a/src/main/java/vazkii/botania/common/block/mana/BlockDistributor.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockDistributor.java
@@ -15,13 +15,12 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
-
-import vazkii.botania.common.block.BlockMod;
+import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.mana.TileDistributor;
 
 import javax.annotation.Nonnull;
 
-public class BlockDistributor extends BlockMod {
+public class BlockDistributor extends BlockModWaterloggable {
 
 	private static final VoxelShape SHAPE = Block.makeCuboidShape(4, 0, 4, 12, 16, 12);
 

--- a/src/main/java/vazkii/botania/common/block/mana/BlockDistributor.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockDistributor.java
@@ -15,6 +15,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
+
 import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.mana.TileDistributor;
 

--- a/src/main/java/vazkii/botania/common/block/mana/BlockEnchanter.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockEnchanter.java
@@ -41,7 +41,7 @@ public class BlockEnchanter extends BlockMod implements IWandable, IWandHUD {
 
 	public BlockEnchanter(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BotaniaStateProps.ENCHANTER_DIRECTION, Direction.Axis.X));
+		setDefaultState(getDefaultState().with(BotaniaStateProps.ENCHANTER_DIRECTION, Direction.Axis.X));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/mana/BlockForestDrum.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockForestDrum.java
@@ -25,6 +25,7 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraftforge.common.IShearable;
+
 import vazkii.botania.api.internal.IManaBurst;
 import vazkii.botania.api.mana.IManaTrigger;
 import vazkii.botania.common.block.BlockModWaterloggable;
@@ -33,6 +34,7 @@ import vazkii.botania.common.item.ItemHorn;
 import vazkii.botania.common.item.ModItems;
 
 import javax.annotation.Nonnull;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/vazkii/botania/common/block/mana/BlockForestDrum.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockForestDrum.java
@@ -25,21 +25,19 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraftforge.common.IShearable;
-
 import vazkii.botania.api.internal.IManaBurst;
 import vazkii.botania.api.mana.IManaTrigger;
-import vazkii.botania.common.block.BlockMod;
+import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.item.ItemHorn;
 import vazkii.botania.common.item.ModItems;
 
 import javax.annotation.Nonnull;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class BlockForestDrum extends BlockMod implements IManaTrigger {
+public class BlockForestDrum extends BlockModWaterloggable implements IManaTrigger {
 
 	public enum Variant {
 		WILD,

--- a/src/main/java/vazkii/botania/common/block/mana/BlockManaDetector.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockManaDetector.java
@@ -32,7 +32,7 @@ public class BlockManaDetector extends BlockMod implements IManaCollisionGhost {
 
 	public BlockManaDetector(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.POWERED, false));
+		setDefaultState(getDefaultState().with(BlockStateProperties.POWERED, false));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/mana/BlockPool.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockPool.java
@@ -28,6 +28,7 @@ import net.minecraft.world.storage.loot.LootContext;
 import net.minecraft.world.storage.loot.LootParameters;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+
 import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.api.wand.IWandHUD;
 import vazkii.botania.api.wand.IWandable;
@@ -35,6 +36,7 @@ import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.mana.TilePool;
 
 import javax.annotation.Nonnull;
+
 import java.util.Collections;
 import java.util.List;
 

--- a/src/main/java/vazkii/botania/common/block/mana/BlockPool.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockPool.java
@@ -28,19 +28,17 @@ import net.minecraft.world.storage.loot.LootContext;
 import net.minecraft.world.storage.loot.LootParameters;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
-
 import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.api.wand.IWandHUD;
 import vazkii.botania.api.wand.IWandable;
-import vazkii.botania.common.block.BlockMod;
+import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.mana.TilePool;
 
 import javax.annotation.Nonnull;
-
 import java.util.Collections;
 import java.util.List;
 
-public class BlockPool extends BlockMod implements IWandHUD, IWandable {
+public class BlockPool extends BlockModWaterloggable implements IWandHUD, IWandable {
 	private static final VoxelShape SLAB = makeCuboidShape(0, 0, 0, 16, 8, 16);
 	private static final VoxelShape CUTOUT = makeCuboidShape(1, 1, 1, 15, 8, 15);
 	private static final VoxelShape REAL_SHAPE = VoxelShapes.combineAndSimplify(SLAB, CUTOUT, IBooleanFunction.ONLY_FIRST);

--- a/src/main/java/vazkii/botania/common/block/mana/BlockPrism.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockPrism.java
@@ -24,6 +24,7 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraftforge.items.ItemHandlerHelper;
+
 import vazkii.botania.api.internal.IManaBurst;
 import vazkii.botania.api.mana.ILens;
 import vazkii.botania.api.mana.IManaCollisionGhost;

--- a/src/main/java/vazkii/botania/common/block/mana/BlockPrism.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockPrism.java
@@ -24,25 +24,24 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
 import net.minecraftforge.items.ItemHandlerHelper;
-
 import vazkii.botania.api.internal.IManaBurst;
 import vazkii.botania.api.mana.ILens;
 import vazkii.botania.api.mana.IManaCollisionGhost;
 import vazkii.botania.api.mana.IManaTrigger;
 import vazkii.botania.api.state.BotaniaStateProps;
-import vazkii.botania.common.block.BlockMod;
+import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.TileSimpleInventory;
 import vazkii.botania.common.block.tile.mana.TilePrism;
 import vazkii.botania.common.core.helper.InventoryHelper;
 
 import javax.annotation.Nonnull;
 
-public class BlockPrism extends BlockMod implements IManaTrigger, IManaCollisionGhost {
+public class BlockPrism extends BlockModWaterloggable implements IManaTrigger, IManaCollisionGhost {
 	private static final VoxelShape SHAPE = makeCuboidShape(4, 0, 4, 12, 16, 12);
 
 	public BlockPrism(Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState()
+		setDefaultState(getDefaultState()
 				.with(BlockStateProperties.POWERED, false)
 				.with(BotaniaStateProps.HAS_LENS, false));
 	}
@@ -55,6 +54,7 @@ public class BlockPrism extends BlockMod implements IManaTrigger, IManaCollision
 
 	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		super.fillStateContainer(builder);
 		builder.add(BlockStateProperties.POWERED, BotaniaStateProps.HAS_LENS);
 	}
 

--- a/src/main/java/vazkii/botania/common/block/mana/BlockPump.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockPump.java
@@ -20,32 +20,31 @@ import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
-
-import vazkii.botania.common.block.BlockMod;
+import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.mana.TilePump;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
-public class BlockPump extends BlockMod {
+public class BlockPump extends BlockModWaterloggable {
 
 	private static final VoxelShape X_SHAPE = makeCuboidShape(0, 0, 4, 16, 8, 12);
 	private static final VoxelShape Z_SHAPE = makeCuboidShape(4, 0, 0, 12, 8, 16);
 
 	public BlockPump(Properties builder) {
 		super(builder);
-		setDefaultState(getStateContainer().getBaseState().with(BlockStateProperties.HORIZONTAL_FACING, Direction.SOUTH));
+		setDefaultState(getDefaultState().with(BlockStateProperties.HORIZONTAL_FACING, Direction.SOUTH));
 	}
 
 	@Override
 	protected void fillStateContainer(StateContainer.Builder<Block, BlockState> builder) {
+		super.fillStateContainer(builder);
 		builder.add(BlockStateProperties.HORIZONTAL_FACING);
 	}
 
-	@Nullable
+	@Nonnull
 	@Override
 	public BlockState getStateForPlacement(BlockItemUseContext context) {
-		return getDefaultState().with(BlockStateProperties.HORIZONTAL_FACING, context.getPlacementHorizontalFacing().getOpposite());
+		return super.getStateForPlacement(context).with(BlockStateProperties.HORIZONTAL_FACING, context.getPlacementHorizontalFacing().getOpposite());
 	}
 
 	@Nonnull

--- a/src/main/java/vazkii/botania/common/block/mana/BlockPump.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockPump.java
@@ -20,6 +20,7 @@ import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
+
 import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.mana.TilePump;
 

--- a/src/main/java/vazkii/botania/common/block/mana/BlockRuneAltar.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockRuneAltar.java
@@ -24,6 +24,7 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.util.math.shapes.VoxelShapes;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
+
 import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.api.wand.IWandable;
 import vazkii.botania.common.block.BlockModWaterloggable;

--- a/src/main/java/vazkii/botania/common/block/mana/BlockRuneAltar.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockRuneAltar.java
@@ -24,17 +24,16 @@ import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.util.math.shapes.VoxelShapes;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
-
 import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.api.wand.IWandable;
-import vazkii.botania.common.block.BlockMod;
+import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.TileRuneAltar;
 import vazkii.botania.common.block.tile.TileSimpleInventory;
 import vazkii.botania.common.core.helper.InventoryHelper;
 
 import javax.annotation.Nonnull;
 
-public class BlockRuneAltar extends BlockMod implements IWandable {
+public class BlockRuneAltar extends BlockModWaterloggable implements IWandable {
 
 	private static final VoxelShape TOP = Block.makeCuboidShape(0, 6, 0, 16, 12, 16);
 	private static final VoxelShape BOTTOM = Block.makeCuboidShape(2, 0, 2, 14, 6, 14);

--- a/src/main/java/vazkii/botania/common/block/mana/BlockSpawnerClaw.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockSpawnerClaw.java
@@ -18,6 +18,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
+
 import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.TileSpawnerClaw;
 

--- a/src/main/java/vazkii/botania/common/block/mana/BlockSpawnerClaw.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockSpawnerClaw.java
@@ -18,13 +18,12 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
-
-import vazkii.botania.common.block.BlockMod;
+import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.TileSpawnerClaw;
 
 import javax.annotation.Nonnull;
 
-public class BlockSpawnerClaw extends BlockMod {
+public class BlockSpawnerClaw extends BlockModWaterloggable {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(2, 0, 2, 14, 2, 14);
 

--- a/src/main/java/vazkii/botania/common/block/mana/BlockSpreader.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockSpreader.java
@@ -9,6 +9,7 @@
 package vazkii.botania.common.block.mana;
 
 import com.google.common.collect.ImmutableList;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
@@ -31,6 +32,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.items.ItemHandlerHelper;
+
 import vazkii.botania.api.mana.ILens;
 import vazkii.botania.api.wand.IWandHUD;
 import vazkii.botania.api.wand.IWandable;
@@ -43,6 +45,7 @@ import vazkii.botania.common.item.ModItems;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import java.util.List;
 
 public class BlockSpreader extends BlockModWaterloggable implements IWandable, IWandHUD, IWireframeAABBProvider {

--- a/src/main/java/vazkii/botania/common/block/mana/BlockSpreader.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockSpreader.java
@@ -9,7 +9,6 @@
 package vazkii.botania.common.block.mana;
 
 import com.google.common.collect.ImmutableList;
-
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
@@ -32,12 +31,11 @@ import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.items.ItemHandlerHelper;
-
 import vazkii.botania.api.mana.ILens;
 import vazkii.botania.api.wand.IWandHUD;
 import vazkii.botania.api.wand.IWandable;
 import vazkii.botania.api.wand.IWireframeAABBProvider;
-import vazkii.botania.common.block.BlockMod;
+import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.mana.TileSpreader;
 import vazkii.botania.common.core.helper.ColorHelper;
 import vazkii.botania.common.core.helper.InventoryHelper;
@@ -45,10 +43,9 @@ import vazkii.botania.common.item.ModItems;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import java.util.List;
 
-public class BlockSpreader extends BlockMod implements IWandable, IWandHUD, IWireframeAABBProvider {
+public class BlockSpreader extends BlockModWaterloggable implements IWandable, IWandHUD, IWireframeAABBProvider {
 	private static final VoxelShape RENDER_SHAPE = makeCuboidShape(1, 1, 1, 15, 15, 15);
 
 	public enum Variant {

--- a/src/main/java/vazkii/botania/common/block/mana/BlockTerraPlate.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockTerraPlate.java
@@ -23,6 +23,7 @@ import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
+
 import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.TileTerraPlate;
 import vazkii.botania.common.item.ModItems;

--- a/src/main/java/vazkii/botania/common/block/mana/BlockTerraPlate.java
+++ b/src/main/java/vazkii/botania/common/block/mana/BlockTerraPlate.java
@@ -23,14 +23,13 @@ import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
 import net.minecraft.world.IBlockReader;
 import net.minecraft.world.World;
-
-import vazkii.botania.common.block.BlockMod;
+import vazkii.botania.common.block.BlockModWaterloggable;
 import vazkii.botania.common.block.tile.TileTerraPlate;
 import vazkii.botania.common.item.ModItems;
 
 import javax.annotation.Nonnull;
 
-public class BlockTerraPlate extends BlockMod {
+public class BlockTerraPlate extends BlockModWaterloggable {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(0, 0, 0, 16, 3, 16);
 

--- a/src/main/java/vazkii/botania/common/block/string/BlockRedStringComparator.java
+++ b/src/main/java/vazkii/botania/common/block/string/BlockRedStringComparator.java
@@ -25,7 +25,7 @@ public class BlockRedStringComparator extends BlockRedString {
 
 	public BlockRedStringComparator(Block.Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.FACING, Direction.DOWN));
+		setDefaultState(getDefaultState().with(BlockStateProperties.FACING, Direction.DOWN));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/string/BlockRedStringContainer.java
+++ b/src/main/java/vazkii/botania/common/block/string/BlockRedStringContainer.java
@@ -23,7 +23,7 @@ public class BlockRedStringContainer extends BlockRedString {
 
 	public BlockRedStringContainer(Block.Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.FACING, Direction.DOWN));
+		setDefaultState(getDefaultState().with(BlockStateProperties.FACING, Direction.DOWN));
 	}
 
 	@Nonnull

--- a/src/main/java/vazkii/botania/common/block/string/BlockRedStringDispenser.java
+++ b/src/main/java/vazkii/botania/common/block/string/BlockRedStringDispenser.java
@@ -26,7 +26,7 @@ public class BlockRedStringDispenser extends BlockRedString {
 
 	public BlockRedStringDispenser(Block.Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.FACING, Direction.DOWN).with(BlockStateProperties.POWERED, false));
+		setDefaultState(getDefaultState().with(BlockStateProperties.FACING, Direction.DOWN).with(BlockStateProperties.POWERED, false));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/string/BlockRedStringFertilizer.java
+++ b/src/main/java/vazkii/botania/common/block/string/BlockRedStringFertilizer.java
@@ -29,7 +29,7 @@ public class BlockRedStringFertilizer extends BlockRedString implements IGrowabl
 
 	public BlockRedStringFertilizer(Block.Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.FACING, Direction.DOWN));
+		setDefaultState(getDefaultState().with(BlockStateProperties.FACING, Direction.DOWN));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/string/BlockRedStringInterceptor.java
+++ b/src/main/java/vazkii/botania/common/block/string/BlockRedStringInterceptor.java
@@ -34,7 +34,7 @@ public class BlockRedStringInterceptor extends BlockRedString {
 
 	public BlockRedStringInterceptor(Block.Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.FACING, Direction.DOWN).with(BlockStateProperties.POWERED, false));
+		setDefaultState(getDefaultState().with(BlockStateProperties.FACING, Direction.DOWN).with(BlockStateProperties.POWERED, false));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/block/string/BlockRedStringRelay.java
+++ b/src/main/java/vazkii/botania/common/block/string/BlockRedStringRelay.java
@@ -23,7 +23,7 @@ public class BlockRedStringRelay extends BlockRedString {
 
 	public BlockRedStringRelay(Block.Properties builder) {
 		super(builder);
-		setDefaultState(stateContainer.getBaseState().with(BlockStateProperties.FACING, Direction.DOWN));
+		setDefaultState(getDefaultState().with(BlockStateProperties.FACING, Direction.DOWN));
 	}
 
 	@Nonnull

--- a/src/main/java/vazkii/botania/common/block/tile/TileIncensePlate.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileIncensePlate.java
@@ -11,15 +11,16 @@ package vazkii.botania.common.block.tile;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.particles.ParticleTypes;
 import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.Effects;
+import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tileentity.ITickableTileEntity;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraftforge.registries.ObjectHolder;
-
 import vazkii.botania.api.brew.Brew;
 import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.client.fx.WispParticleData;
@@ -30,8 +31,8 @@ import vazkii.botania.common.lib.LibBlockNames;
 import vazkii.botania.common.lib.LibMisc;
 
 import javax.annotation.Nonnull;
-
 import java.util.List;
+import java.util.Random;
 
 public class TileIncensePlate extends TileSimpleInventory implements ITickableTileEntity {
 	@ObjectHolder(LibMisc.MOD_ID + ":" + LibBlockNames.INCENSE_PLATE) public static TileEntityType<TileIncensePlate> TYPE;
@@ -51,6 +52,12 @@ public class TileIncensePlate extends TileSimpleInventory implements ITickableTi
 	public void tick() {
 		ItemStack stack = itemHandler.getStackInSlot(0);
 		if (!stack.isEmpty() && burning) {
+			if(getBlockState().get(BlockStateProperties.WATERLOGGED)) {
+				burning = false;
+				timeLeft = 0;
+				spawnSmokeParticles();
+			}
+
 			Brew brew = ((ItemIncenseStick) ModItems.incenseStick).getBrew(stack);
 			EffectInstance effect = brew.getPotionEffects(stack).get(0);
 			if (timeLeft > 0) {
@@ -106,9 +113,26 @@ public class TileIncensePlate extends TileSimpleInventory implements ITickableTi
 		}
 	}
 
+	private void spawnSmokeParticles() {
+		Random random = world.getRandom();
+		world.addParticle(ParticleTypes.SMOKE,
+				pos.getX() + 0.25D + random.nextDouble() / 2.0D * (random.nextBoolean() ? 1 : -1),
+				pos.getY() + 0.4D,
+				pos.getZ() + 0.25D + random.nextDouble() / 2.0D * (random.nextBoolean() ? 1 : -1),
+				0.0D,
+				0.005D,
+				0.0D);
+
+	}
+
 	public void ignite() {
 		ItemStack stack = itemHandler.getStackInSlot(0);
 		if (stack.isEmpty() || burning) {
+			return;
+		}
+
+		if(getBlockState().get(BlockStateProperties.WATERLOGGED)) {
+			spawnSmokeParticles();
 			return;
 		}
 

--- a/src/main/java/vazkii/botania/common/block/tile/TileIncensePlate.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileIncensePlate.java
@@ -21,6 +21,7 @@ import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraftforge.registries.ObjectHolder;
+
 import vazkii.botania.api.brew.Brew;
 import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.client.fx.WispParticleData;
@@ -31,6 +32,7 @@ import vazkii.botania.common.lib.LibBlockNames;
 import vazkii.botania.common.lib.LibMisc;
 
 import javax.annotation.Nonnull;
+
 import java.util.List;
 import java.util.Random;
 
@@ -52,9 +54,8 @@ public class TileIncensePlate extends TileSimpleInventory implements ITickableTi
 	public void tick() {
 		ItemStack stack = itemHandler.getStackInSlot(0);
 		if (!stack.isEmpty() && burning) {
-			if(getBlockState().get(BlockStateProperties.WATERLOGGED)) {
-				burning = false;
-				timeLeft = 0;
+			if (getBlockState().get(BlockStateProperties.WATERLOGGED) && timeLeft > 1) {
+				timeLeft = 1;
 				spawnSmokeParticles();
 			}
 
@@ -113,25 +114,28 @@ public class TileIncensePlate extends TileSimpleInventory implements ITickableTi
 		}
 	}
 
-	private void spawnSmokeParticles() {
+	public void spawnSmokeParticles() {
 		Random random = world.getRandom();
-		world.addParticle(ParticleTypes.SMOKE,
-				pos.getX() + 0.25D + random.nextDouble() / 2.0D * (random.nextBoolean() ? 1 : -1),
-				pos.getY() + 0.4D,
-				pos.getZ() + 0.25D + random.nextDouble() / 2.0D * (random.nextBoolean() ? 1 : -1),
-				0.0D,
-				0.005D,
-				0.0D);
-
+		for (int i = 0; i < 4; ++i) {
+			world.addParticle(ParticleTypes.SMOKE,
+					pos.getX() + 0.5 + random.nextDouble() / 2.0 * (random.nextBoolean() ? 1 : -1),
+					pos.getY() + 1,
+					pos.getZ() + 0.5 + random.nextDouble() / 2.0 * (random.nextBoolean() ? 1 : -1),
+					0.0D,
+					0.05D,
+					0.0D);
+		}
+		world.playSound(null, pos, SoundEvents.ENTITY_GENERIC_EXTINGUISH_FIRE, SoundCategory.BLOCKS, 0.1F, 1.0F);
 	}
 
 	public void ignite() {
 		ItemStack stack = itemHandler.getStackInSlot(0);
+
 		if (stack.isEmpty() || burning) {
 			return;
 		}
 
-		if(getBlockState().get(BlockStateProperties.WATERLOGGED)) {
+		if (getBlockState().get(BlockStateProperties.WATERLOGGED)) {
 			spawnSmokeParticles();
 			return;
 		}


### PR DESCRIPTION
Currently this works for all non-full blocks, but that may change.

- [ ] Petal Apothecary and variants
- [x] Animated Torch
- [x] Livingwood Avatar
- [ ] Manatide Bellows
- [x] Botanical Brewery
- [x] Cocoon of Caprice
- [x] Mana Distributor
- [x] All Floating Flowers
- [x] All Drums
- [x] Eye of the Ancients
- [x] Hovering Hourglass
- [x] Incense Plate (with special interaction)
- [x] Luminizer Launcher
- [x] Luminizer and variants
- [x] Mana Pool
- [x] Mana Prism
- [x] Mana Pump
- [x] Mana/Natura/Gaia Pylons
- [x] Runic Altar
- [x] Spark Tinkerer
- [x] Life Imbuer
- [x] Mana Spreader and variants
- [x] Starfield Creator
- [x] Terrestrial Agglomeration Plate
- [x] Teru Teru Bozu
- [x] Tiny Planet
- [x] Tiny Potato
- [x] Corporea Index
- [x] Corporea Crystal Cube

Unlit incense sticks also drop from broken incense plates, and all blocks with blockstate properties now use ```getDefaultState()``` instead of ```stateContainer.getBaseState()``` in their constructors when setting the default state, which are functionally equivalent for the non-waterloggable blocks.