### PR TITLE
Gaia guardian tweaks

### DIFF
--- a/src/main/java/vazkii/botania/common/core/loot/ModLootModifiers.java
+++ b/src/main/java/vazkii/botania/common/core/loot/ModLootModifiers.java
@@ -17,11 +17,13 @@ import static vazkii.botania.common.lib.ResourceLocationHelper.prefix;
 public class ModLootModifiers {
 	public static final LootConditionType TRUE_GUARDIAN_KILLER = new LootConditionType(new TrueGuardianKiller.Serializer());
 	public static final LootConditionType ENABLE_RELICS = new LootConditionType(new EnableRelics.Serializer());
+	public static final LootConditionType KILLED_BY_REAL_PLAYER = new LootConditionType(new RealPlayerCondition.Serializer());
 	public static final LootFunctionType BIND_UUID = new LootFunctionType(new BindUuid.Serializer());
 
 	public static void init() {
 		Registry.register(Registry.LOOT_CONDITION_TYPE, prefix("true_guardian_killer"), TRUE_GUARDIAN_KILLER);
 		Registry.register(Registry.LOOT_CONDITION_TYPE, prefix("enable_relics"), ENABLE_RELICS);
+		Registry.register(Registry.LOOT_CONDITION_TYPE, prefix("killed_by_player"), KILLED_BY_REAL_PLAYER);
 		Registry.register(Registry.LOOT_FUNCTION_TYPE, prefix("bind_uuid"), BIND_UUID);
 	}
 }

--- a/src/main/java/vazkii/botania/common/core/loot/RealPlayerCondition.java
+++ b/src/main/java/vazkii/botania/common/core/loot/RealPlayerCondition.java
@@ -1,0 +1,63 @@
+/*
+ * This class is distributed as part of the Botania Mod.
+ * Get the Source Code in github:
+ * https://github.com/Vazkii/Botania
+ *
+ * Botania is Open Source and distributed under the
+ * Botania License: http://botaniamod.net/license.php
+ */
+package vazkii.botania.common.core.loot;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.loot.ILootSerializer;
+import net.minecraft.loot.LootConditionType;
+import net.minecraft.loot.LootContext;
+import net.minecraft.loot.LootParameter;
+import net.minecraft.loot.LootParameters;
+import net.minecraft.loot.conditions.ILootCondition;
+
+import vazkii.botania.common.entity.EntityDoppleganger;
+
+import javax.annotation.Nonnull;
+
+import java.util.Set;
+
+public class RealPlayerCondition implements ILootCondition {
+	public static final RealPlayerCondition INSTANCE = new RealPlayerCondition();
+
+	private RealPlayerCondition() {}
+
+	@Override
+	public boolean test(LootContext lootContext) {
+		PlayerEntity player = lootContext.get(LootParameters.LAST_DAMAGE_PLAYER);
+		return EntityDoppleganger.isTruePlayer(player);
+	}
+
+	@Nonnull
+	@Override
+	public Set<LootParameter<?>> getRequiredParameters() {
+		return ImmutableSet.of(LootParameters.LAST_DAMAGE_PLAYER);
+	}
+
+	@Nonnull
+	@Override
+	public LootConditionType func_230419_b_() {
+		return ModLootModifiers.KILLED_BY_REAL_PLAYER;
+	}
+
+	public static class Serializer implements ILootSerializer<RealPlayerCondition> {
+		@Override
+		public void serialize(@Nonnull JsonObject json, @Nonnull RealPlayerCondition value, @Nonnull JsonSerializationContext context) {}
+
+		@Nonnull
+		@Override
+		public RealPlayerCondition deserialize(@Nonnull JsonObject json, @Nonnull JsonDeserializationContext context) {
+			return INSTANCE;
+		}
+	}
+}

--- a/src/main/java/vazkii/botania/common/entity/EntityDoppleganger.java
+++ b/src/main/java/vazkii/botania/common/entity/EntityDoppleganger.java
@@ -460,6 +460,9 @@ public class EntityDoppleganger extends MobEntity implements IEntityAdditionalSp
 				pixie.spawnExplosionParticle();
 				pixie.remove();
 			}
+			for (EntityMagicLandmine landmine : world.getEntitiesWithinAABB(EntityMagicLandmine.class, getArenaBB(getSource()))) {
+				landmine.remove();
+			}
 		}
 
 		playSound(SoundEvents.ENTITY_GENERIC_EXPLODE, 20F, (1F + (world.rand.nextFloat() - world.rand.nextFloat()) * 0.2F) * 0.7F);

--- a/src/main/java/vazkii/botania/common/entity/EntityDoppleganger.java
+++ b/src/main/java/vazkii/botania/common/entity/EntityDoppleganger.java
@@ -447,6 +447,19 @@ public class EntityDoppleganger extends MobEntity implements IEntityAdditionalSp
 					DopplegangerNoArmorTrigger.INSTANCE.trigger((ServerPlayerEntity) player, this, currSource);
 				}
 			}
+
+			// Clear wither from nearby players
+			for (PlayerEntity player : getPlayersAround()) {
+				if (player.getActivePotionEffect(Effects.WITHER) != null) {
+					player.removePotionEffect(Effects.WITHER);
+				}
+			}
+
+			// Stop all the pixies leftover from the fight
+			for (EntityPixie pixie : world.getEntitiesWithinAABB(EntityPixie.class, getArenaBB(getSource()), p -> p.isAlive() && p.getPixieType() == 1)) {
+				pixie.spawnExplosionParticle();
+				pixie.remove();
+			}
 		}
 
 		playSound(SoundEvents.ENTITY_GENERIC_EXPLODE, 20F, (1F + (world.rand.nextFloat() - world.rand.nextFloat()) * 0.2F) * 0.7F);
@@ -503,14 +516,18 @@ public class EntityDoppleganger extends MobEntity implements IEntityAdditionalSp
 	}
 
 	public List<PlayerEntity> getPlayersAround() {
-		float range = 15F;
-		return world.getEntitiesWithinAABB(PlayerEntity.class, new AxisAlignedBB(source.getX() + 0.5 - range, source.getY() + 0.5 - range, source.getZ() + 0.5 - range, source.getX() + 0.5 + range, source.getY() + 0.5 + range, source.getZ() + 0.5 + range), player -> isTruePlayer(player) && !player.isSpectator());
+		return world.getEntitiesWithinAABB(PlayerEntity.class, getArenaBB(source), player -> isTruePlayer(player) && !player.isSpectator());
 	}
 
 	private static int countGaiaGuardiansAround(World world, BlockPos source) {
-		float range = 15F;
-		List<EntityDoppleganger> l = world.getEntitiesWithinAABB(EntityDoppleganger.class, new AxisAlignedBB(source.getX() + 0.5 - range, source.getY() + 0.5 - range, source.getZ() + 0.5 - range, source.getX() + 0.5 + range, source.getY() + 0.5 + range, source.getZ() + 0.5 + range));
+		List<EntityDoppleganger> l = world.getEntitiesWithinAABB(EntityDoppleganger.class, getArenaBB(source));
 		return l.size();
+	}
+
+	@Nonnull
+	private static AxisAlignedBB getArenaBB(@Nonnull BlockPos source) {
+		double range = 15.0;
+		return new AxisAlignedBB(source.getX() + 0.5 - range, source.getY() + 0.5 - range, source.getZ() + 0.5 - range, source.getX() + 0.5 + range, source.getY() + 0.5 + range, source.getZ() + 0.5 + range);
 	}
 
 	private void particles() {

--- a/src/main/java/vazkii/botania/common/entity/EntityDoppleganger.java
+++ b/src/main/java/vazkii/botania/common/entity/EntityDoppleganger.java
@@ -29,6 +29,7 @@ import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.inventory.EquipmentSlotType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.loot.LootTables;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.IPacket;
 import net.minecraft.network.PacketBuffer;
@@ -99,6 +100,7 @@ public class EntityDoppleganger extends MobEntity implements IEntityAdditionalSp
 	private static final int MOB_SPAWN_TICKS = MOB_SPAWN_BASE_TICKS + MOB_SPAWN_START_TICKS + MOB_SPAWN_END_TICKS;
 	private static final int MOB_SPAWN_WAVES = 10;
 	private static final int MOB_SPAWN_WAVE_TIME = MOB_SPAWN_BASE_TICKS / MOB_SPAWN_WAVES;
+	private static final int DAMAGE_CAP = 32;
 
 	private static final String TAG_INVUL_TIME = "invulTime";
 	private static final String TAG_AGGRO = "aggro";
@@ -375,8 +377,7 @@ public class EntityDoppleganger extends MobEntity implements IEntityAdditionalSp
 				playersWhoAttacked.add(player.getUniqueID());
 			}
 
-			int cap = 25;
-			return super.attackEntityFrom(source, Math.min(cap, amount));
+			return super.attackEntityFrom(source, Math.min(DAMAGE_CAP, amount));
 		}
 
 		return false;
@@ -397,7 +398,7 @@ public class EntityDoppleganger extends MobEntity implements IEntityAdditionalSp
 
 	@Override
 	protected void damageEntity(@Nonnull DamageSource source, float amount) {
-		super.damageEntity(source, amount);
+		super.damageEntity(source, Math.min(DAMAGE_CAP, amount));
 
 		Entity attacker = source.getImmediateSource();
 		if (attacker != null) {
@@ -413,6 +414,12 @@ public class EntityDoppleganger extends MobEntity implements IEntityAdditionalSp
 
 			aggro = true;
 		}
+		hurtResistantTime = Math.max(hurtResistantTime, 20);
+	}
+
+	@Override
+	protected float applyArmorCalculations(DamageSource source, float damage) {
+		return super.applyArmorCalculations(source, Math.min(DAMAGE_CAP, damage));
 	}
 
 	@Override

--- a/src/main/java/vazkii/botania/common/entity/EntityDoppleganger.java
+++ b/src/main/java/vazkii/botania/common/entity/EntityDoppleganger.java
@@ -382,7 +382,7 @@ public class EntityDoppleganger extends MobEntity implements IEntityAdditionalSp
 		return false;
 	}
 
-	private static final Pattern FAKE_PLAYER_PATTERN = Pattern.compile("^(?:\\[.*\\])|(?:ComputerCraft)$");
+	private static final Pattern FAKE_PLAYER_PATTERN = Pattern.compile("^(?:\\[.*]|ComputerCraft)$");
 
 	public static boolean isTruePlayer(Entity e) {
 		if (!(e instanceof PlayerEntity)) {

--- a/src/main/resources/data/botania/loot_tables/dice/roll_1.json
+++ b/src/main/resources/data/botania/loot_tables/dice/roll_1.json
@@ -1,0 +1,19 @@
+{
+  "type": "gift",
+  "pools": [
+    {
+      "name": "life_essence",
+      "rolls": 1,
+      "entries": [{
+        "type": "item",
+        "name": "botania:life_essence",
+        "functions": [
+          {
+            "function": "set_count",
+            "count": { "min": 2, "max": 16 }
+          }
+        ]
+      }]
+    }
+  ]
+}

--- a/src/main/resources/data/botania/loot_tables/dice/roll_2.json
+++ b/src/main/resources/data/botania/loot_tables/dice/roll_2.json
@@ -1,0 +1,32 @@
+{
+  "type": "gift",
+  "pools": [
+    {
+      "name": "life_essence",
+      "rolls": 1,
+      "entries": [{
+        "type": "item",
+        "name": "botania:life_essence",
+        "functions": [
+          {
+            "function": "set_count",
+            "count": { "min": 2, "max": 4 }
+          }
+        ]
+      }]
+    },
+    {
+      "name": "overgrowth_seeds",
+      "rolls": 1,
+      "entries": [{
+        "type": "item",
+        "name": "botania:overgrowth_seed",
+        "functions": [
+          {
+            "function": "set_count", "count": 1
+          }
+        ]
+      }]
+    }
+  ]
+}

--- a/src/main/resources/data/botania/loot_tables/dice/roll_3.json
+++ b/src/main/resources/data/botania/loot_tables/dice/roll_3.json
@@ -1,0 +1,31 @@
+{
+  "type": "gift",
+  "pools": [
+    {
+      "name": "life_essence",
+      "rolls": 1,
+      "entries": [{
+        "type": "item",
+        "name": "botania:life_essence",
+        "functions": [
+          {
+            "function": "set_count",
+            "count": { "min": 4, "max": 6 }
+          }
+        ]
+      }]
+    },
+    {
+      "name": "runes",
+      "rolls": { "min": 2, "max": 4 },
+      "entries": [{
+        "type": "minecraft:loot_table",
+        "name": "botania:gaia_guardian/runes"
+      }],
+      "functions": [{
+        "function": "set_count",
+        "count": { "min": 1, "max": 3 }
+      }]
+    }
+  ]
+}

--- a/src/main/resources/data/botania/loot_tables/dice/roll_4.json
+++ b/src/main/resources/data/botania/loot_tables/dice/roll_4.json
@@ -1,0 +1,31 @@
+{
+  "type": "gift",
+  "pools": [
+    {
+      "name": "life_essence",
+      "rolls": 1,
+      "entries": [{
+        "type": "item",
+        "name": "botania:life_essence",
+        "functions": [
+          {
+            "function": "set_count",
+            "count": { "min": 4, "max": 8 }
+          }
+        ]
+      }]
+    },
+    {
+      "name": "materials",
+      "rolls": 1,
+      "entries": [{
+        "type": "minecraft:loot_table",
+        "name": "botania:gaia_guardian/materials"
+      }],
+      "functions": [{
+        "function": "set_count",
+        "count": { "min": 2, "max": 10 }
+      }]
+    }
+  ]
+}

--- a/src/main/resources/data/botania/loot_tables/dice/roll_5.json
+++ b/src/main/resources/data/botania/loot_tables/dice/roll_5.json
@@ -1,0 +1,43 @@
+{
+  "type": "gift",
+  "pools": [
+    {
+      "name": "life_essence",
+      "rolls": 1,
+      "entries": [{
+        "type": "item",
+        "name": "botania:life_essence",
+        "functions": [
+          {
+            "function": "set_count",
+            "count": { "min": 6, "max": 10 }
+          }
+        ]
+      }]
+    },
+    {
+      "name": "materials",
+      "rolls": 1,
+      "entries": [{
+        "type": "minecraft:loot_table",
+        "name": "botania:gaia_guardian/materials"
+      }],
+      "functions": [{
+        "function": "set_count",
+        "count": { "min": 4, "max": 8 }
+      }]
+    },
+    {
+      "name": "runes",
+      "rolls": { "min": 0, "max": 3 },
+      "entries": [{
+        "type": "minecraft:loot_table",
+        "name": "botania:gaia_guardian/runes"
+      }],
+      "functions": [{
+        "function": "set_count",
+        "count": { "min": 1, "max": 3 }
+      }]
+    }
+  ]
+}

--- a/src/main/resources/data/botania/loot_tables/dice/roll_6.json
+++ b/src/main/resources/data/botania/loot_tables/dice/roll_6.json
@@ -1,0 +1,53 @@
+{
+  "type": "gift",
+  "pools": [
+    {
+      "name": "life_essence",
+      "rolls": 1,
+      "entries": [{
+        "type": "item",
+        "name": "botania:life_essence",
+        "functions": [
+          {
+            "function": "set_count",
+            "count": { "min": 8, "max": 12 }
+          }
+        ]
+      }]
+    },
+    {
+      "name": "materials",
+      "rolls": 1,
+      "entries": [{
+          "type": "minecraft:loot_table",
+          "name": "botania:gaia_guardian/materials"
+      }],
+      "functions": [{
+        "function": "set_count",
+        "count": { "min": 5, "max": 10 }
+      }]
+    },
+    {
+      "name": "runes",
+      "rolls": { "min": 1, "max": 3 },
+      "entries": [{
+        "type": "minecraft:loot_table",
+        "name": "botania:gaia_guardian/runes"
+      }],
+      "functions": [{
+        "function": "set_count",
+        "count": { "min": 1, "max": 3 }
+      }]
+    },
+    {
+      "name": "black_lotuses",
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "name": "botania:gaia_guardian/lotuses"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/botania/loot_tables/gaia_guardian.json
+++ b/src/main/resources/data/botania/loot_tables/gaia_guardian.json
@@ -2,7 +2,7 @@
   "pools": [
     {
       "name": "life_essence",
-      "conditions": [{ "condition": "killed_by_player" }],
+      "conditions": [{ "condition": "botania:killed_by_player" }],
       "rolls": 1,
       "entries": [{
         "type": "item",
@@ -20,7 +20,7 @@
     {
       "name": "music_disc",
       "conditions": [
-        { "condition": "killed_by_player" },
+        { "condition": "botania:killed_by_player" },
         { "condition": "random_chance", "chance": 0.2 }
       ],
       "rolls": 1,

--- a/src/main/resources/data/botania/loot_tables/gaia_guardian/lotuses.json
+++ b/src/main/resources/data/botania/loot_tables/gaia_guardian/lotuses.json
@@ -1,0 +1,26 @@
+{
+  "pools": [
+    {
+      "name": "black_lotuses",
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "item",
+          "entryName": "superBlackLotus",
+          "name": "botania:blacker_lotus",
+          "weight": 3,
+          "quality": 1
+        },
+        {
+          "type": "item",
+          "entryName": "normalBlackLotus",
+          "name": "botania:black_lotus",
+          "weight": 7,
+          "functions": [
+            { "function": "set_count", "count": { "min": 1, "max": 3 } }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/botania/loot_tables/gaia_guardian/materials.json
+++ b/src/main/resources/data/botania/loot_tables/gaia_guardian/materials.json
@@ -1,0 +1,44 @@
+{
+  "pools": [
+    {
+      "name": "manasteel",
+      "conditions": [
+        { "condition": "random_chance", "chance": 0.9 }
+      ],
+      "rolls": 1,
+      "entries": [{
+        "type": "item",
+        "name": "botania:manasteel_ingot",
+        "functions": [{ "function": "set_count", "count": { "min": 16, "max": 27 } }]
+      }]
+    },
+    {
+      "name": "mana_pearl",
+      "conditions": [
+        { "condition": "random_chance", "chance": 0.7 }
+      ],
+      "rolls": 1,
+      "entries": [{
+        "type": "item",
+        "name": "botania:mana_pearl",
+        "functions": [
+          { "function": "set_count", "count": { "min": 8, "max": 13 } }
+        ]
+      }]
+    },
+    {
+      "name": "mana_diamond",
+      "conditions": [
+        { "condition": "random_chance", "chance": 0.5 }
+      ],
+      "rolls": 1,
+      "entries": [{
+        "type": "item",
+        "name": "botania:mana_diamond",
+        "functions": [
+          { "function": "set_count", "count": { "min": 4, "max": 6 } }
+        ]
+      }]
+    }
+  ]
+}

--- a/src/main/resources/data/botania/loot_tables/gaia_guardian/runes.json
+++ b/src/main/resources/data/botania/loot_tables/gaia_guardian/runes.json
@@ -3,102 +3,71 @@
     {
       "name": "runes",
       "rolls": 1,
+      "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }],
       "entries": [
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_water",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_water"
         },
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_fire",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_fire"
         },
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_earth",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_earth"
         },
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_air",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_air"
         },
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_spring",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_spring"
         },
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_summer",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_summer"
         },
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_autumn",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_autumn"
         },
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_winter",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_winter"
         },
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_mana",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_mana"
         },
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_lust",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_lust"
         },
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_gluttony",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_gluttony"
         },
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_greed",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_greed"
         },
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_sloth",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_sloth"
         },
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_wrath",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_wrath"
         },
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_envy",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_envy"
         },
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
           "type": "item",
-          "name": "botania:rune_pride",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "name": "botania:rune_pride"
         }
       ]
     }

--- a/src/main/resources/data/botania/loot_tables/gaia_guardian/runes.json
+++ b/src/main/resources/data/botania/loot_tables/gaia_guardian/runes.json
@@ -1,0 +1,106 @@
+{
+  "pools": [
+    {
+      "name": "runes",
+      "rolls": 1,
+      "entries": [
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_water",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        },
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_fire",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        },
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_earth",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        },
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_air",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        },
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_spring",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        },
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_summer",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        },
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_autumn",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        },
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_winter",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        },
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_mana",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        },
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_lust",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        },
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_gluttony",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        },
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_greed",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        },
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_sloth",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        },
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_wrath",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        },
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_envy",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        },
+        {
+          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
+          "type": "item",
+          "name": "botania:rune_pride",
+          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/botania/loot_tables/gaia_guardian_2.json
+++ b/src/main/resources/data/botania/loot_tables/gaia_guardian_2.json
@@ -26,20 +26,8 @@
       "rolls": 1,
       "entries": [
         {
-          "type": "item",
-          "entryName": "superBlackLotus",
-          "name": "botania:blacker_lotus",
-          "weight": 3,
-          "quality": 1
-        },
-        {
-          "type": "item",
-          "entryName": "normalBlackLotus",
-          "name": "botania:black_lotus",
-          "weight": 7,
-          "functions": [
-            { "function": "set_count", "count": { "min": 1, "max": 3 } }
-          ]
+          "type": "minecraft:loot_table",
+          "name": "botania:gaia_guardian/lotuses"
         }
       ]
     },
@@ -88,47 +76,15 @@
       }]
     },
     {
-      "name": "manasteel",
-      "conditions": [
-        { "condition": "botania:killed_by_player" },
-        { "condition": "random_chance", "chance": 0.9 }
-      ],
+      "name": "materials",
+      "conditions": [{ "condition": "botania:killed_by_player" }],
       "rolls": 1,
-      "entries": [{
-        "type": "item",
-        "name": "botania:manasteel_ingot",
-        "functions": [{ "function": "set_count", "count": { "min": 16, "max": 27 } }]
-      }]
-    },
-    {
-      "name": "mana_pearl",
-      "conditions": [
-        { "condition": "botania:killed_by_player" },
-        { "condition": "random_chance", "chance": 0.7 }
-      ],
-      "rolls": 1,
-      "entries": [{
-        "type": "item",
-        "name": "botania:mana_pearl",
-        "functions": [
-          { "function": "set_count", "count": { "min": 8, "max": 13 } }
-        ]
-      }]
-    },
-    {
-      "name": "mana_diamond",
-      "conditions": [
-        { "condition": "botania:killed_by_player" },
-        { "condition": "random_chance", "chance": 0.5 }
-      ],
-      "rolls": 1,
-      "entries": [{
-        "type": "item",
-        "name": "botania:mana_diamond",
-        "functions": [
-          { "function": "set_count", "count": { "min": 4, "max": 6 } }
-        ]
-      }]
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "name": "botania:gaia_guardian/materials"
+        }
+      ]
     },
     {
       "name": "runes",
@@ -136,100 +92,8 @@
       "rolls": { "min": 1, "max": 6 },
       "entries": [
         {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_water",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
-        },
-        {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_fire",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
-        },
-        {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_earth",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
-        },
-        {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_air",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
-        },
-        {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_spring",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
-        },
-        {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_summer",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
-        },
-        {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_autumn",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
-        },
-        {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_winter",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
-        },
-        {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_mana",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
-        },
-        {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_lust",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
-        },
-        {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_gluttony",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
-        },
-        {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_greed",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
-        },
-        {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_sloth",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
-        },
-        {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_wrath",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
-        },
-        {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_envy",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
-        },
-        {
-          "conditions": [{ "condition": "random_chance", "chance": 0.3 }],
-          "type": "item",
-          "name": "botania:rune_pride",
-          "functions": [{ "function": "set_count", "count": { "min": 2, "max": 4 } }]
+          "type": "minecraft:loot_table",
+          "name": "botania:gaia_guardian/runes"
         }
       ]
     },

--- a/src/main/resources/data/botania/loot_tables/gaia_guardian_2.json
+++ b/src/main/resources/data/botania/loot_tables/gaia_guardian_2.json
@@ -2,7 +2,7 @@
   "pools": [
     {
       "name": "life_essence",
-      "conditions": [{ "condition": "killed_by_player" }],
+      "conditions": [{ "condition": "botania:killed_by_player" }],
       "rolls": 1,
       "entries": [{
         "type": "item",
@@ -20,7 +20,7 @@
     {
       "name": "black_lotuses",
       "conditions": [
-        { "condition": "killed_by_player" },
+        { "condition": "botania:killed_by_player" },
         { "condition": "random_chance", "chance": 0.5 }
       ],
       "rolls": 1,
@@ -45,7 +45,7 @@
     },
     {
       "name": "ancient_wills",
-      "conditions": [{ "condition": "killed_by_player" }],
+      "conditions": [{ "condition": "botania:killed_by_player" }],
       "rolls": 1,
       "entries": [
         {
@@ -77,7 +77,7 @@
     {
       "name": "overgrowth_seeds",
       "conditions": [
-        { "condition": "killed_by_player" },
+        { "condition": "botania:killed_by_player" },
         { "condition": "random_chance", "chance": 0.25 }
       ],
       "rolls": 1,
@@ -90,7 +90,7 @@
     {
       "name": "manasteel",
       "conditions": [
-        { "condition": "killed_by_player" },
+        { "condition": "botania:killed_by_player" },
         { "condition": "random_chance", "chance": 0.9 }
       ],
       "rolls": 1,
@@ -103,7 +103,7 @@
     {
       "name": "mana_pearl",
       "conditions": [
-        { "condition": "killed_by_player" },
+        { "condition": "botania:killed_by_player" },
         { "condition": "random_chance", "chance": 0.7 }
       ],
       "rolls": 1,
@@ -118,7 +118,7 @@
     {
       "name": "mana_diamond",
       "conditions": [
-        { "condition": "killed_by_player" },
+        { "condition": "botania:killed_by_player" },
         { "condition": "random_chance", "chance": 0.5 }
       ],
       "rolls": 1,
@@ -132,7 +132,7 @@
     },
     {
       "name": "runes",
-      "conditions": [{ "condition": "killed_by_player" }],
+      "conditions": [{ "condition": "botania:killed_by_player" }],
       "rolls": { "min": 1, "max": 6 },
       "entries": [
         {
@@ -236,7 +236,7 @@
     {
       "name": "pinkinator",
       "conditions": [
-        { "condition": "killed_by_player" },
+        { "condition": "botania:killed_by_player" },
         { "condition": "random_chance", "chance": 0.2 }
       ],
       "rolls": 1,
@@ -248,7 +248,7 @@
     {
       "name": "music_discs",
       "conditions": [
-        { "condition": "killed_by_player" },
+        { "condition": "botania:killed_by_player" },
         { "condition": "random_chance", "chance": 0.44 }
       ],
       "rolls": 1,
@@ -273,7 +273,7 @@
     {
       "name": "relics",
       "conditions": [
-        { "condition": "killed_by_player" },
+        { "condition": "botania:killed_by_player" },
         { "condition": "botania:enable_relics" }
       ],
       "rolls": 1,


### PR DESCRIPTION
Submitting for feedback, mostly.
cc @williewillus @Alwinfy

* a bit of anticheese
* more loot: dice of fate give spirits and some more random stuff once out of relics, because people dislike having to grind the guardian (not our fault, really, but modpack authors sometimes don't playtest their own grind)
* a bit of niceties: nerfing health in multiplayer by a bunch, killing pixies and clearing wither on death of the guardian, bumping the damage cap, and triggering win advancements for everyone involved, not just the true killer

Any of this anticheese is overkill? Anything to tweak?