### PR TITLE
Remove a redundant translation

### DIFF
--- a/src/main/java/vazkii/botania/client/render/tile/RenderTileTinyPotato.java
+++ b/src/main/java/vazkii/botania/client/render/tile/RenderTileTinyPotato.java
@@ -271,7 +271,6 @@ public class RenderTileTinyPotato extends TileEntityRenderer<TileTinyPotato> {
 			ms.rotate(mc.getRenderManager().getCameraOrientation());
 			float f1 = 0.016666668F * 1.6F;
 			ms.scale(-f1, -f1, f1);
-			ms.translate(0.0F, 0F / f1, 0.0F);
 			int halfWidth = mc.fontRenderer.getStringWidth(potato.name.getString()) / 2;
 
 			float opacity = Minecraft.getInstance().gameSettings.getTextBackgroundOpacity(0.25F);


### PR DESCRIPTION
While this proof may not be particularly formal, it should hopefully be adequate.

## Hypothesis

I believe that the highlighted statement here
```patch
@@ -271,7 +271,6 @@ private void renderName(TileTinyPotato potato, String name, MatrixStack ms, IRen
			ms.rotate(mc.getRenderManager().getCameraOrientation());
			float f1 = 0.016666668F * 1.6F;
			ms.scale(-f1, -f1, f1);
-			ms.translate(0.0F, 0F / f1, 0.0F);
			int halfWidth = mc.fontRenderer.getStringWidth(potato.name.getString()) / 2;

			float opacity = Minecraft.getInstance().gameSettings.getTextBackgroundOpacity(0.25F);
```
is redundant.

## All arguments are `0`

Firstly, it is necessary to realize that the expression `0F / f1` evaluates to `0`. That is because the value `f1` is the constant expression `0.016666668F * 1.6F`. Substituting that expression into the former results in `0F / (0.016666668F * 1.6F)`, which, according to [Wolfram|Alpha](https://www.wolframalpha.com/input/?i=0+%2F+%280.016666668+*+1.6%29) comes to `0`.

Therefore, in this case,
```java
ms.translate(0.0F, 0F / f1, 0.0F);
```
is equivalent to
```java
ms.translate(0.0F, 0.0F, 0.0F);
```

And the translation is by `(0, 0, 0)`.

## Translating by `(0, 0, 0)` multiplies by the identity matrix

While we cannot be exactly sure about the implementation of `ms.translate`, a translation of `(x, y, z)` with 4x4 matrices is usually implemented by multiplying with a matrix of the following form:

|1|0|0|x|
|-|-|-|-|
|0|1|0|y|
|0|0|1|z|
|0|0|0|1|

In this case, `x`, `y` and `z` are all `0`, so the matrix looks like this:

|1|0|0|0|
|-|-|-|-|
|0|1|0|0|
|0|0|1|0|
|0|0|0|1|

Avid readers may notice that this is an **identity matrix**, that is, multiplying a matrix `m` by it results in `m`, and multiplying it by a matrix `m` results in `m`. In other words, multiplying by an identity matrix results in no transformation at all.

## Conclusion

In conclusion, a translation of `(0, 0, 0)`, as in
```java
ms.translate(0.0F, 0F / f1, 0.0F);
```
is equivalent to multiplying by an identity matrix, which is equivalent to no transformation at all. Therefore, the line is redundant. □
