### PR TITLE
Prioritize Vitreous Pickaxe for the Ring of Correction when breaking glass

### DIFF
--- a/src/main/java/vazkii/botania/api/item/ISortableTool.java
+++ b/src/main/java/vazkii/botania/api/item/ISortableTool.java
@@ -8,6 +8,7 @@
  */
 package vazkii.botania.api.item;
 
+import net.minecraft.block.BlockState;
 import net.minecraft.item.ItemStack;
 
 /**
@@ -31,8 +32,20 @@ public interface ISortableTool {
 	 * <br>
 	 * All intermediate tool levels are there for other mod tools that wish to occupy the spots inbetween.
 	 * Of course, you don't have to always adhere to this. Tools like the <b>Vitreous Pickaxe</b> don't,
-	 * that one in particular is priority 0 so it's never picked.
+	 * that one in particular is priority 0, unless looking at glass, in which case it's {@link Integer#MAX_VALUE}.
+	 *
+	 * @param state The blockstate being broken.
 	 */
-	public int getSortingPriority(ItemStack stack);
+	default int getSortingPriority(ItemStack stack, BlockState state) {
+		return getSortingPriority(stack);
+	}
+
+	/**
+	 * @deprecated Override {@link #getSortingPriority(ItemStack, BlockState)} instead.
+	 */
+	@Deprecated
+	default int getSortingPriority(ItemStack stack) {
+		return 0;
+	}
 
 }

--- a/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemSwapRing.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/bauble/ItemSwapRing.java
@@ -42,10 +42,11 @@ public class ItemSwapRing extends ItemBauble {
 		ISortableTool tool = (ISortableTool) currentStack.getItem();
 
 		BlockRayTraceResult pos = ToolCommons.raytraceFromEntity(player, 4.5F, false);
-		ToolType typeToFind = null;
 
+		ToolType typeToFind;
+		BlockState state;
 		if (player.isSwingInProgress && pos.getType() == RayTraceResult.Type.BLOCK) {
-			BlockState state = entity.world.getBlockState(pos.getPos());
+			state = entity.world.getBlockState(pos.getPos());
 
 			Material mat = state.getMaterial();
 			if (ToolCommons.materialsPick.contains(mat)) {
@@ -54,15 +55,15 @@ public class ItemSwapRing extends ItemBauble {
 				typeToFind = ToolType.SHOVEL;
 			} else if (ToolCommons.materialsAxe.contains(mat)) {
 				typeToFind = ToolType.AXE;
+			} else {
+				return;
 			}
-		}
-
-		if (typeToFind == null) {
+		} else {
 			return;
 		}
 
 		ItemStack bestTool = currentStack;
-		int bestToolPriority = currentStack.getToolTypes().contains(typeToFind) ? tool.getSortingPriority(currentStack) : -1;
+		int bestToolPriority = currentStack.getToolTypes().contains(typeToFind) ? tool.getSortingPriority(currentStack, state) : -1;
 		int bestSlot = -1;
 
 		for (int i = 0; i < player.inventory.getSizeInventory(); i++) {
@@ -70,7 +71,7 @@ public class ItemSwapRing extends ItemBauble {
 			if (!stackInSlot.isEmpty() && stackInSlot.getItem() instanceof ISortableTool && stackInSlot != currentStack) {
 				ISortableTool toolInSlot = (ISortableTool) stackInSlot.getItem();
 				if (stackInSlot.getToolTypes().contains(typeToFind)) {
-					int priority = toolInSlot.getSortingPriority(stackInSlot);
+					int priority = toolInSlot.getSortingPriority(stackInSlot, state);
 					if (priority > bestToolPriority) {
 						bestTool = stackInSlot;
 						bestToolPriority = priority;

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/ItemGlassPick.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/ItemGlassPick.java
@@ -75,9 +75,8 @@ public class ItemGlassPick extends ItemManasteelPick {
 	@Override
 	public boolean onBlockStartBreak(ItemStack itemstack, BlockPos pos, PlayerEntity player) {
 		BlockState state = player.world.getBlockState(pos);
-		boolean isGlass = state.getMaterial() == Material.GLASS || Tags.Blocks.GLASS.contains(state.getBlock());
 		boolean hasSilk = EnchantmentHelper.getEnchantmentLevel(Enchantments.SILK_TOUCH, itemstack) > 0;
-		if (hasSilk || !isGlass) {
+		if (hasSilk || !isGlass(state)) {
 			return super.onBlockStartBreak(itemstack, pos, player);
 		}
 
@@ -98,14 +97,19 @@ public class ItemGlassPick extends ItemManasteelPick {
 		}
 	}
 
+	private boolean isGlass(BlockState state) {
+		return state.getMaterial() == Material.GLASS || Tags.Blocks.GLASS.contains(state.getBlock());
+	}
+
 	@Override
 	public int getManaPerDamage() {
 		return MANA_PER_DAMAGE;
 	}
 
 	@Override
-	public int getSortingPriority(ItemStack stack) {
-		return 0;
+	public int getSortingPriority(ItemStack stack, BlockState state) {
+		// if you have a Vitreous Pickaxe on you you probably want it to be chosen when breaking glass
+		return isGlass(state) ? Integer.MAX_VALUE : 0;
 	}
 
 }

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/ItemGlassPick.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/ItemGlassPick.java
@@ -108,7 +108,6 @@ public class ItemGlassPick extends ItemManasteelPick {
 
 	@Override
 	public int getSortingPriority(ItemStack stack, BlockState state) {
-		// if you have a Vitreous Pickaxe on you you probably want it to be chosen when breaking glass
 		return isGlass(state) ? Integer.MAX_VALUE : 0;
 	}
 

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/manasteel/ItemManasteelAxe.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/manasteel/ItemManasteelAxe.java
@@ -8,6 +8,7 @@
  */
 package vazkii.botania.common.item.equipment.tool.manasteel;
 
+import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -89,7 +90,7 @@ public class ItemManasteelAxe extends AxeItem implements IManaUsingItem, ISortab
 	}
 
 	@Override
-	public int getSortingPriority(ItemStack stack) {
+	public int getSortingPriority(ItemStack stack, BlockState state) {
 		return ToolCommons.getToolPriority(stack);
 	}
 }

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/manasteel/ItemManasteelPick.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/manasteel/ItemManasteelPick.java
@@ -8,6 +8,7 @@
  */
 package vazkii.botania.common.item.equipment.tool.manasteel;
 
+import net.minecraft.block.BlockState;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -89,7 +90,7 @@ public class ItemManasteelPick extends PickaxeItem implements IManaUsingItem, IS
 	}
 
 	@Override
-	public int getSortingPriority(ItemStack stack) {
+	public int getSortingPriority(ItemStack stack, BlockState state) {
 		return ToolCommons.getToolPriority(stack);
 	}
 }

--- a/src/main/java/vazkii/botania/common/item/equipment/tool/manasteel/ItemManasteelShovel.java
+++ b/src/main/java/vazkii/botania/common/item/equipment/tool/manasteel/ItemManasteelShovel.java
@@ -119,7 +119,7 @@ public class ItemManasteelShovel extends ShovelItem implements IManaUsingItem, I
 	}
 
 	@Override
-	public int getSortingPriority(ItemStack stack) {
+	public int getSortingPriority(ItemStack stack, BlockState state) {
 		return ToolCommons.getToolPriority(stack);
 	}
 }


### PR DESCRIPTION
This PR ensures that the Vitreous Pickaxe is swapped for by the Ring of Correction when breaking glass. The previous behaviour was that it would always be swapped out.

Here it is after the changes:

https://user-images.githubusercontent.com/11538216/103090080-ef54b500-45e7-11eb-8ea3-67cae6c33ab6.mp4


