### PR TITLE
Add "Botanist Ready" Superflat preset

### DIFF
--- a/src/main/java/vazkii/botania/mixin/MixinFlatPresetsScreen.java
+++ b/src/main/java/vazkii/botania/mixin/MixinFlatPresetsScreen.java
@@ -1,0 +1,54 @@
+/*
+ * This class is distributed as part of the Botania Mod.
+ * Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ */
+package vazkii.botania.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import vazkii.botania.common.block.ModBlocks;
+import vazkii.botania.common.item.ModItems;
+
+import net.minecraft.block.Blocks;
+import net.minecraft.client.gui.screen.FlatPresetsScreen;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.IItemProvider;
+import net.minecraft.util.RegistryKey;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.biome.Biomes;
+import net.minecraft.world.gen.FlatLayerInfo;
+import net.minecraft.world.gen.feature.structure.Structure;
+
+import java.util.Collections;
+import java.util.List;
+
+@Mixin(FlatPresetsScreen.class)
+public class MixinFlatPresetsScreen {
+
+	@Invoker("func_238640_a_")
+	public static void botania_addFlatWorldPreset(ITextComponent name, IItemProvider icon, RegistryKey<Biome> biome, List<Structure<?>> structures, boolean b1, boolean b2, boolean b3, FlatLayerInfo... layers) {
+	}
+
+	@Inject(method = "<clinit>", at = @At("RETURN"))
+	private static void onClinit(CallbackInfo ci) {
+		botania_addFlatWorldPreset(new TranslationTextComponent("botaniamisc.preset.botanistReady"),
+				ModItems.twigWand,
+				Biomes.PLAINS,
+				Collections.emptyList(),
+				// idk what these are I just copied them from Redstone Ready
+				false, false, false,
+				new FlatLayerInfo(64, ModBlocks.livingrockBrick),
+				new FlatLayerInfo(1, Blocks.BEDROCK));
+	}
+
+}

--- a/src/main/java/vazkii/botania/mixin/MixinFlatPresetsScreen.java
+++ b/src/main/java/vazkii/botania/mixin/MixinFlatPresetsScreen.java
@@ -8,18 +8,8 @@
  */
 package vazkii.botania.mixin;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.gen.Invoker;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import vazkii.botania.common.block.ModBlocks;
-import vazkii.botania.common.item.ModItems;
-
 import net.minecraft.block.Blocks;
 import net.minecraft.client.gui.screen.FlatPresetsScreen;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.IItemProvider;
 import net.minecraft.util.RegistryKey;
 import net.minecraft.util.text.ITextComponent;
@@ -29,6 +19,15 @@ import net.minecraft.world.biome.Biomes;
 import net.minecraft.world.gen.FlatLayerInfo;
 import net.minecraft.world.gen.feature.structure.Structure;
 
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import vazkii.botania.common.block.ModBlocks;
+import vazkii.botania.common.item.ModItems;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -36,8 +35,7 @@ import java.util.List;
 public class MixinFlatPresetsScreen {
 
 	@Invoker("func_238640_a_")
-	public static void botania_addFlatWorldPreset(ITextComponent name, IItemProvider icon, RegistryKey<Biome> biome, List<Structure<?>> structures, boolean b1, boolean b2, boolean b3, FlatLayerInfo... layers) {
-	}
+	public static void botania_addFlatWorldPreset(ITextComponent name, IItemProvider icon, RegistryKey<Biome> biome, List<Structure<?>> structures, boolean b1, boolean b2, boolean b3, FlatLayerInfo... layers) {}
 
 	@Inject(method = "<clinit>", at = @At("RETURN"))
 	private static void onClinit(CallbackInfo ci) {

--- a/src/main/resources/assets/botania/botania.mixins.json
+++ b/src/main/resources/assets/botania/botania.mixins.json
@@ -23,6 +23,7 @@
     "AccessorWitherEntity",
     "MixinAbstractMinecartEntity",
     "MixinEndermanPickupBlock",
+    "MixinFlatPresetsScreen",
     "MixinLootTable",
     "MixinPlayerEntity",
     "MixinThrowableEntity"

--- a/src/main/resources/assets/botania/lang/en_us.json
+++ b/src/main/resources/assets/botania/lang/en_us.json
@@ -123,6 +123,7 @@
   "botaniamisc.santaweaveInfo": "Manaweave, changed up for the \u00a7cs\u00a7fe\u00a7ca\u00a7fs\u00a7co\u00a7fn",
   "botaniamisc.scaleChange": "Change Scale",
   "botaniamisc.invalidDodge": "Invalid Dodge Packet",
+  "botaniamisc.preset.botanistReady": "Botanist Ready",
 
   "botania.nei.brewery": "Botanical Brewery",
   "botania.nei.elvenTrade": "Elven Trade",


### PR DESCRIPTION
This PR adds a superflat preset called "Botanist Ready".

It looks like this in the menu:

![](https://i.imgur.com/050XABe.png)

and like this in-game:

![](https://user-images.githubusercontent.com/11538216/103025509-df869380-4549-11eb-8056-e4d841025acc.png)
