### PR TITLE
Add API method to register IHornHarvestable instances

### DIFF
--- a/src/main/java/vazkii/botania/api/BotaniaAPI.java
+++ b/src/main/java/vazkii/botania/api/BotaniaAPI.java
@@ -152,8 +152,8 @@ public interface BotaniaAPI {
 	/**
 	 * Make Botania recognize a Block as IHornHarvestable without explicitly implementing the interface
 	 *
-	 * @param blockId		The block ID
-	 * @param harvestable	The harvestable
+	 * @param blockId     The block ID
+	 * @param harvestable The harvestable
 	 */
 	default void registerHornHarvestableBlock(ResourceLocation blockId, IHornHarvestable harvestable) {
 

--- a/src/main/java/vazkii/botania/api/BotaniaAPI.java
+++ b/src/main/java/vazkii/botania/api/BotaniaAPI.java
@@ -28,12 +28,14 @@ import vazkii.botania.api.corporea.ICorporeaNodeDetector;
 import vazkii.botania.api.internal.DummyManaNetwork;
 import vazkii.botania.api.internal.IManaNetwork;
 import vazkii.botania.api.internal.OrechidOutput;
+import vazkii.botania.api.item.IHornHarvestable;
 
 import javax.annotation.Nonnull;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 
 public interface BotaniaAPI {
@@ -140,6 +142,20 @@ public interface BotaniaAPI {
 	 * @param transformer Function from color to a new block
 	 */
 	default void registerPaintableBlock(ResourceLocation blockId, Function<DyeColor, Block> transformer) {
+
+	}
+
+	default Optional<IHornHarvestable> getHornHarvestable(Block block) {
+		return Optional.empty();
+	}
+
+	/**
+	 * Make Botania recognize a Block as IHornHarvestable without explicitly implementing the interface
+	 *
+	 * @param blockId		The block ID
+	 * @param harvestable	The harvestable
+	 */
+	default void registerHornHarvestableBlock(ResourceLocation blockId, IHornHarvestable harvestable) {
 
 	}
 

--- a/src/main/java/vazkii/botania/api/item/IHornHarvestable.java
+++ b/src/main/java/vazkii/botania/api/item/IHornHarvestable.java
@@ -13,8 +13,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 /**
- * A Block that implements this can be uprooted by the various horns in Botania.
- * Alternatively, implementations of this can be registered independently via BotaniaAPI#registerHornHarvestableBlock
+ * This interface handles uprooting by the various horns in Botania.
+ * Implementations can be registered via BotaniaAPI#registerHornHarvestableBlock
  */
 public interface IHornHarvestable {
 

--- a/src/main/java/vazkii/botania/api/item/IHornHarvestable.java
+++ b/src/main/java/vazkii/botania/api/item/IHornHarvestable.java
@@ -14,6 +14,7 @@ import net.minecraft.world.World;
 
 /**
  * A Block that implements this can be uprooted by the various horns in Botania.
+ * Alternatively, implementations of this can be registered independently via BotaniaAPI#registerHornHarvestableBlock
  */
 public interface IHornHarvestable {
 

--- a/src/main/java/vazkii/botania/common/block/ModBlocks.java
+++ b/src/main/java/vazkii/botania/common/block/ModBlocks.java
@@ -43,6 +43,7 @@ import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 
+import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.item.IPetalApothecary;
 import vazkii.botania.api.state.BotaniaStateProps;
 import vazkii.botania.api.state.enums.AlfPortalState;
@@ -56,6 +57,7 @@ import vazkii.botania.common.block.mana.*;
 import vazkii.botania.common.block.string.*;
 import vazkii.botania.common.entity.EntityEnderAirBottle;
 import vazkii.botania.common.entity.EntityVineBall;
+import vazkii.botania.common.impl.DefaultHornHarvestable;
 import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.block.ItemBlockDreamwood;
 import vazkii.botania.common.item.block.ItemBlockElven;
@@ -624,6 +626,40 @@ public final class ModBlocks {
 		register(r, LibBlockNames.MOTIF_DAYBLOOM, motifDaybloom);
 		register(r, LibBlockNames.MOTIF_NIGHTSHADE, motifNightshade);
 		register(r, LibBlockNames.MOTIF_HYDROANGEAS, motifHydroangeas);
+
+		BotaniaAPI.instance().registerHornHarvestableBlock(whiteShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(orangeShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(magentaShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(lightBlueShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(yellowShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(limeShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(pinkShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(grayShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(lightGrayShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(cyanShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(purpleShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(blueShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(brownShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(greenShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(redShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(blackShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+
+		BotaniaAPI.instance().registerHornHarvestableBlock(whiteMushroom.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(orangeMushroom.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(magentaMushroom.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(lightBlueMushroom.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(yellowMushroom.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(limeMushroom.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(pinkMushroom.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(grayMushroom.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(lightGrayMushroom.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(cyanMushroom.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(purpleMushroom.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(blueMushroom.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(brownMushroom.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(greenMushroom.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(redMushroom.getRegistryName(), DefaultHornHarvestable.INSTANCE);
+		BotaniaAPI.instance().registerHornHarvestableBlock(blackShinyFlower.getRegistryName(), DefaultHornHarvestable.INSTANCE);
 	}
 
 	public static void registerItemBlocks(RegistryEvent.Register<Item> evt) {

--- a/src/main/java/vazkii/botania/common/block/decor/BlockModMushroom.java
+++ b/src/main/java/vazkii/botania/common/block/decor/BlockModMushroom.java
@@ -23,7 +23,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
-import vazkii.botania.api.item.IHornHarvestable;
 import vazkii.botania.api.recipe.ICustomApothecaryColor;
 import vazkii.botania.client.fx.SparkleParticleData;
 import vazkii.botania.common.core.handler.ConfigHandler;
@@ -32,7 +31,7 @@ import javax.annotation.Nonnull;
 
 import java.util.Random;
 
-public class BlockModMushroom extends MushroomBlock implements IHornHarvestable, ICustomApothecaryColor {
+public class BlockModMushroom extends MushroomBlock implements ICustomApothecaryColor {
 
 	private static final VoxelShape SHAPE = makeCuboidShape(4.8, 0, 4.8, 12.8, 16, 12.8);
 	public final DyeColor color;
@@ -73,19 +72,6 @@ public class BlockModMushroom extends MushroomBlock implements IHornHarvestable,
 			world.addParticle(data, pos.getX() + 0.3 + rand.nextFloat() * 0.5, pos.getY() + 0.5 + rand.nextFloat() * 0.5, pos.getZ() + 0.3 + rand.nextFloat() * 0.5, 0, 0, 0);
 		}
 	}
-
-	@Override
-	public boolean canHornHarvest(World world, BlockPos pos, ItemStack stack, EnumHornType hornType) {
-		return false;
-	}
-
-	@Override
-	public boolean hasSpecialHornHarvest(World world, BlockPos pos, ItemStack stack, EnumHornType hornType) {
-		return false;
-	}
-
-	@Override
-	public void harvestByHorn(World world, BlockPos pos, ItemStack stack, EnumHornType hornType) {}
 
 	@Override
 	public int getParticleColor(ItemStack stack) {

--- a/src/main/java/vazkii/botania/common/block/decor/BlockShinyFlower.java
+++ b/src/main/java/vazkii/botania/common/block/decor/BlockShinyFlower.java
@@ -10,17 +10,14 @@ package vazkii.botania.common.block.decor;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.item.DyeColor;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockReader;
-import net.minecraft.world.World;
 
-import vazkii.botania.api.item.IHornHarvestable;
 import vazkii.botania.common.block.BlockModFlower;
 
 import javax.annotation.Nonnull;
 
-public class BlockShinyFlower extends BlockModFlower implements IHornHarvestable {
+public class BlockShinyFlower extends BlockModFlower {
 
 	public BlockShinyFlower(DyeColor color, Properties builder) {
 		super(color, builder);
@@ -30,18 +27,5 @@ public class BlockShinyFlower extends BlockModFlower implements IHornHarvestable
 	public boolean canGrow(@Nonnull IBlockReader world, @Nonnull BlockPos pos, @Nonnull BlockState state, boolean fuckifiknow) {
 		return false;
 	}
-
-	@Override
-	public boolean canHornHarvest(World world, BlockPos pos, ItemStack stack, EnumHornType hornType) {
-		return false;
-	}
-
-	@Override
-	public boolean hasSpecialHornHarvest(World world, BlockPos pos, ItemStack stack, EnumHornType hornType) {
-		return false;
-	}
-
-	@Override
-	public void harvestByHorn(World world, BlockPos pos, ItemStack stack, EnumHornType hornType) {}
 
 }

--- a/src/main/java/vazkii/botania/common/impl/BotaniaAPIImpl.java
+++ b/src/main/java/vazkii/botania/common/impl/BotaniaAPIImpl.java
@@ -318,6 +318,10 @@ public class BotaniaAPIImpl implements BotaniaAPI {
 
 	@Override
 	public Optional<IHornHarvestable> getHornHarvestable(Block block) {
+		if (block instanceof IHornHarvestable) {
+			// callers of this method on blocks which still implement the interface should still receive the instance
+			return Optional.of((IHornHarvestable) block);
+		}
 		return Optional.ofNullable(hornHarvestableBlocks.getOrDefault(block.getRegistryName(), null));
 	}
 

--- a/src/main/java/vazkii/botania/common/impl/BotaniaAPIImpl.java
+++ b/src/main/java/vazkii/botania/common/impl/BotaniaAPIImpl.java
@@ -27,6 +27,7 @@ import vazkii.botania.api.brew.Brew;
 import vazkii.botania.api.corporea.ICorporeaNodeDetector;
 import vazkii.botania.api.internal.IManaNetwork;
 import vazkii.botania.api.internal.OrechidOutput;
+import vazkii.botania.api.item.IHornHarvestable;
 import vazkii.botania.client.fx.SparkleParticleData;
 import vazkii.botania.common.Botania;
 import vazkii.botania.common.block.subtile.functional.SubTileSolegnolia;
@@ -42,10 +43,7 @@ import vazkii.botania.common.lib.LibMisc;
 
 import javax.annotation.Nonnull;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -266,6 +264,7 @@ public class BotaniaAPIImpl implements BotaniaAPI {
 	private final Map<ResourceLocation, Integer> legacyOreWeights = new ConcurrentHashMap<>();
 	private final Map<ResourceLocation, Integer> legacyNetherOreWeights = new ConcurrentHashMap<>();
 	private final Map<ResourceLocation, Function<DyeColor, Block>> paintableBlocks = new ConcurrentHashMap<>();
+	private final Map<ResourceLocation, IHornHarvestable> hornHarvestableBlocks = new ConcurrentHashMap<>();
 
 	@Override
 	public List<OrechidOutput> getOrechidWeights() {
@@ -315,6 +314,16 @@ public class BotaniaAPIImpl implements BotaniaAPI {
 	@Override
 	public void registerPaintableBlock(ResourceLocation block, Function<DyeColor, Block> transformer) {
 		paintableBlocks.put(block, transformer);
+	}
+
+	@Override
+	public Optional<IHornHarvestable> getHornHarvestable(Block block) {
+		return Optional.ofNullable(hornHarvestableBlocks.getOrDefault(block.getRegistryName(), null));
+	}
+
+	@Override
+	public void registerHornHarvestableBlock(ResourceLocation block, IHornHarvestable harvestable) {
+		hornHarvestableBlocks.put(block, harvestable);
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/impl/DefaultHornHarvestable.java
+++ b/src/main/java/vazkii/botania/common/impl/DefaultHornHarvestable.java
@@ -1,0 +1,32 @@
+/*
+ * This class is distributed as part of the Botania Mod.
+ * Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ */
+package vazkii.botania.common.impl;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import vazkii.botania.api.item.IHornHarvestable;
+
+public class DefaultHornHarvestable implements IHornHarvestable {
+	public static final IHornHarvestable INSTANCE = new DefaultHornHarvestable();
+
+	@Override
+	public boolean canHornHarvest(World world, BlockPos pos, ItemStack stack, EnumHornType hornType) {
+		return false;
+	}
+
+	@Override
+	public boolean hasSpecialHornHarvest(World world, BlockPos pos, ItemStack stack, EnumHornType hornType) {
+		return false;
+	}
+
+	@Override
+	public void harvestByHorn(World world, BlockPos pos, ItemStack stack, EnumHornType hornType) {}
+}

--- a/src/main/java/vazkii/botania/common/item/ItemHorn.java
+++ b/src/main/java/vazkii/botania/common/item/ItemHorn.java
@@ -25,11 +25,13 @@ import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
+import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.item.IHornHarvestable;
 import vazkii.botania.api.item.IHornHarvestable.EnumHornType;
 import vazkii.botania.common.lib.ModTags;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -85,8 +87,10 @@ public class ItemHorn extends Item {
 		for (BlockPos pos : BlockPos.getAllInBoxMutable(srcPos.add(-range, -rangeY, -range),
 				srcPos.add(range, rangeY, range))) {
 			Block block = world.getBlockState(pos).getBlock();
-			if (block instanceof IHornHarvestable
-					? ((IHornHarvestable) block).canHornHarvest(world, pos, stack, type)
+			IHornHarvestable harvestable = getHarvestable(block);
+
+			if (harvestable != null
+					? harvestable.canHornHarvest(world, pos, stack, type)
 					: type == EnumHornType.WILD && block instanceof BushBlock && !block.isIn(ModTags.Blocks.SPECIAL_FLOWERS)
 							|| type == EnumHornType.CANOPY && BlockTags.LEAVES.contains(block)
 							|| type == EnumHornType.COVERING && block == Blocks.SNOW) {
@@ -101,13 +105,22 @@ public class ItemHorn extends Item {
 			BlockPos currCoords = coords.get(i);
 			BlockState state = world.getBlockState(currCoords);
 			Block block = state.getBlock();
+			IHornHarvestable harvestable = getHarvestable(block);
 
-			if (block instanceof IHornHarvestable && ((IHornHarvestable) block).hasSpecialHornHarvest(world, currCoords, stack, type)) {
-				((IHornHarvestable) block).harvestByHorn(world, currCoords, stack, type);
+			if (harvestable != null && harvestable.hasSpecialHornHarvest(world, currCoords, stack, type)) {
+				harvestable.harvestByHorn(world, currCoords, stack, type);
 			} else {
 				world.destroyBlock(currCoords, true);
 			}
 		}
+	}
+
+	@Nullable
+	public static IHornHarvestable getHarvestable(Block block) {
+		if(block instanceof IHornHarvestable) {
+			return (IHornHarvestable) block;
+		}
+		return BotaniaAPI.instance().getHornHarvestable(block).orElse(null);
 	}
 
 }

--- a/src/main/java/vazkii/botania/common/item/ItemHorn.java
+++ b/src/main/java/vazkii/botania/common/item/ItemHorn.java
@@ -117,7 +117,7 @@ public class ItemHorn extends Item {
 
 	@Nullable
 	public static IHornHarvestable getHarvestable(Block block) {
-		if(block instanceof IHornHarvestable) {
+		if (block instanceof IHornHarvestable) {
 			return (IHornHarvestable) block;
 		}
 		return BotaniaAPI.instance().getHornHarvestable(block).orElse(null);

--- a/src/main/java/vazkii/botania/common/item/ItemHorn.java
+++ b/src/main/java/vazkii/botania/common/item/ItemHorn.java
@@ -31,7 +31,6 @@ import vazkii.botania.api.item.IHornHarvestable.EnumHornType;
 import vazkii.botania.common.lib.ModTags;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -87,7 +86,7 @@ public class ItemHorn extends Item {
 		for (BlockPos pos : BlockPos.getAllInBoxMutable(srcPos.add(-range, -rangeY, -range),
 				srcPos.add(range, rangeY, range))) {
 			Block block = world.getBlockState(pos).getBlock();
-			IHornHarvestable harvestable = getHarvestable(block);
+			IHornHarvestable harvestable = BotaniaAPI.instance().getHornHarvestable(block).orElse(null);
 
 			if (harvestable != null
 					? harvestable.canHornHarvest(world, pos, stack, type)
@@ -105,7 +104,7 @@ public class ItemHorn extends Item {
 			BlockPos currCoords = coords.get(i);
 			BlockState state = world.getBlockState(currCoords);
 			Block block = state.getBlock();
-			IHornHarvestable harvestable = getHarvestable(block);
+			IHornHarvestable harvestable = BotaniaAPI.instance().getHornHarvestable(block).orElse(null);
 
 			if (harvestable != null && harvestable.hasSpecialHornHarvest(world, currCoords, stack, type)) {
 				harvestable.harvestByHorn(world, currCoords, stack, type);
@@ -113,14 +112,6 @@ public class ItemHorn extends Item {
 				world.destroyBlock(currCoords, true);
 			}
 		}
-	}
-
-	@Nullable
-	public static IHornHarvestable getHarvestable(Block block) {
-		if (block instanceof IHornHarvestable) {
-			return (IHornHarvestable) block;
-		}
-		return BotaniaAPI.instance().getHornHarvestable(block).orElse(null);
 	}
 
 }


### PR DESCRIPTION
This removes the need to explicitly implement the interface in block classes.