### PR TITLE
Add ability to use gog level type in server.properties

### DIFF
--- a/src/main/java/vazkii/botania/common/Botania.java
+++ b/src/main/java/vazkii/botania/common/Botania.java
@@ -287,7 +287,7 @@ public class Botania {
 					+ " \"Do not Override\". Whoever had the brilliant idea of overriding it needs to go"
 					+ " back to elementary school and learn to read. (Actual classname: " + clname + ")");
 		}
-		if (Botania.gardenOfGlassLoaded) {
+		if (Botania.gardenOfGlassLoaded && event.getServer() instanceof DedicatedServer) {
 			WorldTypeUtil.setupForDedicatedServer((DedicatedServer) event.getServer());
 		}
 	}

--- a/src/main/java/vazkii/botania/common/Botania.java
+++ b/src/main/java/vazkii/botania/common/Botania.java
@@ -21,6 +21,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.crafting.IRecipeSerializer;
 import net.minecraft.particles.ParticleType;
 import net.minecraft.potion.Effect;
+import net.minecraft.server.dedicated.DedicatedServer;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityType;
@@ -102,6 +103,7 @@ import vazkii.botania.common.network.PacketHandler;
 import vazkii.botania.common.world.ModFeatures;
 import vazkii.botania.common.world.SkyblockChunkGenerator;
 import vazkii.botania.common.world.SkyblockWorldEvents;
+import vazkii.botania.common.world.WorldTypeUtil;
 import vazkii.botania.data.DataGenerators;
 import vazkii.patchouli.api.IMultiblock;
 import vazkii.patchouli.api.IStateMatcher;
@@ -284,6 +286,9 @@ public class Botania {
 					+ "This will cause crashes and compatibility issues, and that's why it's marked as"
 					+ " \"Do not Override\". Whoever had the brilliant idea of overriding it needs to go"
 					+ " back to elementary school and learn to read. (Actual classname: " + clname + ")");
+		}
+		if (Botania.gardenOfGlassLoaded) {
+			WorldTypeUtil.setupForDedicatedServer((DedicatedServer) event.getServer());
 		}
 	}
 

--- a/src/main/java/vazkii/botania/common/world/WorldTypeUtil.java
+++ b/src/main/java/vazkii/botania/common/world/WorldTypeUtil.java
@@ -1,0 +1,39 @@
+package vazkii.botania.common.world;
+
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.util.registry.DynamicRegistries;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.SimpleRegistry;
+import net.minecraft.world.Dimension;
+import net.minecraft.world.DimensionType;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.provider.OverworldBiomeProvider;
+import net.minecraft.world.gen.DimensionSettings;
+import net.minecraft.world.gen.settings.DimensionGeneratorSettings;
+import net.minecraft.world.storage.ServerWorldInfo;
+import vazkii.botania.common.Botania;
+
+import java.util.Locale;
+import java.util.Optional;
+
+public class WorldTypeUtil {
+    private static boolean isServerLevelSkyblock(DedicatedServer server) {
+        String levelType = Optional.ofNullable((String) server.getServerProperties().serverProperties.get("level-type")).map((str) -> str.toLowerCase(Locale.ROOT)).orElse("default");
+        return Botania.gardenOfGlassLoaded && levelType.equals("botania-skyblock");
+    }
+
+    public static void setupForDedicatedServer(DedicatedServer server) {
+        if (!isServerLevelSkyblock(server)) return;
+
+        DynamicRegistries registries = server.func_244267_aX();
+        ServerWorldInfo worldInfo = (ServerWorldInfo) server.func_240793_aU_();
+        long seed = worldInfo.generatorSettings.getSeed();
+        Registry<DimensionType> dimensions = registries.getRegistry(Registry.DIMENSION_TYPE_KEY);
+        Registry<Biome> biomes = registries.getRegistry(Registry.BIOME_KEY);
+        Registry<DimensionSettings> dimensionSettings = registries.getRegistry(Registry.NOISE_SETTINGS_KEY);
+        SimpleRegistry<Dimension> simpleregistry = DimensionType.getDefaultSimpleRegistry(dimensions, biomes, dimensionSettings, seed);
+        SimpleRegistry<Dimension> skyblock = DimensionGeneratorSettings.func_242749_a(dimensions, simpleregistry, new SkyblockChunkGenerator(new OverworldBiomeProvider(seed, false, false, biomes), seed, () -> dimensionSettings.getOrThrow(DimensionSettings.field_242734_c)));
+
+        worldInfo.generatorSettings = new DimensionGeneratorSettings(worldInfo.generatorSettings.getSeed(), worldInfo.generatorSettings.doesGenerateFeatures(), worldInfo.generatorSettings.hasBonusChest(), skyblock);
+    }
+}

--- a/src/main/java/vazkii/botania/common/world/WorldTypeUtil.java
+++ b/src/main/java/vazkii/botania/common/world/WorldTypeUtil.java
@@ -1,3 +1,11 @@
+/*
+ * This class is distributed as part of the Botania Mod.
+ * Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ */
 package vazkii.botania.common.world;
 
 import net.minecraft.server.dedicated.DedicatedServer;
@@ -11,29 +19,30 @@ import net.minecraft.world.biome.provider.OverworldBiomeProvider;
 import net.minecraft.world.gen.DimensionSettings;
 import net.minecraft.world.gen.settings.DimensionGeneratorSettings;
 import net.minecraft.world.storage.ServerWorldInfo;
+
 import vazkii.botania.common.Botania;
 
 import java.util.Locale;
 import java.util.Optional;
 
 public class WorldTypeUtil {
-    private static boolean isServerLevelSkyblock(DedicatedServer server) {
-        String levelType = Optional.ofNullable((String) server.getServerProperties().serverProperties.get("level-type")).map((str) -> str.toLowerCase(Locale.ROOT)).orElse("default");
-        return Botania.gardenOfGlassLoaded && levelType.equals("botania-skyblock");
-    }
+	private static boolean isServerLevelSkyblock(DedicatedServer server) {
+		String levelType = Optional.ofNullable((String) server.getServerProperties().serverProperties.get("level-type")).map((str) -> str.toLowerCase(Locale.ROOT)).orElse("default");
+		return Botania.gardenOfGlassLoaded && levelType.equals("botania-skyblock");
+	}
 
-    public static void setupForDedicatedServer(DedicatedServer server) {
-        if (!isServerLevelSkyblock(server)) return;
-
-        DynamicRegistries registries = server.func_244267_aX();
-        ServerWorldInfo worldInfo = (ServerWorldInfo) server.func_240793_aU_();
-        long seed = worldInfo.generatorSettings.getSeed();
-        Registry<DimensionType> dimensions = registries.getRegistry(Registry.DIMENSION_TYPE_KEY);
-        Registry<Biome> biomes = registries.getRegistry(Registry.BIOME_KEY);
-        Registry<DimensionSettings> dimensionSettings = registries.getRegistry(Registry.NOISE_SETTINGS_KEY);
-        SimpleRegistry<Dimension> simpleregistry = DimensionType.getDefaultSimpleRegistry(dimensions, biomes, dimensionSettings, seed);
-        SimpleRegistry<Dimension> skyblock = DimensionGeneratorSettings.func_242749_a(dimensions, simpleregistry, new SkyblockChunkGenerator(new OverworldBiomeProvider(seed, false, false, biomes), seed, () -> dimensionSettings.getOrThrow(DimensionSettings.field_242734_c)));
-
-        worldInfo.generatorSettings = new DimensionGeneratorSettings(worldInfo.generatorSettings.getSeed(), worldInfo.generatorSettings.doesGenerateFeatures(), worldInfo.generatorSettings.hasBonusChest(), skyblock);
-    }
+	public static void setupForDedicatedServer(DedicatedServer server) {
+		if (!isServerLevelSkyblock(server)) {
+			return;
+		}
+		DynamicRegistries registries = server.func_244267_aX();
+		ServerWorldInfo worldInfo = (ServerWorldInfo) server.func_240793_aU_();
+		long seed = worldInfo.generatorSettings.getSeed();
+		Registry<DimensionType> dimensions = registries.getRegistry(Registry.DIMENSION_TYPE_KEY);
+		Registry<Biome> biomes = registries.getRegistry(Registry.BIOME_KEY);
+		Registry<DimensionSettings> dimensionSettings = registries.getRegistry(Registry.NOISE_SETTINGS_KEY);
+		SimpleRegistry<Dimension> simpleregistry = DimensionType.getDefaultSimpleRegistry(dimensions, biomes, dimensionSettings, seed);
+		SimpleRegistry<Dimension> skyblock = DimensionGeneratorSettings.func_242749_a(dimensions, simpleregistry, new SkyblockChunkGenerator(new OverworldBiomeProvider(seed, false, false, biomes), seed, () -> dimensionSettings.getOrThrow(DimensionSettings.field_242734_c)));
+		worldInfo.generatorSettings = new DimensionGeneratorSettings(worldInfo.generatorSettings.getSeed(), worldInfo.generatorSettings.doesGenerateFeatures(), worldInfo.generatorSettings.hasBonusChest(), skyblock);
+	}
 }

--- a/src/main/java/vazkii/botania/common/world/WorldTypeUtil.java
+++ b/src/main/java/vazkii/botania/common/world/WorldTypeUtil.java
@@ -21,13 +21,15 @@ import net.minecraft.world.gen.settings.DimensionGeneratorSettings;
 import net.minecraft.world.storage.ServerWorldInfo;
 
 import vazkii.botania.common.Botania;
+import vazkii.botania.mixin.AccessorPropertyManager;
+import vazkii.botania.mixin.AccessorServerWorldInfo;
 
 import java.util.Locale;
 import java.util.Optional;
 
 public class WorldTypeUtil {
 	private static boolean isServerLevelSkyblock(DedicatedServer server) {
-		String levelType = Optional.ofNullable((String) server.getServerProperties().serverProperties.get("level-type")).map((str) -> str.toLowerCase(Locale.ROOT)).orElse("default");
+		String levelType = Optional.ofNullable((String) ((AccessorPropertyManager) server.getServerProperties()).getServerProperties().get("level-type")).map((str) -> str.toLowerCase(Locale.ROOT)).orElse("default");
 		return Botania.gardenOfGlassLoaded && levelType.equals("botania-skyblock");
 	}
 
@@ -37,12 +39,13 @@ public class WorldTypeUtil {
 		}
 		DynamicRegistries registries = server.func_244267_aX();
 		ServerWorldInfo worldInfo = (ServerWorldInfo) server.func_240793_aU_();
-		long seed = worldInfo.generatorSettings.getSeed();
+		DimensionGeneratorSettings generatorSettings = ((AccessorServerWorldInfo) worldInfo).getGeneratorSettings();
+		long seed = generatorSettings.getSeed();
 		Registry<DimensionType> dimensions = registries.getRegistry(Registry.DIMENSION_TYPE_KEY);
 		Registry<Biome> biomes = registries.getRegistry(Registry.BIOME_KEY);
 		Registry<DimensionSettings> dimensionSettings = registries.getRegistry(Registry.NOISE_SETTINGS_KEY);
 		SimpleRegistry<Dimension> simpleregistry = DimensionType.getDefaultSimpleRegistry(dimensions, biomes, dimensionSettings, seed);
 		SimpleRegistry<Dimension> skyblock = DimensionGeneratorSettings.func_242749_a(dimensions, simpleregistry, new SkyblockChunkGenerator(new OverworldBiomeProvider(seed, false, false, biomes), seed, () -> dimensionSettings.getOrThrow(DimensionSettings.field_242734_c)));
-		worldInfo.generatorSettings = new DimensionGeneratorSettings(worldInfo.generatorSettings.getSeed(), worldInfo.generatorSettings.doesGenerateFeatures(), worldInfo.generatorSettings.hasBonusChest(), skyblock);
+		((AccessorServerWorldInfo) worldInfo).setGeneratorSettings(new DimensionGeneratorSettings(generatorSettings.getSeed(), generatorSettings.doesGenerateFeatures(), generatorSettings.hasBonusChest(), skyblock));
 	}
 }

--- a/src/main/java/vazkii/botania/mixin/AccessorPropertyManager.java
+++ b/src/main/java/vazkii/botania/mixin/AccessorPropertyManager.java
@@ -1,0 +1,22 @@
+/*
+ * This class is distributed as part of the Botania Mod.
+ * Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ */
+package vazkii.botania.mixin;
+
+import net.minecraft.server.dedicated.PropertyManager;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.Properties;
+
+@Mixin(PropertyManager.class)
+public interface AccessorPropertyManager {
+	@Accessor
+	Properties getServerProperties();
+}

--- a/src/main/java/vazkii/botania/mixin/AccessorServerWorldInfo.java
+++ b/src/main/java/vazkii/botania/mixin/AccessorServerWorldInfo.java
@@ -1,0 +1,24 @@
+/*
+ * This class is distributed as part of the Botania Mod.
+ * Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ */
+package vazkii.botania.mixin;
+
+import net.minecraft.world.gen.settings.DimensionGeneratorSettings;
+import net.minecraft.world.storage.ServerWorldInfo;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ServerWorldInfo.class)
+public interface AccessorServerWorldInfo {
+	@Accessor
+	DimensionGeneratorSettings getGeneratorSettings();
+
+	@Accessor
+	void setGeneratorSettings(DimensionGeneratorSettings settings);
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,6 +1,3 @@
 public net.minecraft.client.gui.screen.BiomeGeneratorTypeScreens <init>(Ljava/lang/String;)V
 
 public net.minecraft.entity.projectile.ProjectileEntity <init>(Lnet/minecraft/entity/EntityType;Lnet/minecraft/world/World;)V
-
-public net.minecraft.server.dedicated.PropertyManager field_73672_b # serverProperties
-public-f net.minecraft.world.storage.ServerWorldInfo field_237343_c_ # generatorSettings

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,3 +1,6 @@
 public net.minecraft.client.gui.screen.BiomeGeneratorTypeScreens <init>(Ljava/lang/String;)V
 
 public net.minecraft.entity.projectile.ProjectileEntity <init>(Lnet/minecraft/entity/EntityType;Lnet/minecraft/world/World;)V
+
+public net.minecraft.server.dedicated.PropertyManager field_73672_b # serverProperties
+public-f net.minecraft.world.storage.ServerWorldInfo field_237343_c_ # generatorSettings

--- a/src/main/resources/assets/botania/botania.mixins.json
+++ b/src/main/resources/assets/botania/botania.mixins.json
@@ -5,6 +5,7 @@
   "package": "vazkii.botania.mixin",
   "refmap": "botania.refmap.json",
   "mixins": [
+    "AccessorPropertyManager",
     "AccessorAbstractFurnaceTileEntity",
     "AccessorAbstractHorseEntity",
     "AccessorAbstractSpawner",
@@ -19,6 +20,7 @@
     "AccessorMobEntity",
     "AccessorNearestAttackableTarget",
     "AccessorRecipeManager",
+    "AccessorServerWorldInfo",
     "AccessorStats",
     "AccessorWitherEntity",
     "MixinAbstractMinecartEntity",


### PR DESCRIPTION
Creating a world on server with level type set to "botania-skyblock" will now create the GoG skyblock world. 
Closes #3511 