### PR TITLE
Allow paintslinger lens to dye sparks

### DIFF
--- a/src/main/java/vazkii/botania/common/entity/EntityCorporeaSpark.java
+++ b/src/main/java/vazkii/botania/common/entity/EntityCorporeaSpark.java
@@ -261,12 +261,6 @@ public class EntityCorporeaSpark extends EntitySparkBase implements ICorporeaSpa
 					if (!world.isRemote) {
 						setNetwork(color);
 
-						if (isMaster()) {
-							restartNetwork();
-						} else {
-							findNetwork();
-						}
-
 						stack.shrink(1);
 					}
 
@@ -281,6 +275,21 @@ public class EntityCorporeaSpark extends EntitySparkBase implements ICorporeaSpa
 		}
 
 		return ActionResultType.PASS;
+	}
+
+	@Override
+	public void setNetwork(DyeColor color) {
+		if (color == getNetwork()) {
+			return;
+		}
+
+		super.setNetwork(color);
+
+		if (isMaster()) {
+			restartNetwork();
+		} else {
+			findNetwork();
+		}
 	}
 
 	@Nonnull

--- a/src/main/java/vazkii/botania/common/entity/ModEntities.java
+++ b/src/main/java/vazkii/botania/common/entity/ModEntities.java
@@ -58,7 +58,7 @@ public final class ModEntities {
 			.setShouldReceiveVelocityUpdates(false)
 			.build("");
 	public static final EntityType<EntitySpark> SPARK = EntityType.Builder.<EntitySpark>create(EntitySpark::new, EntityClassification.MISC)
-			.size(0.1F, 0.5F)
+			.size(0.2F, 0.5F)
 			.immuneToFire()
 			.setTrackingRange(64)
 			.setUpdateInterval(10)
@@ -83,7 +83,7 @@ public final class ModEntities {
 			.setShouldReceiveVelocityUpdates(true)
 			.build("");
 	public static final EntityType<EntityCorporeaSpark> CORPOREA_SPARK = EntityType.Builder.<EntityCorporeaSpark>create(EntityCorporeaSpark::new, EntityClassification.MISC)
-			.size(0.1F, 0.5F)
+			.size(0.2F, 0.5F)
 			.immuneToFire()
 			.setTrackingRange(64)
 			.setUpdateInterval(40)

--- a/src/main/java/vazkii/botania/common/item/ItemCorporeaSpark.java
+++ b/src/main/java/vazkii/botania/common/item/ItemCorporeaSpark.java
@@ -54,7 +54,7 @@ public class ItemCorporeaSpark extends Item {
 				if (this == ModItems.corporeaSparkMaster) {
 					spark.setMaster(true);
 				}
-				spark.setPosition(pos.getX() + 0.5, pos.getY() + 1.5, pos.getZ() + 0.5);
+				spark.setPosition(pos.getX() + 0.5, pos.getY() + 1.25, pos.getZ() + 0.5);
 				world.addEntity(spark);
 			}
 			return ActionResultType.SUCCESS;

--- a/src/main/java/vazkii/botania/common/item/ItemSpark.java
+++ b/src/main/java/vazkii/botania/common/item/ItemSpark.java
@@ -41,7 +41,7 @@ public class ItemSpark extends Item implements IManaGivingItem {
 				if (!world.isRemote) {
 					stack.shrink(1);
 					EntitySpark spark = new EntitySpark(world);
-					spark.setPosition(pos.getX() + 0.5, pos.getY() + 1.5, pos.getZ() + 0.5);
+					spark.setPosition(pos.getX() + 0.5, pos.getY() + 1.25, pos.getZ() + 0.5);
 					world.addEntity(spark);
 					attach.attachSpark(spark);
 				}


### PR DESCRIPTION
Currently checks against `EntitySparkBase` because `ISpark` and `ICorporeaSpark`, despite their names, are disjoint

when testing i noticed that horizontally-fired bursts are at "eye-level" with the bottoms of sparks, so if you'd like to nudge those downward for reliable collisions, i can do that

![diagram of what i mean by above](https://user-images.githubusercontent.com/20421383/89688141-32c3b680-d8c7-11ea-9d39-53d04150e141.png)