### PR TITLE
Makes luminizer shaders not square

### DIFF
--- a/src/main/resources/assets/botania/shader/halo.frag
+++ b/src/main/resources/assets/botania/shader/halo.frag
@@ -11,7 +11,7 @@ void main() {
    
    for(int i = -4 ; i < 4; i++)
         for(int j = -3; j < 3; j++)
-            sum += texture2D(bgl_RenderedTexture, texcoord + vec2(0, 0) * 0.004) * 0.25;
+            sum += texture2D(bgl_RenderedTexture, texcoord) * 0.25;
 
     if(texture2D(bgl_RenderedTexture, texcoord).r < 0.3)
        gl_FragColor = sum * sum * 0.012 + texture2D(bgl_RenderedTexture, texcoord);

--- a/src/main/resources/assets/botania/shader/halo.frag
+++ b/src/main/resources/assets/botania/shader/halo.frag
@@ -11,7 +11,7 @@ void main() {
    
    for(int i = -4 ; i < 4; i++)
         for(int j = -3; j < 3; j++)
-            sum += texture2D(bgl_RenderedTexture, texcoord + vec2(j, i) * 0.004) * 0.25;
+            sum += texture2D(bgl_RenderedTexture, texcoord + vec2(0, 0) * 0.004) * 0.25;
 
     if(texture2D(bgl_RenderedTexture, texcoord).r < 0.3)
        gl_FragColor = sum * sum * 0.012 + texture2D(bgl_RenderedTexture, texcoord);


### PR DESCRIPTION
**Before the changes**
https://user-images.githubusercontent.com/11804768/114567336-8605ba00-9c49-11eb-9f37-c904111f58f6.mp4

**After the changes**
https://user-images.githubusercontent.com/11804768/114567400-974ec680-9c49-11eb-8e96-a6990b6afe73.mp4


This does not have a visible change on the Babylon key attack or the tiara's halo for what I tested.

This Fixes #3638