### PR TITLE
Add alternative constructor to accept suppliers for EffectInstances

### DIFF
--- a/src/main/java/vazkii/botania/api/brew/Brew.java
+++ b/src/main/java/vazkii/botania/api/brew/Brew.java
@@ -12,17 +12,19 @@ import com.google.common.collect.ImmutableList;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.EffectInstance;
+import net.minecraft.potion.PotionUtils;
 import net.minecraftforge.registries.ForgeRegistryEntry;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * The class for a Brew definition, each one is a singleton.
  */
 public class Brew extends ForgeRegistryEntry<Brew> {
-	private final int color;
+	private final Supplier<Integer> color;
 	private final int cost;
-	private final List<EffectInstance> effects;
+	private final Supplier<List<EffectInstance>> effects;
 	private boolean canInfuseBloodPendant = true;
 	private boolean canInfuseIncense = true;
 
@@ -35,9 +37,20 @@ public class Brew extends ForgeRegistryEntry<Brew> {
 	 * @param effects A list of effects to apply to the player when they drink it.
 	 */
 	public Brew(int color, int cost, EffectInstance... effects) {
-		this.color = color;
+		this.color = () -> color;
 		this.cost = cost;
-		this.effects = ImmutableList.copyOf(effects);
+		this.effects = () -> ImmutableList.copyOf(effects);
+	}
+
+	/**
+	 * Alternative constructor for brews that allows for potion effects from mods that use DeferredRegisters and gets the potion color using PotionUtils
+	 * @param cost    The cost, in Mana for this brew.
+	 * @param effects A supplier that supplies a list of effects to apply to the player when they drink it.
+	 */
+	public Brew(int cost, Supplier<List<EffectInstance>> effects) {
+		this.color = () -> PotionUtils.getPotionColorFromEffectList(effects.get());
+		this.cost = cost;
+		this.effects = effects;
 	}
 
 	/**
@@ -84,7 +97,7 @@ public class Brew extends ForgeRegistryEntry<Brew> {
 	 * Alfglass Flask at all times.
 	 */
 	public int getColor(ItemStack stack) {
-		return color;
+		return color.get();
 	}
 
 	/**
@@ -107,7 +120,7 @@ public class Brew extends ForgeRegistryEntry<Brew> {
 	 * Vial or an Alfglass Flask at all times.
 	 */
 	public List<EffectInstance> getPotionEffects(ItemStack stack) {
-		return effects;
+		return effects.get();
 	}
 
 }

--- a/src/main/java/vazkii/botania/api/brew/Brew.java
+++ b/src/main/java/vazkii/botania/api/brew/Brew.java
@@ -49,7 +49,7 @@ public class Brew extends ForgeRegistryEntry<Brew> {
 	public Brew(int cost, Supplier<List<EffectInstance>> effects) {
 		this.color = () -> PotionUtils.getPotionColorFromEffectList(effects.get());
 		this.cost = cost;
-		this.effects = () -> ImmutableList.copyOf(effects.get());
+		this.effects = effects;
 	}
 
 	/**

--- a/src/main/java/vazkii/botania/api/brew/Brew.java
+++ b/src/main/java/vazkii/botania/api/brew/Brew.java
@@ -49,7 +49,7 @@ public class Brew extends ForgeRegistryEntry<Brew> {
 	public Brew(int cost, Supplier<List<EffectInstance>> effects) {
 		this.color = () -> PotionUtils.getPotionColorFromEffectList(effects.get());
 		this.cost = cost;
-		this.effects = effects;
+		this.effects = () -> ImmutableList.copyOf(effects.get());
 	}
 
 	/**

--- a/src/main/java/vazkii/botania/api/brew/Brew.java
+++ b/src/main/java/vazkii/botania/api/brew/Brew.java
@@ -39,7 +39,8 @@ public class Brew extends ForgeRegistryEntry<Brew> {
 	public Brew(int color, int cost, EffectInstance... effects) {
 		this.color = () -> color;
 		this.cost = cost;
-		this.effects = () -> ImmutableList.copyOf(effects);
+		List<EffectInstance> savedEffects = ImmutableList.copyOf(effects);
+		this.effects = () -> savedEffects;
 	}
 
 	/**

--- a/src/main/java/vazkii/botania/api/brew/Brew.java
+++ b/src/main/java/vazkii/botania/api/brew/Brew.java
@@ -43,7 +43,6 @@ public class Brew extends ForgeRegistryEntry<Brew> {
 	}
 
 	/**
-	 * Alternative constructor for brews that allows for potion effects from mods that use DeferredRegisters and gets the potion color using PotionUtils
 	 * @param cost    The cost, in Mana for this brew.
 	 * @param effects A supplier that supplies a list of effects to apply to the player when they drink it.
 	 */


### PR DESCRIPTION
The current Brew class is unable to create Brews using Effects that are registered through DeferredRegisters. By adding a supplier and modifying various fields to only use the EffectaInstance when needed through suppliers, Minecraft will not crash when trying to register a Brew using effects from other mods. 

I ran into this issue when I was trying to add brews when Botania is installed for my mod and am currently using a workaround to bypass the crash.
https://github.com/MinerArcana/Astral/compare/feature/botania_compat#diff-f4145c9694231af724e6a15feceb81e8