### PR TITLE
Remove the and slimeblock requirement for Unethical TNT

### DIFF
--- a/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEntropinnyum.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileEntropinnyum.java
@@ -70,11 +70,9 @@ public class SubTileEntropinnyum extends TileEntityGeneratingFlower {
 
 			if (state.getBlock() instanceof DetectorRailBlock) {
 				rails++;
-			} else if (state.getBlock() instanceof SlimeBlock || state.getBlock() instanceof HoneyBlock) {
-				slimes++;
 			}
 
-			if (movingPistons > 0 && rails > 0 && slimes > 0) {
+			if (movingPistons > 0 && rails > 0) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Slime block is not necessary to create a duped tnt , here is a image of that
![图片](https://user-images.githubusercontent.com/39846845/113138880-f3344b00-9258-11eb-81ca-4ccf6c74912b.png)
this setup is designed to not even use sticky piston , so literally doesnt need any slime or slimeblock 
If anyone want to check it out I will leave a world download 