### PR TITLE
Fully implementing IBlockProvider on rods

### DIFF
--- a/src/main/java/vazkii/botania/api/mana/ManaItemHandler.java
+++ b/src/main/java/vazkii/botania/api/mana/ManaItemHandler.java
@@ -128,7 +128,8 @@ public interface ManaItemHandler {
 	}
 
 	/**
-	 * Determines how many times the given tool can get the requested amount of mana.  Takes discounts into consideration.
+	 * Determines how many times the given tool can get the requested amount of mana. Takes discounts into
+	 * consideration.
 	 * 
 	 * @param manaToGet How much mana is to be requested per invocation
 	 * @return The number of invocations that could be executed before exhausting the player's mana available

--- a/src/main/java/vazkii/botania/api/mana/ManaItemHandler.java
+++ b/src/main/java/vazkii/botania/api/mana/ManaItemHandler.java
@@ -128,6 +128,16 @@ public interface ManaItemHandler {
 	}
 
 	/**
+	 * Determines how many times the given tool can get the requested amount of mana.  Takes discounts into consideration.
+	 * 
+	 * @param manaToGet How much mana is to be requested per invocation
+	 * @return The number of invocations that could be executed before exhausting the player's mana available
+	 */
+	default int getInvocationCountForTool(ItemStack stack, PlayerEntity player, int manaToGet) {
+		return 0;
+	}
+
+	/**
 	 * Gets the sum of all the discounts on IManaDiscountArmor items equipped
 	 * on the player passed in. This discount can vary based on what the passed tool is.
 	 */

--- a/src/main/java/vazkii/botania/common/impl/mana/ManaItemHandlerImpl.java
+++ b/src/main/java/vazkii/botania/common/impl/mana/ManaItemHandlerImpl.java
@@ -189,19 +189,51 @@ public class ManaItemHandlerImpl implements ManaItemHandler {
 
 		return false;
 	}
+	
+	private int discountManaForTool(ItemStack stack, PlayerEntity player, int inCost) {
+		float multiplier = Math.max(0F, 1F - getFullDiscountForTools(player, stack));
+		return (int) (inCost * multiplier);
+	}
 
 	@Override
 	public int requestManaForTool(ItemStack stack, PlayerEntity player, int manaToGet, boolean remove) {
-		float multiplier = Math.max(0F, 1F - getFullDiscountForTools(player, stack));
-		int cost = (int) (manaToGet * multiplier);
-		return (int) (requestMana(stack, player, cost, remove) / multiplier);
+		int cost = discountManaForTool(stack, player, manaToGet);
+		return requestMana(stack, player, cost, remove);
 	}
 
 	@Override
 	public boolean requestManaExactForTool(ItemStack stack, PlayerEntity player, int manaToGet, boolean remove) {
-		float multiplier = Math.max(0F, 1F - getFullDiscountForTools(player, stack));
-		int cost = (int) (manaToGet * multiplier);
+		int cost = discountManaForTool(stack, player, manaToGet);
 		return requestManaExact(stack, player, cost, remove);
+	}
+
+	@Override
+	public int getInvocationCountForTool(ItemStack stack, PlayerEntity player, int manaToGet) {
+		if (stack.isEmpty()) {
+			return 0;
+		}
+		
+		int cost = discountManaForTool(stack, player, manaToGet);
+		int invocations = 0;
+
+		List<ItemStack> items = getManaItems(player);
+		List<ItemStack> acc = getManaAccesories(player);
+		for (ItemStack stackInSlot : Iterables.concat(items, acc)) {
+			if (stackInSlot == stack) {
+				continue;
+			}
+			IManaItem manaItemSlot = (IManaItem) stackInSlot.getItem();
+			int availableMana = manaItemSlot.getMana(stackInSlot);
+			if (manaItemSlot.canExportManaToItem(stackInSlot, stack) && availableMana > cost) {
+				if (stack.getItem() instanceof IManaItem && !((IManaItem) stack.getItem()).canReceiveManaFromItem(stack, stackInSlot)) {
+					continue;
+				}
+
+				invocations += availableMana / cost;
+			}
+		}
+
+		return invocations;
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/impl/mana/ManaItemHandlerImpl.java
+++ b/src/main/java/vazkii/botania/common/impl/mana/ManaItemHandlerImpl.java
@@ -189,7 +189,7 @@ public class ManaItemHandlerImpl implements ManaItemHandler {
 
 		return false;
 	}
-	
+
 	private int discountManaForTool(ItemStack stack, PlayerEntity player, int inCost) {
 		float multiplier = Math.max(0F, 1F - getFullDiscountForTools(player, stack));
 		return (int) (inCost * multiplier);
@@ -212,7 +212,7 @@ public class ManaItemHandlerImpl implements ManaItemHandler {
 		if (stack.isEmpty()) {
 			return 0;
 		}
-		
+
 		int cost = discountManaForTool(stack, player, manaToGet);
 		int invocations = 0;
 

--- a/src/main/java/vazkii/botania/common/item/rod/ItemCobbleRod.java
+++ b/src/main/java/vazkii/botania/common/item/rod/ItemCobbleRod.java
@@ -44,7 +44,8 @@ public class ItemCobbleRod extends Item implements IManaUsingItem, IBlockProvide
 	@Override
 	public boolean provideBlock(PlayerEntity player, ItemStack requestor, ItemStack stack, Block block, boolean doit) {
 		if (block == Blocks.COBBLESTONE) {
-			return !doit || ManaItemHandler.instance().requestManaExactForTool(requestor, player, COST, true);
+			return (doit && ManaItemHandler.instance().requestManaExactForTool(requestor, player, COST, true)) ||
+					(!doit && ManaItemHandler.instance().requestManaExactForTool(requestor, player, COST, false));
 		}
 		return false;
 	}
@@ -52,7 +53,7 @@ public class ItemCobbleRod extends Item implements IManaUsingItem, IBlockProvide
 	@Override
 	public int getBlockCount(PlayerEntity player, ItemStack requestor, ItemStack stack, Block block) {
 		if (block == Blocks.COBBLESTONE) {
-			return -1;
+			return ManaItemHandler.instance().getInvocationCountForTool(requestor, player, COST);
 		}
 		return 0;
 	}

--- a/src/main/java/vazkii/botania/common/item/rod/ItemDirtRod.java
+++ b/src/main/java/vazkii/botania/common/item/rod/ItemDirtRod.java
@@ -89,7 +89,8 @@ public class ItemDirtRod extends Item implements IManaUsingItem, IBlockProvider,
 	@Override
 	public boolean provideBlock(PlayerEntity player, ItemStack requestor, ItemStack stack, Block block, boolean doit) {
 		if (block == Blocks.DIRT) {
-			return !doit || ManaItemHandler.instance().requestManaExactForTool(requestor, player, COST, true);
+			return (doit && ManaItemHandler.instance().requestManaExactForTool(requestor, player, COST, true)) ||
+					(!doit && ManaItemHandler.instance().requestManaExactForTool(requestor, player, COST, false));
 		}
 		return false;
 	}
@@ -97,7 +98,7 @@ public class ItemDirtRod extends Item implements IManaUsingItem, IBlockProvider,
 	@Override
 	public int getBlockCount(PlayerEntity player, ItemStack requestor, ItemStack stack, Block block) {
 		if (block == Blocks.DIRT) {
-			return -1;
+			return ManaItemHandler.instance().getInvocationCountForTool(requestor, player, COST);
 		}
 		return 0;
 	}

--- a/src/main/java/vazkii/botania/common/item/rod/ItemTerraformRod.java
+++ b/src/main/java/vazkii/botania/common/item/rod/ItemTerraformRod.java
@@ -148,7 +148,8 @@ public class ItemTerraformRod extends Item implements IManaUsingItem, IBlockProv
 	@Override
 	public boolean provideBlock(PlayerEntity player, ItemStack requestor, ItemStack stack, Block block, boolean doit) {
 		if (block == Blocks.DIRT) {
-			return !doit || ManaItemHandler.instance().requestManaExactForTool(requestor, player, ItemDirtRod.COST, true);
+			return (doit && ManaItemHandler.instance().requestManaExactForTool(requestor, player, ItemDirtRod.COST, true)) ||
+					(!doit && ManaItemHandler.instance().requestManaExactForTool(requestor, player, ItemDirtRod.COST, false));
 		}
 		return false;
 	}
@@ -156,7 +157,7 @@ public class ItemTerraformRod extends Item implements IManaUsingItem, IBlockProv
 	@Override
 	public int getBlockCount(PlayerEntity player, ItemStack requestor, ItemStack stack, Block block) {
 		if (block == Blocks.DIRT) {
-			return -1;
+			return ManaItemHandler.instance().getInvocationCountForTool(requestor, player, ItemDirtRod.COST);
 		}
 		return 0;
 	}


### PR DESCRIPTION
 - provideBlock was not respecting doit=false as a full check of capability
 - getBlockCount providing a -1 sentinel for "infinite" is not accurate when the capability is in fact not infinite but dependent on mana availability.
 - Refactored a little bit in ManaItemHandlerImpl to avoid code duplication.
 - That refactoring revealed that requestManaForTool was un-discounting for some undocumented reason.  The function appears unused internally anyway, and I cannot think of any reason why it would undo the discount, so I nuked that.