### PR TITLE
Add recipe upgrading to Fabulous Pool from Mana Pool

### DIFF
--- a/src/generated/resources/data/botania/advancements/recipes/botania/fabulous_pool_upgrade.json
+++ b/src/generated/resources/data/botania/advancements/recipes/botania/fabulous_pool_upgrade.json
@@ -1,0 +1,43 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "botania:fabulous_pool_upgrade"
+    ]
+  },
+  "criteria": {
+    "has_item": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "botania:bifrost_perm"
+          }
+        ]
+      }
+    },
+    "has_alt_item": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "botania:rainbow_rod"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "botania:fabulous_pool_upgrade"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_item",
+      "has_alt_item",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/generated/resources/data/botania/recipes/fabulous_pool_upgrade.json
+++ b/src/generated/resources/data/botania/recipes/fabulous_pool_upgrade.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "BPB",
+    "BBB"
+  ],
+  "key": {
+    "P": {
+      "item": "botania:mana_pool"
+    },
+    "B": {
+      "item": "botania:bifrost_perm"
+    }
+  },
+  "result": {
+    "item": "botania:fabulous_pool"
+  }
+}

--- a/src/main/java/vazkii/botania/data/recipes/RecipeProvider.java
+++ b/src/main/java/vazkii/botania/data/recipes/RecipeProvider.java
@@ -141,6 +141,14 @@ public class RecipeProvider extends net.minecraft.data.RecipeProvider {
 				.addCriterion("has_item", hasItem(ModBlocks.shimmerrock))
 				.addCriterion("has_alt_item", hasItem(ModItems.rainbowRod))
 				.build(consumer);
+		ShapedRecipeBuilder.shapedRecipe(ModBlocks.fabulousPool)
+				.key('P', ModBlocks.manaPool)
+				.key('B', ModBlocks.bifrostPerm)
+				.patternLine("BPB")
+				.patternLine("BBB")
+				.addCriterion("has_item", hasItem(ModBlocks.bifrostPerm))
+				.addCriterion("has_alt_item", hasItem(ModItems.rainbowRod))
+				.build(consumer, prefix(Registry.ITEM.getKey(ModBlocks.fabulousPool.asItem()).getPath() + "_upgrade"));
 		ShapedRecipeBuilder.shapedRecipe(ModBlocks.runeAltar)
 				.key('P', Ingredient.fromItemListStream(Stream.of(
 						new Ingredient.SingleItemList(new ItemStack(ModItems.manaPearl)),

--- a/src/main/resources/data/botania/patchouli_books/lexicon/en_us/entries/tools/rainbow_rod.json
+++ b/src/main/resources/data/botania/patchouli_books/lexicon/en_us/entries/tools/rainbow_rod.json
@@ -43,6 +43,11 @@
       "type": "crafting",
       "text": "botania.page.rainbowRod7",
       "recipe": "botania:fabulous_pool"
+    },
+    {
+      "type": "crafting",
+      "text": "botania.page.rainbowRod7",
+      "recipe": "botania:fabulous_pool_upgrade"
     }
   ]
 }


### PR DESCRIPTION
Not sure if this is okay to add, close PR if it is not good (and sorry for wasting time ;-;)

Also added the recipe to the lexicon, but it made the text a bit too close to the bottom of the page.
Perhaps this should be on another page? Will change if so, let me know.

<details>
<summary>Screenshots</summary>

![Upgrading a Mana Pool to Fabulous Pool in a Crafting Table](https://user-images.githubusercontent.com/630920/107381646-04e75500-6b2a-11eb-9c80-eee5951e8a49.png)
![Botania Lexicon page for Fabulous Pool crafting](https://user-images.githubusercontent.com/630920/107381580-f305b200-6b29-11eb-9047-bb5f00c6e5bb.png)
</details>