### PR TITLE
Use a trie to resolve tiny potato shaders

### DIFF
--- a/src/main/java/vazkii/botania/client/core/helper/TinyPotatoShaderHelper.java
+++ b/src/main/java/vazkii/botania/client/core/helper/TinyPotatoShaderHelper.java
@@ -1,0 +1,116 @@
+package vazkii.botania.client.core.helper;
+
+import com.mojang.datafixers.util.Pair;
+import it.unimi.dsi.fastutil.chars.Char2ObjectMap;
+import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public class TinyPotatoShaderHelper {
+    private static final Trie<ShaderHelper.BotaniaShader> SHADERS = new Trie<>();
+
+    static {
+        SHADERS.put("gaia", ShaderHelper.BotaniaShader.DOPPLEGANGER);
+        SHADERS.put("hot", ShaderHelper.BotaniaShader.HALO);
+        SHADERS.put("magic", ShaderHelper.BotaniaShader.ENCHANTER_RUNE);
+        SHADERS.put("gold", ShaderHelper.BotaniaShader.GOLD);
+        SHADERS.put("snoop", ShaderHelper.BotaniaShader.TERRA_PLATE);
+    }
+
+    public static Pair<ShaderHelper.BotaniaShader, String> stripShaderName(String name) {
+        Trie.TrieResult<ShaderHelper.BotaniaShader> result = SHADERS.lookup(name);
+        if (result == null) {
+            return Pair.of(null, name);
+        } else {
+            return Pair.of(result.value, name.substring(result.keyLength).trim());
+        }
+    }
+
+    private static class Trie<T> {
+        private final TrieNode root = new TrieNode();
+
+        public void put(String key, T value) {
+            TrieNode node = root;
+            for (int i = 0; i < key.length(); i++) {
+                char c = key.charAt(i);
+                node = node.children.computeIfAbsent(c, $ -> new TrieNode());
+            }
+            node.value = value;
+        }
+
+        @Nullable
+        public TrieResult<T> lookup(String key) {
+            TrieNode node = root;
+            int keyLength = 0;
+            T found = node.value;
+            int i;
+            for (i = 0; i < key.length(); i++) {
+                node = node.children.get(key.charAt(i));
+                if (node == null) {
+                    break;
+                }
+                if (node.value != null) {
+                    keyLength = i + 1;
+                    found = node.value;
+                }
+            }
+            if (found != null) {
+                return new TrieResult<>(keyLength, found);
+            }
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return "Trie" + root;
+        }
+
+        public static class TrieResult<T> {
+            public final int keyLength;
+            public final T value;
+
+            TrieResult(int keyLength, T value) {
+                this.keyLength = keyLength;
+                this.value = value;
+            }
+
+            @Override
+            public String toString() {
+                return "TrieResult{" +
+                       "keyLength=" + keyLength +
+                       ", value=" + value +
+                       '}';
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+                TrieResult<?> that = (TrieResult<?>) o;
+                return keyLength == that.keyLength && Objects.equals(value, that.value);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(keyLength, value);
+            }
+        }
+
+        private class TrieNode {
+            @Nullable
+            T value;
+            final Char2ObjectMap<TrieNode> children = new Char2ObjectOpenHashMap<>();
+
+            @Override
+            public String toString() {
+                StringBuilder sb = new StringBuilder("TrieNode");
+                if (value != null) {
+                    sb.append("[").append(value).append("]");
+                }
+                sb.append(children);
+                return sb.toString();
+            }
+        }
+    }
+}

--- a/src/main/java/vazkii/botania/client/core/helper/TinyPotatoShaderHelper.java
+++ b/src/main/java/vazkii/botania/client/core/helper/TinyPotatoShaderHelper.java
@@ -95,10 +95,12 @@ public class TinyPotatoShaderHelper {
 
 			@Override
 			public boolean equals(Object o) {
-				if (this == o)
+				if (this == o) {
 					return true;
-				if (o == null || getClass() != o.getClass())
+				}
+				if (o == null || getClass() != o.getClass()) {
 					return false;
+				}
 				TrieResult<?> that = (TrieResult<?>) o;
 				return keyLength == that.keyLength && Objects.equals(value, that.value);
 			}

--- a/src/main/java/vazkii/botania/client/core/helper/TinyPotatoShaderHelper.java
+++ b/src/main/java/vazkii/botania/client/core/helper/TinyPotatoShaderHelper.java
@@ -1,116 +1,128 @@
+/*
+ * This class is distributed as part of the Botania Mod.
+ * Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ */
 package vazkii.botania.client.core.helper;
 
 import com.mojang.datafixers.util.Pair;
+
 import it.unimi.dsi.fastutil.chars.Char2ObjectMap;
 import it.unimi.dsi.fastutil.chars.Char2ObjectOpenHashMap;
 
 import javax.annotation.Nullable;
+
 import java.util.Objects;
 
 public class TinyPotatoShaderHelper {
-    private static final Trie<ShaderHelper.BotaniaShader> SHADERS = new Trie<>();
+	private static final Trie<ShaderHelper.BotaniaShader> SHADERS = new Trie<>();
 
-    static {
-        SHADERS.put("gaia", ShaderHelper.BotaniaShader.DOPPLEGANGER);
-        SHADERS.put("hot", ShaderHelper.BotaniaShader.HALO);
-        SHADERS.put("magic", ShaderHelper.BotaniaShader.ENCHANTER_RUNE);
-        SHADERS.put("gold", ShaderHelper.BotaniaShader.GOLD);
-        SHADERS.put("snoop", ShaderHelper.BotaniaShader.TERRA_PLATE);
-    }
+	static {
+		SHADERS.put("gaia", ShaderHelper.BotaniaShader.DOPPLEGANGER);
+		SHADERS.put("hot", ShaderHelper.BotaniaShader.HALO);
+		SHADERS.put("magic", ShaderHelper.BotaniaShader.ENCHANTER_RUNE);
+		SHADERS.put("gold", ShaderHelper.BotaniaShader.GOLD);
+		SHADERS.put("snoop", ShaderHelper.BotaniaShader.TERRA_PLATE);
+	}
 
-    public static Pair<ShaderHelper.BotaniaShader, String> stripShaderName(String name) {
-        Trie.TrieResult<ShaderHelper.BotaniaShader> result = SHADERS.lookup(name);
-        if (result == null) {
-            return Pair.of(null, name);
-        } else {
-            return Pair.of(result.value, name.substring(result.keyLength).trim());
-        }
-    }
+	public static Pair<ShaderHelper.BotaniaShader, String> stripShaderName(String name) {
+		Trie.TrieResult<ShaderHelper.BotaniaShader> result = SHADERS.lookup(name);
+		if (result == null) {
+			return Pair.of(null, name);
+		} else {
+			return Pair.of(result.value, name.substring(result.keyLength).trim());
+		}
+	}
 
-    private static class Trie<T> {
-        private final TrieNode root = new TrieNode();
+	private static class Trie<T> {
+		private final TrieNode root = new TrieNode();
 
-        public void put(String key, T value) {
-            TrieNode node = root;
-            for (int i = 0; i < key.length(); i++) {
-                char c = key.charAt(i);
-                node = node.children.computeIfAbsent(c, $ -> new TrieNode());
-            }
-            node.value = value;
-        }
+		public void put(String key, T value) {
+			TrieNode node = root;
+			for (int i = 0; i < key.length(); i++) {
+				char c = key.charAt(i);
+				node = node.children.computeIfAbsent(c, $ -> new TrieNode());
+			}
+			node.value = value;
+		}
 
-        @Nullable
-        public TrieResult<T> lookup(String key) {
-            TrieNode node = root;
-            int keyLength = 0;
-            T found = node.value;
-            int i;
-            for (i = 0; i < key.length(); i++) {
-                node = node.children.get(key.charAt(i));
-                if (node == null) {
-                    break;
-                }
-                if (node.value != null) {
-                    keyLength = i + 1;
-                    found = node.value;
-                }
-            }
-            if (found != null) {
-                return new TrieResult<>(keyLength, found);
-            }
-            return null;
-        }
+		@Nullable
+		public TrieResult<T> lookup(String key) {
+			TrieNode node = root;
+			int keyLength = 0;
+			T found = node.value;
+			int i;
+			for (i = 0; i < key.length(); i++) {
+				node = node.children.get(key.charAt(i));
+				if (node == null) {
+					break;
+				}
+				if (node.value != null) {
+					keyLength = i + 1;
+					found = node.value;
+				}
+			}
+			if (found != null) {
+				return new TrieResult<>(keyLength, found);
+			}
+			return null;
+		}
 
-        @Override
-        public String toString() {
-            return "Trie" + root;
-        }
+		@Override
+		public String toString() {
+			return "Trie" + root;
+		}
 
-        public static class TrieResult<T> {
-            public final int keyLength;
-            public final T value;
+		public static class TrieResult<T> {
+			public final int keyLength;
+			public final T value;
 
-            TrieResult(int keyLength, T value) {
-                this.keyLength = keyLength;
-                this.value = value;
-            }
+			TrieResult(int keyLength, T value) {
+				this.keyLength = keyLength;
+				this.value = value;
+			}
 
-            @Override
-            public String toString() {
-                return "TrieResult{" +
-                       "keyLength=" + keyLength +
-                       ", value=" + value +
-                       '}';
-            }
+			@Override
+			public String toString() {
+				return "TrieResult{" +
+						"keyLength=" + keyLength +
+						", value=" + value +
+						'}';
+			}
 
-            @Override
-            public boolean equals(Object o) {
-                if (this == o) return true;
-                if (o == null || getClass() != o.getClass()) return false;
-                TrieResult<?> that = (TrieResult<?>) o;
-                return keyLength == that.keyLength && Objects.equals(value, that.value);
-            }
+			@Override
+			public boolean equals(Object o) {
+				if (this == o)
+					return true;
+				if (o == null || getClass() != o.getClass())
+					return false;
+				TrieResult<?> that = (TrieResult<?>) o;
+				return keyLength == that.keyLength && Objects.equals(value, that.value);
+			}
 
-            @Override
-            public int hashCode() {
-                return Objects.hash(keyLength, value);
-            }
-        }
+			@Override
+			public int hashCode() {
+				return Objects.hash(keyLength, value);
+			}
+		}
 
-        private class TrieNode {
-            @Nullable
-            T value;
-            final Char2ObjectMap<TrieNode> children = new Char2ObjectOpenHashMap<>();
+		private class TrieNode {
+			@Nullable
+			T value;
+			final Char2ObjectMap<TrieNode> children = new Char2ObjectOpenHashMap<>();
 
-            @Override
-            public String toString() {
-                StringBuilder sb = new StringBuilder("TrieNode");
-                if (value != null) {
-                    sb.append("[").append(value).append("]");
-                }
-                sb.append(children);
-                return sb.toString();
-            }
-        }
-    }
+			@Override
+			public String toString() {
+				StringBuilder sb = new StringBuilder("TrieNode");
+				if (value != null) {
+					sb.append("[").append(value).append("]");
+				}
+				sb.append(children);
+				return sb.toString();
+			}
+		}
+	}
 }

--- a/src/main/java/vazkii/botania/client/render/tile/RenderTileTinyPotato.java
+++ b/src/main/java/vazkii/botania/client/render/tile/RenderTileTinyPotato.java
@@ -41,6 +41,7 @@ import vazkii.botania.client.core.handler.ContributorFancinessHandler;
 import vazkii.botania.client.core.handler.MiscellaneousIcons;
 import vazkii.botania.client.core.helper.ShaderHelper;
 import vazkii.botania.client.core.helper.ShaderWrappedRenderLayer;
+import vazkii.botania.client.core.helper.TinyPotatoShaderHelper;
 import vazkii.botania.client.core.proxy.ClientProxy;
 import vazkii.botania.client.lib.LibResources;
 import vazkii.botania.common.block.tile.TileTinyPotato;
@@ -63,32 +64,8 @@ public class RenderTileTinyPotato extends TileEntityRenderer<TileTinyPotato> {
 		super(manager);
 	}
 
-	private static boolean matches(String name, String match) {
-		return name.equals(match) || name.startsWith(match + " ");
-	}
-
-	private static String removeFromFront(String name, String match) {
-		return name.substring(match.length()).trim();
-	}
-
 	public static IBakedModel getModelFromDisplayName(ITextComponent displayName) {
-		return getModel(stripShaderName(displayName.getString().trim().toLowerCase()).getSecond());
-	}
-
-	private static Pair<ShaderHelper.BotaniaShader, String> stripShaderName(String name) {
-		if (matches(name, "gaia")) {
-			return Pair.of(ShaderHelper.BotaniaShader.DOPPLEGANGER, removeFromFront(name, "gaia"));
-		} else if (matches(name, "hot")) {
-			return Pair.of(ShaderHelper.BotaniaShader.HALO, removeFromFront(name, "hot"));
-		} else if (matches(name, "magic")) {
-			return Pair.of(ShaderHelper.BotaniaShader.ENCHANTER_RUNE, removeFromFront(name, "magic"));
-		} else if (matches(name, "gold")) {
-			return Pair.of(ShaderHelper.BotaniaShader.GOLD, removeFromFront(name, "gold"));
-		} else if (matches(name, "snoop")) {
-			return Pair.of(ShaderHelper.BotaniaShader.TERRA_PLATE, removeFromFront(name, "snoop"));
-		} else {
-			return Pair.of(null, name);
-		}
+		return getModel(TinyPotatoShaderHelper.stripShaderName(displayName.getString().trim().toLowerCase()).getSecond());
 	}
 
 	private static IBakedModel getModel(String name) {
@@ -123,7 +100,7 @@ public class RenderTileTinyPotato extends TileEntityRenderer<TileTinyPotato> {
 		ms.push();
 
 		String name = potato.name.getString().toLowerCase().trim();
-		Pair<ShaderHelper.BotaniaShader, String> shaderStrippedName = stripShaderName(name);
+		Pair<ShaderHelper.BotaniaShader, String> shaderStrippedName = TinyPotatoShaderHelper.stripShaderName(name);
 		ShaderHelper.BotaniaShader shader = shaderStrippedName.getFirst();
 		name = shaderStrippedName.getSecond();
 		RenderType layer = getRenderLayer(shader);


### PR DESCRIPTION
This PR likely offers negligible performance benefit, if any, because of the relatively high constant factor in looking up the character for each node: [incredibly detailed benchmarking](https://gist.github.com/eutropius225/e5d7688c81e6512671fe54c1f02b04b0) has shown that the trie-based lookups are usually a little slower than the hardcoded lookups.

Nevertheless, this system is more extensible (please) and has a much better asymptotic time complexity. Additionally, planting tries (maybe it was trees?) is good for the environment.