### PR TITLE
Note datagenned files as `linguist-generated`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *      text=auto eol=lf
 *.java text      diff=java eol=lf
+/src/generated/**      linguist-generated


### PR DESCRIPTION
This should make datagenned files hidden by default in diffs, and not show up in stats