### PR TITLE
Improve TNT ethics, fix world-loading deadlock.

### DIFF
--- a/src/main/java/vazkii/botania/common/Botania.java
+++ b/src/main/java/vazkii/botania/common/Botania.java
@@ -66,6 +66,7 @@ import vazkii.botania.common.block.string.BlockRedStringInterceptor;
 import vazkii.botania.common.block.subtile.functional.SubTileDaffomill;
 import vazkii.botania.common.block.subtile.functional.SubTileLoonuim;
 import vazkii.botania.common.block.subtile.functional.SubTileVinculotus;
+import vazkii.botania.common.block.subtile.generating.SubTileEntropinnyum;
 import vazkii.botania.common.block.subtile.generating.SubTileNarslimmus;
 import vazkii.botania.common.block.tile.ModTiles;
 import vazkii.botania.common.block.tile.TileAlfPortal;
@@ -178,6 +179,7 @@ public class Botania {
 		forgeBus.addListener(PotionEmptiness::onSpawn);
 		forgeBus.addListener(PotionSoulCross::onEntityKill);
 		forgeBus.addListener(SubTileNarslimmus::onSpawn);
+		forgeBus.addListener(SubTileEntropinnyum::onEntityJoin);
 		forgeBus.addListener(SubTileDaffomill::onItemTrack);
 		forgeBus.addListener(SubTileVinculotus::onEndermanTeleport);
 		forgeBus.addListener(EventPriority.LOWEST, SubTileLoonuim::onDrops);

--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEntropinnyum.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEntropinnyum.java
@@ -18,7 +18,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
-import net.minecraftforge.common.MinecraftForge;
+import net.minecraft.world.World;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 
 import vazkii.botania.api.subtile.RadiusDescriptor;
@@ -34,23 +34,20 @@ public class SubTileEntropinnyum extends TileEntityGeneratingFlower {
 	private static final int EXPLODE_EFFECT_EVENT = 0;
 	private static final int ANGRY_EFFECT_EVENT = 1;
 
-	static {
-		MinecraftForge.EVENT_BUS.addListener(SubTileEntropinnyum::onEntityJoin);
-	}
-
 	public SubTileEntropinnyum() {
 		super(ModSubtiles.ENTROPINNYUM);
 	}
 
-	private static void onEntityJoin(EntityJoinWorldEvent evt) {
-		Entity e = evt.getEntity();
-		if (!evt.getWorld().isRemote && e instanceof TNTEntity && !e.getPersistentData().contains(TAG_UNETHICAL)) {
-			e.getPersistentData().putBoolean(TAG_UNETHICAL, isUnethical((TNTEntity) e));
+	public static void onEntityJoin(EntityJoinWorldEvent evt) {
+		if (!evt.getWorld().isRemote && evt.getEntity() instanceof TNTEntity && isUnethical(evt.getEntity())) {
+			evt.getEntity().getPersistentData().putBoolean(TAG_UNETHICAL, true);
 		}
 	}
 
-	private static boolean isUnethical(TNTEntity e) {
-		if (e.getFuse() != 80) return false;
+	private static boolean isUnethical(Entity e) {
+		if (!e.world.getChunkProvider().isChunkLoaded(e)) {
+			return false;
+		}
 
 		BlockPos center = e.getPosition();
 		int x = center.getX();

--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEntropinnyum.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEntropinnyum.java
@@ -34,18 +34,24 @@ public class SubTileEntropinnyum extends TileEntityGeneratingFlower {
 	private static final int EXPLODE_EFFECT_EVENT = 0;
 	private static final int ANGRY_EFFECT_EVENT = 1;
 
-	public SubTileEntropinnyum() {
-		super(ModSubtiles.ENTROPINNYUM);
-		MinecraftForge.EVENT_BUS.addListener(this::onEntityJoin);
+	static {
+		MinecraftForge.EVENT_BUS.addListener(SubTileEntropinnyum::onEntityJoin);
 	}
 
-	private void onEntityJoin(EntityJoinWorldEvent evt) {
-		if (!evt.getWorld().isRemote && evt.getEntity() instanceof TNTEntity && isUnethical(evt.getEntity())) {
-			evt.getEntity().getPersistentData().putBoolean(TAG_UNETHICAL, true);
+	public SubTileEntropinnyum() {
+		super(ModSubtiles.ENTROPINNYUM);
+	}
+
+	private static void onEntityJoin(EntityJoinWorldEvent evt) {
+		Entity e = evt.getEntity();
+		if (!evt.getWorld().isRemote && e instanceof TNTEntity && !e.getPersistentData().contains(TAG_UNETHICAL)) {
+			e.getPersistentData().putBoolean(TAG_UNETHICAL, isUnethical((TNTEntity) e));
 		}
 	}
 
-	private static boolean isUnethical(Entity e) {
+	private static boolean isUnethical(TNTEntity e) {
+		if (e.getFuse() != 80) return false;
+
 		BlockPos center = e.getPosition();
 		int x = center.getX();
 		int y = center.getY();

--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEntropinnyum.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEntropinnyum.java
@@ -18,7 +18,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
 
 import vazkii.botania.api.subtile.RadiusDescriptor;


### PR DESCRIPTION
Fixes #3426.

The current solution is to:

- make the whole thing static instead of per Entro because that's terrible all over

- always write the tag, write false if the TNT is ethical, true if it's unethical
- check if the TNT already has the tag before checking whether it's ethical
That should fix the issue ever coming up again, in worlds after this update.

However:
- worlds with Botania just added/updated with TNTs already in the world may still run into the issue

To circumvent that another check has been added:
- if the fuse is already below the max, don't bother checking

However this will still have issues from updating worlds with TNT's that haven't ticked at all since spawning.