### PR TITLE
Fix tiny potato models not working with resource packs

### DIFF
--- a/src/main/java/vazkii/botania/client/lib/LibResources.java
+++ b/src/main/java/vazkii/botania/client/lib/LibResources.java
@@ -22,7 +22,7 @@ public final class LibResources {
 	public static final String PREFIX_MODEL = PREFIX_MOD + "textures/model/";
 	public static final String PREFIX_MISC = PREFIX_MOD + "textures/misc/";
 
-	public static final String PREFIX_TINY_POTATO = "tiny_potato/";
+	public static final String PREFIX_TINY_POTATO = "tiny_potato";
 
 	public static final String GUI_MANA_HUD = PREFIX_GUI + "mana_hud.png";
 	public static final String GUI_CREATIVE = "botania.png";

--- a/src/main/java/vazkii/botania/client/render/tile/RenderTileTinyPotato.java
+++ b/src/main/java/vazkii/botania/client/render/tile/RenderTileTinyPotato.java
@@ -106,7 +106,7 @@ public class RenderTileTinyPotato extends TileEntityRenderer<TileTinyPotato> {
 	}
 
 	private static ResourceLocation taterLocation(String name) {
-		return new ResourceLocation(LibMisc.MOD_ID, LibResources.PREFIX_TINY_POTATO + normalizeName(name));
+		return new ResourceLocation(LibMisc.MOD_ID, LibResources.PREFIX_TINY_POTATO + "/" + normalizeName(name));
 	}
 
 	private static String normalizeName(String name) {


### PR DESCRIPTION
Somehow there was an extra `/` appearing in model names when iterating over the resource locations. This PR fixes that.

???
![what](https://user-images.githubusercontent.com/11538216/108088974-fb517600-7070-11eb-93ae-9b40a80688d1.png)
---
![twontater](https://user-images.githubusercontent.com/11538216/108088932-ed9bf080-7070-11eb-923e-a388fef617e3.png)
