### PR TITLE
Rod of Elytraboosting

### DIFF
--- a/src/main/java/vazkii/botania/common/item/rod/ItemTornadoRod.java
+++ b/src/main/java/vazkii/botania/common/item/rod/ItemTornadoRod.java
@@ -83,7 +83,10 @@ public class ItemTornadoRod extends Item implements IManaUsingItem, IAvatarWield
 					player.playSound(ModSounds.airRod, 0.1F, 0.25F);
 					for (int i = 0; i < 5; i++) {
 						WispParticleData data = WispParticleData.wisp(0.35F + (float) Math.random() * 0.1F, 0.25F, 0.25F, 0.25F);
-						world.addParticle(data, player.getPosX(), player.getPosY(), player.getPosZ(), 0.2F * (float) (Math.random() - 0.5), -0.01F * (float) Math.random(), 0.2F * (float) (Math.random() - 0.5));
+						world.addParticle(data, player.getPosX(), player.getPosY(), player.getPosZ(),
+								0.2F * (float) (Math.random() - 0.5),
+								-0.01F * (float) Math.random(),
+								0.2F * (float) (Math.random() - 0.5));
 					}
 				}
 
@@ -185,20 +188,20 @@ public class ItemTornadoRod extends Item implements IManaUsingItem, IAvatarWield
 
 	private void doAvatarElytraBoost(PlayerEntity p, World world) {
 		Vector3d lookDir = p.getLookVec();
-		double mult = 1.25*Math.pow(2.71828, -0.5 * p.getMotion().length());
-		p.setMotion(p.getMotion().getX() + lookDir.getX() * mult
-				, p.getMotion().getY() + lookDir.getY() * mult
-				, p.getMotion().getZ() + lookDir.getZ() * mult);
+		double mult = 1.25 * Math.pow(2.71828, -0.5 * p.getMotion().length());
+		p.setMotion(p.getMotion().getX() + lookDir.getX() * mult,
+				p.getMotion().getY() + lookDir.getY() * mult,
+				p.getMotion().getZ() + lookDir.getZ() * mult);
 
 		for (int i = 0; i < 20; i++) {
 			for (int j = 0; j < 5; j++) {
 				WispParticleData data = WispParticleData.wisp(0.35F + (float) Math.random() * 0.1F, 0.25F, 0.25F, 0.25F);
-				world.addParticle(data, p.getPosX() + lookDir.getX() * i
-						, p.getPosY() + lookDir.getY() * i
-						, p.getPosZ() + lookDir.getZ() * i
-						, 0.2F * (float) (Math.random() - 0.5) * (Math.abs(lookDir.getY()) + Math.abs(lookDir.getZ())) + -0.01F * (float) Math.random() * lookDir.getX()
-						, 0.2F * (float) (Math.random() - 0.5) * (Math.abs(lookDir.getX()) + Math.abs(lookDir.getZ())) + -0.01F * (float) Math.random() * lookDir.getY()
-						, 0.2F * (float) (Math.random() - 0.5) * (Math.abs(lookDir.getY()) + Math.abs(lookDir.getX())) + -0.01F * (float) Math.random() * lookDir.getZ());
+				world.addParticle(data, p.getPosX() + lookDir.getX() * i,
+						p.getPosY() + lookDir.getY() * i,
+						p.getPosZ() + lookDir.getZ() * i,
+						0.2F * (float) (Math.random() - 0.5) * (Math.abs(lookDir.getY()) + Math.abs(lookDir.getZ())) + -0.01F * (float) Math.random() * lookDir.getX(),
+						0.2F * (float) (Math.random() - 0.5) * (Math.abs(lookDir.getX()) + Math.abs(lookDir.getZ())) + -0.01F * (float) Math.random() * lookDir.getY(),
+						0.2F * (float) (Math.random() - 0.5) * (Math.abs(lookDir.getY()) + Math.abs(lookDir.getX())) + -0.01F * (float) Math.random() * lookDir.getZ());
 			}
 		}
 	}
@@ -209,7 +212,11 @@ public class ItemTornadoRod extends Item implements IManaUsingItem, IAvatarWield
 		for (int i = 0; i < 20; i++) {
 			for (int j = 0; j < 5; j++) {
 				WispParticleData data = WispParticleData.wisp(0.35F + (float) Math.random() * 0.1F, 0.25F, 0.25F, 0.25F);
-				world.addParticle(data, p.getPosX(), p.getPosY() + i, p.getPosZ(), 0.2F * (float) (Math.random() - 0.5), -0.01F * (float) Math.random(), 0.2F * (float) (Math.random() - 0.5));
+				world.addParticle(data, p.getPosX(),
+						p.getPosY() + i, p.getPosZ(),
+						0.2F * (float) (Math.random() - 0.5),
+						-0.01F * (float) Math.random(),
+						0.2F * (float) (Math.random() - 0.5));
 			}
 		}
 	}

--- a/src/main/java/vazkii/botania/common/item/rod/ItemTornadoRod.java
+++ b/src/main/java/vazkii/botania/common/item/rod/ItemTornadoRod.java
@@ -71,7 +71,12 @@ public class ItemTornadoRod extends Item implements IManaUsingItem, IAvatarWield
 					player.fallDistance = 0F;
 					double my = IManaProficiencyArmor.hasProficiency(player, stack) ? 1.6 : 1.25;
 					Vector3d oldMot = player.getMotion();
-					player.setMotion(new Vector3d(oldMot.getX(), my, oldMot.getZ()));
+					if (player.isElytraFlying()) {
+						Vector3d lookDir = player.getLookVec();
+						player.setMotion(new Vector3d(lookDir.getX() * my, lookDir.getY() * my, lookDir.getZ() * my));
+					} else {
+						player.setMotion(new Vector3d(oldMot.getX(), my, oldMot.getZ()));
+					}
 
 					player.playSound(ModSounds.airRod, 0.1F, 0.25F);
 					for (int i = 0; i < 5; i++) {
@@ -146,20 +151,45 @@ public class ItemTornadoRod extends Item implements IManaUsingItem, IAvatarWield
 			int rangeY = 3;
 			List<PlayerEntity> players = world.getEntitiesWithinAABB(PlayerEntity.class, new AxisAlignedBB(te.getPos().add(-0.5 - range, -0.5 - rangeY, -0.5 - range), te.getPos().add(0.5 + range, 0.5 + rangeY, 0.5 + range)));
 			for (PlayerEntity p : players) {
-				if (p.getMotion().getY() > 0.3 && p.getMotion().getY() < 2 && !p.isSneaking()) {
-					p.setMotion(p.getMotion().getX(), 2.8, p.getMotion().getZ());
-
-					for (int i = 0; i < 20; i++) {
-						for (int j = 0; j < 5; j++) {
-							WispParticleData data = WispParticleData.wisp(0.35F + (float) Math.random() * 0.1F, 0.25F, 0.25F, 0.25F);
-							world.addParticle(data, p.getPosX(), p.getPosY() + i, p.getPosZ(), 0.2F * (float) (Math.random() - 0.5), -0.01F * (float) Math.random(), 0.2F * (float) (Math.random() - 0.5));
+				if (!p.isSneaking()) {
+					if (p.getMotion().length() > 0.2 && p.getMotion().length() < 1.20 && p.isElytraFlying()) {
+						Vector3d lookDir = (p.getLookVec());
+						p.setMotion(p.getMotion().getX() + lookDir.getX() * 1.25
+								, p.getMotion().getY() + lookDir.getY() * 1.25
+								, p.getMotion().getZ() + lookDir.getZ() * 1.25);
+						for (int i = 0; i < 20; i++) {
+							for (int j = 0; j < 5; j++) {
+								WispParticleData data = WispParticleData.wisp(0.35F + (float) Math.random() * 0.1F, 0.25F, 0.25F, 0.25F);
+								world.addParticle(data, p.getPosX() + lookDir.getX() * i
+										, p.getPosY() + lookDir.getY() * i
+										, p.getPosZ() + lookDir.getZ() * i
+										, 0.2F * (float) (Math.random() - 0.5) * (Math.abs(lookDir.getY()) + Math.abs(lookDir.getZ())) + -0.01F * (float) Math.random() * lookDir.getX()
+										, 0.2F * (float) (Math.random() - 0.5) * (Math.abs(lookDir.getX()) + Math.abs(lookDir.getZ())) + -0.01F * (float) Math.random() * lookDir.getY()					//FIX YOUR SHIT, MAKE PARTICLES GO THE RIGHT WAY
+										, 0.2F * (float) (Math.random() - 0.5) * (Math.abs(lookDir.getY()) + Math.abs(lookDir.getX())) + -0.01F * (float) Math.random() * lookDir.getZ());
+							}
 						}
-					}
 
-					if (!world.isRemote) {
-						p.world.playSound(null, p.getPosX(), p.getPosY(), p.getPosZ(), ModSounds.dash, SoundCategory.PLAYERS, 1F, 1F);
-						p.addPotionEffect(new EffectInstance(ModPotions.featherfeet, 100, 0));
-						tile.receiveMana(-COST);
+						if (!world.isRemote) {
+							p.world.playSound(null, p.getPosX(), p.getPosY(), p.getPosZ(), ModSounds.dash, SoundCategory.PLAYERS, 1F, 1F);
+							p.addPotionEffect(new EffectInstance(ModPotions.featherfeet, 100, 0));
+							tile.receiveMana(-COST);
+						}
+
+					} else if (p.getMotion().getY() > 0.3 && p.getMotion().getY() < 2 && !p.isElytraFlying()) {
+						p.setMotion(p.getMotion().getX(), 2.8, p.getMotion().getZ());
+
+						for (int i = 0; i < 20; i++) {
+							for (int j = 0; j < 5; j++) {
+								WispParticleData data = WispParticleData.wisp(0.35F + (float) Math.random() * 0.1F, 0.25F, 0.25F, 0.25F);
+								world.addParticle(data, p.getPosX(), p.getPosY() + i, p.getPosZ(), 0.2F * (float) (Math.random() - 0.5), -0.01F * (float) Math.random(), 0.2F * (float) (Math.random() - 0.5));
+							}
+						}
+
+						if (!world.isRemote) {
+							p.world.playSound(null, p.getPosX(), p.getPosY(), p.getPosZ(), ModSounds.dash, SoundCategory.PLAYERS, 1F, 1F);
+							p.addPotionEffect(new EffectInstance(ModPotions.featherfeet, 100, 0));
+							tile.receiveMana(-COST);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Idea by LeoBeliik
- Make the Rod of the Skies give an elytra boost which I believe is *slightly* worse than the lowest tier firework.
- Make Livingwood Avatars holding said rod give people flying by them a boost. This boost is a bit stronger than the handheld rod boost. No this doesn't stack infinitely, no human railguns for you.

So yeah, this is pr the for the videos I kept sending on Vazcord.
I believe the intensity of the boosts aren't all too unbalanced- the avatars are stationary, require some infrastructure, and its boosts aren't continuous like the rod's, so they can be a bit bigger.
Similarly, the normal rod boost is about on par with a regular lowest tier firework, if not slightly worse, so I believe that's at least decent.