### PR TITLE
Update zh_cn.json

### DIFF
--- a/src/main/resources/assets/botania/lang/zh_cn.json
+++ b/src/main/resources/assets/botania/lang/zh_cn.json
@@ -902,7 +902,7 @@
   "block.botania.shimmerwood_planks": "微光木板",
   "block.botania.shimmerwood_planks_slab": "微光木板台阶",
   "block.botania.shimmerwood_planks_stairs": "微光木板楼梯",
-  "block.botania.avatar": "活木枝化身",
+  "block.botania.avatar": "活木化身",
   "block.botania.dry_grass": "干草地",
   "block.botania.golden_grass": "黄金草地",
   "block.botania.vivid_grass": "鲜草草地",


### PR DESCRIPTION
Fixed an error: "livingwood avatar" should not be translated as "livingwood twig avatar".