### PR TITLE
Overhaul Rafflowsia to scale with flower variety

### DIFF
--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileRafflowsia.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileRafflowsia.java
@@ -8,10 +8,12 @@
  */
 package vazkii.botania.common.block.subtile.generating;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.ListNBT;
 import net.minecraft.nbt.StringNBT;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.registry.Registry;
 import net.minecraftforge.common.util.Constants;
@@ -33,7 +35,7 @@ public class SubTileRafflowsia extends TileEntityGeneratingFlower {
 	public static final String TAG_STREAK_LENGTH = "streakLength";
 
 	@Nullable
-	private List<String> lastFlowers = new LinkedList<>();
+	private List<Block> lastFlowers = new LinkedList<>();
 	private int streakLength = -1;
 	private int lastFlowerCount = 0;
 
@@ -66,11 +68,11 @@ public class SubTileRafflowsia extends TileEntityGeneratingFlower {
 	 * 
 	 * @return the last time the flower showed up in history.
 	 */
-	private int processFlower(String flower) {
-		for (ListIterator<String> it = lastFlowers.listIterator(); it.hasNext();) {
+	private int processFlower(Block flower) {
+		for (ListIterator<Block> it = lastFlowers.listIterator(); it.hasNext();) {
 			int index = it.nextIndex();
-			String streakFlower = it.next();
-			if (streakFlower.equals(flower)) {
+			Block streakFlower = it.next();
+			if (streakFlower == flower) {
 				it.remove();
 				lastFlowers.add(0, streakFlower);
 				return index;
@@ -97,7 +99,7 @@ public class SubTileRafflowsia extends TileEntityGeneratingFlower {
 
 						BlockState state = getWorld().getBlockState(pos);
 						if (state.isIn(ModTags.Blocks.SPECIAL_FLOWERS) && state.getBlock() != ModSubtiles.rafflowsia) {
-							streakLength = Math.min(streakLength + 1, processFlower(Registry.BLOCK.getKey(state.getBlock()).toString()));
+							streakLength = Math.min(streakLength + 1, processFlower(state.getBlock()));
 
 							getWorld().destroyBlock(pos, false);
 							addMana(getValueForStreak(streakLength));
@@ -115,8 +117,8 @@ public class SubTileRafflowsia extends TileEntityGeneratingFlower {
 		super.writeToPacketNBT(cmp);
 
 		ListNBT flowerList = new ListNBT();
-		for (String flower : lastFlowers) {
-			flowerList.add(StringNBT.valueOf(flower));
+		for (Block flower : lastFlowers) {
+			flowerList.add(StringNBT.valueOf(flower.getRegistryName().toString()));
 		}
 		cmp.put(TAG_LAST_FLOWERS, flowerList);
 		cmp.putInt(TAG_LAST_FLOWER_TIMES, lastFlowerCount);
@@ -130,7 +132,7 @@ public class SubTileRafflowsia extends TileEntityGeneratingFlower {
 		lastFlowers.clear();
 		ListNBT flowerList = cmp.getList(TAG_LAST_FLOWERS, Constants.NBT.TAG_STRING);
 		for (int i = 0; i < flowerList.size(); i++) {
-			lastFlowers.add(flowerList.getString(i));
+			lastFlowers.add(Registry.BLOCK.getOrDefault(ResourceLocation.tryCreate(flowerList.getString(i))));
 		}
 		lastFlowerCount = cmp.getInt(TAG_LAST_FLOWER_TIMES);
 		streakLength = cmp.getInt(TAG_STREAK_LENGTH);

--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileRafflowsia.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileRafflowsia.java
@@ -38,6 +38,11 @@ public class SubTileRafflowsia extends TileEntityGeneratingFlower {
 	private int lastFlowerCount = 0;
 
 	private static final int RANGE = 5;
+
+	// Below table generated from the function:
+	// f(x) = round(-401.45 + 7.03436 x + 16.0932 x^2 + 7.64878 * 1.25226^x, 100),
+	// where x is the number of unique flowers in the streak.
+	// Function created from a best-fit approximation on the sorted raw mana costs of production of each flower.
 	private static final int[] STREAK_OUTPUTS = { 300, 1100, 1900, 2700, 3500, 4400, 5300, 6300, 7300, 8300, 9400, 10500, 11600, 12800, 14000, 15200, 16500, 17900, 19200, 20700, 22200, 23800, 25400, 27100, 29000, 30900, 33000, 35200, 37700, 40300, 43200, 46500, 50200, 54300, 59100, 64600, 71100, 78600, 87600, 98400 };
 
 	public SubTileRafflowsia() {

--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileRafflowsia.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileRafflowsia.java
@@ -8,12 +8,13 @@
  */
 package vazkii.botania.common.block.subtile.generating;
 
-import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.nbt.CompoundNBT;
-import net.minecraft.util.ResourceLocation;
+import net.minecraft.nbt.ListNBT;
+import net.minecraft.nbt.StringNBT;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.registry.Registry;
+import net.minecraftforge.common.util.Constants;
 
 import vazkii.botania.api.subtile.RadiusDescriptor;
 import vazkii.botania.api.subtile.TileEntityGeneratingFlower;
@@ -22,18 +23,59 @@ import vazkii.botania.common.lib.ModTags;
 
 import javax.annotation.Nullable;
 
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+
 public class SubTileRafflowsia extends TileEntityGeneratingFlower {
-	public static final String TAG_LAST_FLOWER = "lastFlower";
+	public static final String TAG_LAST_FLOWERS = "lastFlowers";
 	public static final String TAG_LAST_FLOWER_TIMES = "lastFlowerTimes";
+	public static final String TAG_STREAK_LENGTH = "streakLength";
 
 	@Nullable
-	private Block lastFlower;
-	private int lastFlowerTimes;
+	private List<String> lastFlowers = new LinkedList<>();
+	private int streakLength = -1;
+	private int lastFlowerCount = 0;
 
 	private static final int RANGE = 5;
+	private static final int[] STREAK_OUTPUTS = { 300, 1100, 1900, 2700, 3500, 4400, 5300, 6300, 7300, 8300, 9400, 10500, 11600, 12800, 14000, 15200, 16500, 17900, 19200, 20700, 22200, 23800, 25400, 27100, 29000, 30900, 33000, 35200, 37700, 40300, 43200, 46500, 50200, 54300, 59100, 64600, 71100, 78600, 87600, 98400 };
 
 	public SubTileRafflowsia() {
 		super(ModSubtiles.RAFFLOWSIA);
+	}
+
+	private int getMaxStreak() {
+		return STREAK_OUTPUTS.length - 1;
+	}
+
+	private int getValueForStreak(int index) {
+		// special-case repeated first flowers
+		if (index != 0) {
+			lastFlowerCount = 0;
+		}
+		return STREAK_OUTPUTS[index] / ++lastFlowerCount;
+	}
+
+	/**
+	 * Processes a flower, placing it in the appropriate place in the history.
+	 * 
+	 * @return the last time the flower showed up in history.
+	 */
+	private int processFlower(String flower) {
+		for (ListIterator<String> it = lastFlowers.listIterator(); it.hasNext();) {
+			int index = it.nextIndex();
+			String streakFlower = it.next();
+			if (streakFlower.equals(flower)) {
+				it.remove();
+				lastFlowers.add(0, streakFlower);
+				return index;
+			}
+		}
+		lastFlowers.add(0, flower);
+		if (lastFlowers.size() >= getMaxStreak()) {
+			lastFlowers.remove(lastFlowers.size() - 1);
+		}
+		return getMaxStreak();
 	}
 
 	@Override
@@ -50,17 +92,10 @@ public class SubTileRafflowsia extends TileEntityGeneratingFlower {
 
 						BlockState state = getWorld().getBlockState(pos);
 						if (state.isIn(ModTags.Blocks.SPECIAL_FLOWERS) && state.getBlock() != ModSubtiles.rafflowsia) {
-							if (state.getBlock() == lastFlower) {
-								lastFlowerTimes++;
-							} else {
-								lastFlower = state.getBlock();
-								lastFlowerTimes = 1;
-							}
-
-							float mod = 1F / lastFlowerTimes;
+							streakLength = Math.min(streakLength + 1, processFlower(Registry.BLOCK.getKey(state.getBlock()).toString()));
 
 							getWorld().destroyBlock(pos, false);
-							addMana((int) (mana * mod));
+							addMana(getValueForStreak(streakLength));
 							sync();
 							return;
 						}
@@ -74,21 +109,26 @@ public class SubTileRafflowsia extends TileEntityGeneratingFlower {
 	public void writeToPacketNBT(CompoundNBT cmp) {
 		super.writeToPacketNBT(cmp);
 
-		if (lastFlower != null) {
-			cmp.putString(TAG_LAST_FLOWER, Registry.BLOCK.getKey(lastFlower).toString());
+		ListNBT flowerList = new ListNBT();
+		for (String flower : lastFlowers) {
+			flowerList.add(StringNBT.valueOf(flower));
 		}
-		cmp.putInt(TAG_LAST_FLOWER_TIMES, lastFlowerTimes);
+		cmp.put(TAG_LAST_FLOWERS, flowerList);
+		cmp.putInt(TAG_LAST_FLOWER_TIMES, lastFlowerCount);
+		cmp.putInt(TAG_STREAK_LENGTH, streakLength);
 	}
 
 	@Override
 	public void readFromPacketNBT(CompoundNBT cmp) {
 		super.readFromPacketNBT(cmp);
 
-		ResourceLocation id = ResourceLocation.tryCreate(cmp.getString(TAG_LAST_FLOWER));
-		if (id != null) {
-			lastFlower = Registry.BLOCK.getValue(id).orElse(null);
+		lastFlowers.clear();
+		ListNBT flowerList = cmp.getList(TAG_LAST_FLOWERS, Constants.NBT.TAG_STRING);
+		for (int i = 0; i < flowerList.size(); i++) {
+			lastFlowers.add(flowerList.getString(i));
 		}
-		lastFlowerTimes = cmp.getInt(TAG_LAST_FLOWER_TIMES);
+		lastFlowerCount = cmp.getInt(TAG_LAST_FLOWER_TIMES);
+		streakLength = cmp.getInt(TAG_STREAK_LENGTH);
 	}
 
 	@Override
@@ -103,7 +143,7 @@ public class SubTileRafflowsia extends TileEntityGeneratingFlower {
 
 	@Override
 	public int getMaxMana() {
-		return 9000;
+		return 100000;
 	}
 
 }

--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileRafflowsia.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileRafflowsia.java
@@ -118,7 +118,7 @@ public class SubTileRafflowsia extends TileEntityGeneratingFlower {
 
 		ListNBT flowerList = new ListNBT();
 		for (Block flower : lastFlowers) {
-			flowerList.add(StringNBT.valueOf(flower.getRegistryName().toString()));
+			flowerList.add(StringNBT.valueOf(Registry.BLOCK.getKey(flower).toString()));
 		}
 		cmp.put(TAG_LAST_FLOWERS, flowerList);
 		cmp.putInt(TAG_LAST_FLOWER_TIMES, lastFlowerCount);

--- a/src/main/java/vazkii/botania/data/BlockLootProvider.java
+++ b/src/main/java/vazkii/botania/data/BlockLootProvider.java
@@ -107,8 +107,8 @@ public class BlockLootProvider implements IDataProvider {
 		functionTable.put(ModSubtiles.hydroangeasFloating, b -> genCopyNbt(b, SubTileHydroangeas.TAG_COOLDOWN, TileEntityGeneratingFlower.TAG_PASSIVE_DECAY_TICKS));
 		functionTable.put(ModSubtiles.munchdew, b -> genCopyNbt(b, SubTileMunchdew.TAG_COOLDOWN));
 		functionTable.put(ModSubtiles.munchdewFloating, b -> genCopyNbt(b, SubTileMunchdew.TAG_COOLDOWN));
-		functionTable.put(ModSubtiles.rafflowsia, b -> genCopyNbt(b, SubTileRafflowsia.TAG_LAST_FLOWER, SubTileRafflowsia.TAG_LAST_FLOWER_TIMES));
-		functionTable.put(ModSubtiles.rafflowsiaFloating, b -> genCopyNbt(b, SubTileRafflowsia.TAG_LAST_FLOWER, SubTileRafflowsia.TAG_LAST_FLOWER_TIMES));
+		functionTable.put(ModSubtiles.rafflowsia, b -> genCopyNbt(b, SubTileRafflowsia.TAG_LAST_FLOWERS, SubTileRafflowsia.TAG_LAST_FLOWER_TIMES));
+		functionTable.put(ModSubtiles.rafflowsiaFloating, b -> genCopyNbt(b, SubTileRafflowsia.TAG_LAST_FLOWERS, SubTileRafflowsia.TAG_LAST_FLOWER_TIMES));
 		functionTable.put(ModSubtiles.spectrolus, b -> genCopyNbt(b, SubTileSpectrolus.TAG_NEXT_COLOR));
 		functionTable.put(ModSubtiles.spectrolusFloating, b -> genCopyNbt(b, SubTileSpectrolus.TAG_NEXT_COLOR));
 		functionTable.put(ModSubtiles.thermalily, b -> genCopyNbt(b, SubTileHydroangeas.TAG_COOLDOWN));

--- a/src/main/resources/assets/botania/lang/en_us.json
+++ b/src/main/resources/assets/botania/lang/en_us.json
@@ -2188,7 +2188,7 @@
 
   "botania.entry.rafflowsia": "Rafflowsia",
   "botania.tagline.rafflowsia": "Mana from flowers",
-  "botania.page.rafflowsia0": "The $(item)Rafflowsia$(0) functions similarly to a $(l:generating_flowers/kekimurus)$(item)Kekimurus$(0)$(/l), but eats $(item)man-made flowers$(0) in the $(l:basics/apothecary)$(item)Petal Apothecary$(0)$(/l) instead. It'll consume any nearby placed flowers and synthesize $(thing)Mana$(0) from them.$(p)However, feeding it the same flower several times in a row yields diminishing returns.",
+  "botania.page.rafflowsia0": "The $(item)Rafflowsia$(0) functions similarly to a $(l:generating_flowers/kekimurus)$(item)Kekimurus$(0)$(/l), but eats $(item)man-made flowers$(0) in the $(l:basics/apothecary)$(item)Petal Apothecary$(0)$(/l) instead. It'll consume any nearby placed flowers and synthesize $(thing)Mana$(0) from them.$(p)While feeding it the same flower several times in a row yields diminishing returns, feeding it a large variety of them can yield ludicrous quantities of $(thing)Mana$(0).",
   "botania.page.rafflowsia1": "$(o)A New Dawn, you could say$().",
 
   "botania.entry.dandelifeon": "Dandelifeon",


### PR DESCRIPTION
Single-flower repetition is nerfed _heavily_, but flower will now output up to 100k per flower for a streak of length 40.



You want to automate this? Good luck.