### PR TITLE
Support mod shears

### DIFF
--- a/src/generated/resources/data/botania/loot_tables/blocks/black_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/black_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/botania/loot_tables/blocks/blue_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/blue_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/botania/loot_tables/blocks/brown_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/brown_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/botania/loot_tables/blocks/cyan_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/cyan_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/botania/loot_tables/blocks/gray_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/gray_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/botania/loot_tables/blocks/green_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/green_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/botania/loot_tables/blocks/light_blue_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/light_blue_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/botania/loot_tables/blocks/light_gray_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/light_gray_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/botania/loot_tables/blocks/lime_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/lime_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/botania/loot_tables/blocks/magenta_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/magenta_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/botania/loot_tables/blocks/orange_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/orange_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/botania/loot_tables/blocks/pink_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/pink_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/botania/loot_tables/blocks/purple_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/purple_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/botania/loot_tables/blocks/red_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/red_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/botania/loot_tables/blocks/white_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/white_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/botania/loot_tables/blocks/yellow_double_flower.json
+++ b/src/generated/resources/data/botania/loot_tables/blocks/yellow_double_flower.json
@@ -18,7 +18,7 @@
             {
               "condition": "minecraft:match_tool",
               "predicate": {
-                "item": "minecraft:shears"
+                "tag": "forge:shears"
               }
             }
           ],

--- a/src/generated/resources/data/forge/tags/items/shears.json
+++ b/src/generated/resources/data/forge/tags/items/shears.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:shears",
+    "botania:elementium_shears",
+    "botania:manasteel_shears"
+  ]
+}

--- a/src/main/java/vazkii/botania/common/lib/ModTags.java
+++ b/src/main/java/vazkii/botania/common/lib/ModTags.java
@@ -58,6 +58,8 @@ public class ModTags {
 		public static final Tag<Item> MAGNET_RING_BLACKLIST = tag("magnet_ring_blacklist");
 		public static final Tag<Item> LOONIUM_BLACKLIST = tag("loonium_blacklist");
 
+		public static final Tag<Item> SHEARS = forgeTag("shears");
+
 		public static final Tag<Item> DISPOSABLE = tag("disposable");
 		public static final Tag<Item> SEMI_DISPOSABLE = tag("semi_disposable");
 

--- a/src/main/java/vazkii/botania/data/BlockLootProvider.java
+++ b/src/main/java/vazkii/botania/data/BlockLootProvider.java
@@ -23,7 +23,6 @@ import net.minecraft.data.DataGenerator;
 import net.minecraft.data.DirectoryCache;
 import net.minecraft.data.IDataProvider;
 import net.minecraft.enchantment.Enchantments;
-import net.minecraft.item.Items;
 import net.minecraft.state.properties.DoubleBlockHalf;
 import net.minecraft.state.properties.SlabType;
 import net.minecraft.util.ResourceLocation;
@@ -60,6 +59,7 @@ import vazkii.botania.common.block.subtile.generating.SubTileSpectrolus;
 import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.lib.LibBlockNames;
 import vazkii.botania.common.lib.LibMisc;
+import vazkii.botania.common.lib.ModTags;
 
 import javax.annotation.Nonnull;
 
@@ -213,7 +213,7 @@ public class BlockLootProvider implements IDataProvider {
 	private static LootTable.Builder genDoubleFlower(Block b) {
 		LootEntry.Builder<?> entry = ItemLootEntry.builder(b)
 				.acceptCondition(BlockStateProperty.builder(b).func_227567_a_(StatePropertiesPredicate.Builder.create().exactMatch(DoublePlantBlock.HALF, DoubleBlockHalf.LOWER)))
-				.acceptCondition(MatchTool.builder(ItemPredicate.Builder.create().item(Items.SHEARS)));
+				.acceptCondition(MatchTool.builder(ItemPredicate.Builder.create().tag(ModTags.Items.SHEARS)));
 		LootPool.Builder pool = LootPool.builder().name("main").rolls(ConstantRange.of(1)).addEntry(entry)
 				.acceptCondition(SurvivesExplosion.builder());
 		return LootTable.builder().addLootPool(pool);

--- a/src/main/java/vazkii/botania/data/ItemTagProvider.java
+++ b/src/main/java/vazkii/botania/data/ItemTagProvider.java
@@ -12,6 +12,7 @@ import net.minecraft.data.DataGenerator;
 import net.minecraft.data.ItemTagsProvider;
 import net.minecraft.item.DyeColor;
 import net.minecraft.item.Item;
+import net.minecraft.item.Items;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.ItemTags;
 import net.minecraft.tags.Tag;
@@ -36,6 +37,8 @@ public class ItemTagProvider extends ItemTagsProvider {
 		this.copy(BlockTags.STAIRS, ItemTags.STAIRS);
 		this.copy(BlockTags.WALLS, ItemTags.WALLS);
 		this.copy(BlockTags.FENCES, ItemTags.FENCES);
+
+		this.getBuilder(ModTags.Items.SHEARS).add(Items.SHEARS).add(ModItems.elementiumShears).add(ModItems.manasteelShears);
 
 		this.copy(ModTags.Blocks.MUNDANE_FLOATING_FLOWERS, ModTags.Items.MUNDANE_FLOATING_FLOWERS);
 		this.copy(ModTags.Blocks.SPECIAL_FLOATING_FLOWERS, ModTags.Items.SPECIAL_FLOATING_FLOWERS);


### PR DESCRIPTION
This PR adds the support of shears of other mods with "forge:shears" tag & adds additionally manasteel and elementium shears to loot tables of double flowers