### PR TITLE
Add lens splitting recipe

### DIFF
--- a/src/generated/resources/data/botania/recipes/dynamic/split_lens.json
+++ b/src/generated/resources/data/botania/recipes/dynamic/split_lens.json
@@ -1,0 +1,3 @@
+{
+  "type": "botania:split_lens"
+}

--- a/src/main/java/vazkii/botania/api/mana/ILens.java
+++ b/src/main/java/vazkii/botania/api/mana/ILens.java
@@ -30,7 +30,8 @@ public interface ILens extends ILensEffect {
 
 	/**
 	 * Sets the composite lens for the sourceLens as the compositeLens, returns
-	 * the ItemStack with the combination.
+	 * the ItemStack with the combination. If compositeLens is empty, this removes
+	 * the composite.
 	 */
 	public ItemStack setCompositeLens(ItemStack sourceLens, ItemStack compositeLens);
 

--- a/src/main/java/vazkii/botania/common/crafting/recipe/SplitLensRecipe.java
+++ b/src/main/java/vazkii/botania/common/crafting/recipe/SplitLensRecipe.java
@@ -1,0 +1,87 @@
+/*
+ * This class is distributed as part of the Botania Mod.
+ * Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ */
+package vazkii.botania.common.crafting.recipe;
+
+import net.minecraft.inventory.CraftingInventory;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipeSerializer;
+import net.minecraft.item.crafting.SpecialRecipe;
+import net.minecraft.item.crafting.SpecialRecipeSerializer;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+
+import vazkii.botania.api.mana.ILens;
+
+import javax.annotation.Nonnull;
+
+public class SplitLensRecipe extends SpecialRecipe {
+	public static final SpecialRecipeSerializer<SplitLensRecipe> SERIALIZER = new SpecialRecipeSerializer<>(SplitLensRecipe::new);
+
+	public SplitLensRecipe(ResourceLocation idIn) {
+		super(idIn);
+	}
+
+	@Override
+	public boolean matches(@Nonnull CraftingInventory inv, @Nonnull World worldIn) {
+		return !getCraftingResult(inv).isEmpty();
+	}
+
+	@Nonnull
+	@Override
+	public ItemStack getCraftingResult(CraftingInventory inv) {
+		ItemStack found = ItemStack.EMPTY;
+		for (int i = 0; i < inv.getSizeInventory(); i++) {
+			ItemStack candidate = inv.getStackInSlot(i);
+			if (candidate.isEmpty()) {
+				continue;
+			}
+			if (!found.isEmpty() || (found = getComposite(candidate)).isEmpty()) {
+				return ItemStack.EMPTY;
+			}
+		}
+		return found;
+	}
+
+	private ItemStack getComposite(ItemStack stack) {
+		Item item = stack.getItem();
+		if (!(item instanceof ILens)) {
+			return ItemStack.EMPTY;
+		}
+		return ((ILens) item).getCompositeLens(stack);
+	}
+
+	@Nonnull
+	@Override
+	public NonNullList<ItemStack> getRemainingItems(CraftingInventory inv) {
+		NonNullList<ItemStack> remaining = NonNullList.withSize(inv.getSizeInventory(), ItemStack.EMPTY);
+		for (int i = 0; i < inv.getSizeInventory(); i++) {
+			ItemStack candidate = inv.getStackInSlot(i);
+			if (candidate.getItem() instanceof ILens) {
+				ItemStack newLens = candidate.copy();
+				ILens lens = (ILens) candidate.getItem();
+				lens.setCompositeLens(newLens, ItemStack.EMPTY);
+				remaining.set(i, newLens);
+			}
+		}
+		return remaining;
+	}
+
+	@Override
+	public boolean canFit(int width, int height) {
+		return width * height >= 1;
+	}
+
+	@Nonnull
+	@Override
+	public IRecipeSerializer<?> getSerializer() {
+		return SERIALIZER;
+	}
+}

--- a/src/main/java/vazkii/botania/common/item/ModItems.java
+++ b/src/main/java/vazkii/botania/common/item/ModItems.java
@@ -717,6 +717,7 @@ public final class ModItems {
 		register(r, "merge_vial", MergeVialRecipe.SERIALIZER);
 		register(r, "phantom_ink_apply", PhantomInkRecipe.SERIALIZER);
 		register(r, "spell_cloth_apply", SpellClothRecipe.SERIALIZER);
+		register(r, "split_lens", SplitLensRecipe.SERIALIZER);
 		register(r, "terra_pick_tipping", TerraPickTippingRecipe.SERIALIZER);
 		register(r, "twig_wand", TwigWandRecipe.SERIALIZER);
 

--- a/src/main/java/vazkii/botania/common/item/lens/ItemLens.java
+++ b/src/main/java/vazkii/botania/common/item/lens/ItemLens.java
@@ -196,7 +196,9 @@ public class ItemLens extends Item implements ILensControl, ICompositableLens, I
 
 	@Override
 	public ItemStack setCompositeLens(ItemStack sourceLens, ItemStack compositeLens) {
-		if (!compositeLens.isEmpty()) {
+		if (compositeLens.isEmpty()) {
+			ItemNBTHelper.removeEntry(sourceLens, TAG_COMPOSITE_LENS);
+		} else {
 			CompoundNBT cmp = compositeLens.write(new CompoundNBT());
 			ItemNBTHelper.setCompound(sourceLens, TAG_COMPOSITE_LENS, cmp);
 		}

--- a/src/main/java/vazkii/botania/data/recipes/RecipeProvider.java
+++ b/src/main/java/vazkii/botania/data/recipes/RecipeProvider.java
@@ -73,6 +73,7 @@ public class RecipeProvider extends net.minecraft.data.RecipeProvider {
 		specialRecipe(consumer, MergeVialRecipe.SERIALIZER);
 		specialRecipe(consumer, PhantomInkRecipe.SERIALIZER);
 		specialRecipe(consumer, SpellClothRecipe.SERIALIZER);
+		specialRecipe(consumer, SplitLensRecipe.SERIALIZER);
 		specialRecipe(consumer, TerraPickTippingRecipe.SERIALIZER);
 
 		registerMain(consumer);


### PR DESCRIPTION
This PR implements a recipe that allows splitting composite lenses into their component lenses.
![example](https://user-images.githubusercontent.com/11538216/107055588-5a89cd80-67c9-11eb-8505-d40e0fa5a08f.png)
The slime ball is lost, but the two lenses are recovered.
