### PR TITLE
Added a missing doc param to the rune altar

### DIFF
--- a/src/main/java/vazkii/botania/common/integration/crafttweaker/RuneAltarRecipeManager.java
+++ b/src/main/java/vazkii/botania/common/integration/crafttweaker/RuneAltarRecipeManager.java
@@ -46,6 +46,7 @@ public class RuneAltarRecipeManager implements IRecipeManager {
 	 *
 	 * @docParam name "petal_apothecary_test"
 	 * @docParam output <item:minecraft:diamond>
+	 * @docParam mana 5000
 	 * @docParam inputs <item:botania:rune_>, <item:botania:orange_petal>, <item:botania:red_petal>
 	 */
 	@ZenCodeType.Method


### PR DESCRIPTION
Without it we can't generate an example for it, so on the docs it looks like:
```zenscript
RuneAltar.addRecipe(name as string, output as IItemStack, mana as int, inputs as IIngredient[]) as void
```

instead of
```
<recipetype:botania:runic_altar>.addRecipe("petal_apothecary_test", <item:minecraft:diamond>, 5000, <item:botania:rune_>, <item:botania:orange_petal>, <item:botania:red_petal>);
```