### PR TITLE
Rebalance rafflowsia

### DIFF
--- a/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_coal_ore.json
+++ b/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_coal_ore.json
@@ -5,5 +5,5 @@
     "type": "block",
     "block": "minecraft:deepslate_coal_ore"
   },
-  "weight": 67415
+  "weight": 75
 }

--- a/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_copper_ore.json
+++ b/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_copper_ore.json
@@ -5,5 +5,5 @@
     "type": "block",
     "block": "minecraft:deepslate_copper_ore"
   },
-  "weight": 7000
+  "weight": 75
 }

--- a/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_diamond_ore.json
+++ b/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_diamond_ore.json
@@ -5,5 +5,5 @@
     "type": "block",
     "block": "minecraft:deepslate_diamond_ore"
   },
-  "weight": 883
+  "weight": 100
 }

--- a/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_emerald_ore.json
+++ b/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_emerald_ore.json
@@ -5,5 +5,5 @@
     "type": "block",
     "block": "minecraft:deepslate_emerald_ore"
   },
-  "weight": 1239
+  "weight": 50
 }

--- a/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_gold_ore.json
+++ b/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_gold_ore.json
@@ -5,5 +5,5 @@
     "type": "block",
     "block": "minecraft:deepslate_gold_ore"
   },
-  "weight": 2647
+  "weight": 125
 }

--- a/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_iron_ore.json
+++ b/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_iron_ore.json
@@ -5,5 +5,5 @@
     "type": "block",
     "block": "minecraft:deepslate_iron_ore"
   },
-  "weight": 29371
+  "weight": 250
 }

--- a/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_lapis_ore.json
+++ b/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_lapis_ore.json
@@ -5,5 +5,5 @@
     "type": "block",
     "block": "minecraft:deepslate_lapis_ore"
   },
-  "weight": 1079
+  "weight": 175
 }

--- a/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_redstone_ore.json
+++ b/Common/src/generated/resources/data/botania/recipes/orechid/deepslate_redstone_ore.json
@@ -5,5 +5,5 @@
     "type": "block",
     "block": "minecraft:deepslate_redstone_ore"
   },
-  "weight": 7654
+  "weight": 150
 }

--- a/Common/src/generated/resources/data/botania/recipes/pure_daisy/end_stone_to_cobbled_deepslate.json
+++ b/Common/src/generated/resources/data/botania/recipes/pure_daisy/end_stone_to_cobbled_deepslate.json
@@ -5,7 +5,7 @@
     "block": "minecraft:end_stone"
   },
   "output": {
-    "name": "minecraft:cobblestone"
+    "name": "minecraft:cobbled_deepslate"
   },
   "success_function": "botania:ender_air_release"
 }

--- a/Common/src/generated/resources/data/botania/tags/blocks/ender_air_convertable.json
+++ b/Common/src/generated/resources/data/botania/tags/blocks/ender_air_convertable.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:stone",
+    "minecraft:deepslate",
+    "minecraft:granite",
+    "minecraft:diorite",
+    "minecraft:andesite"
+  ]
+}

--- a/Common/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileRafflowsia.java
+++ b/Common/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileRafflowsia.java
@@ -37,11 +37,10 @@ public class SubTileRafflowsia extends TileEntityGeneratingFlower {
 
 	private static final int RANGE = 5;
 
-	// Below table generated from the function:
-	// f(x) = round(-401.45 + 7.03436 x + 16.0932 x^2 + 7.64878 * 1.25226^x, 100),
-	// where x is the number of unique flowers in the streak.
+	// Below table generated from this spreadsheet:
+	// https://docs.google.com/spreadsheets/d/1D5qvYRrwm6-czKnXVIEjakt93I0asICgxnPJ_q6UCc0
 	// Function created from a best-fit approximation on the sorted raw mana costs of production of each flower.
-	private static final int[] STREAK_OUTPUTS = { 300, 1100, 1900, 2700, 3500, 4400, 5300, 6300, 7300, 8300, 9400, 10500, 11600, 12800, 14000, 15200, 16500, 17900, 19200, 20700, 22200, 23800, 25400, 27100, 29000, 30900, 33000, 35200, 37700, 40300, 43200, 46500, 50200, 54300, 59100, 64600, 71100, 78600, 87600, 98400 };
+	private static final int[] STREAK_OUTPUTS = { 2000, 2100, 2200, 2300, 3280, 4033, 4657, 5150, 6622, 7860, 10418, 12600, 14769, 16671, 19000, 25400, 33471, 40900, 47579, 53600, 59057, 64264, 69217, 74483, 79352, 83869, 88059, 92129, 96669, 100940, 105239, 112044, 118442, 124612, 130583, 136228, 141703, 178442, 213959, 247725, 279956, 313671, 345833, 377227, 437689, 495526, 553702, 638554 };
 
 	public SubTileRafflowsia(BlockPos pos, BlockState state) {
 		super(ModSubtiles.RAFFLOWSIA, pos, state);

--- a/Common/src/main/java/vazkii/botania/common/entity/EntityEnderAirBottle.java
+++ b/Common/src/main/java/vazkii/botania/common/entity/EntityEnderAirBottle.java
@@ -36,6 +36,7 @@ import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.Vec3;
 
 import vazkii.botania.common.item.ModItems;
+import vazkii.botania.common.lib.ModTags;
 
 import javax.annotation.Nonnull;
 
@@ -62,7 +63,7 @@ public class EntityEnderAirBottle extends ThrowableProjectile implements ItemSup
 		super(ModEntities.ENDER_AIR_BOTTLE, x, y, z, world);
 	}
 
-	private void convertStone(@Nonnull BlockPos pos) {
+	private void convertBlock(@Nonnull BlockPos pos) {
 		List<BlockPos> coordsList = getCoordsToPut(pos);
 		level.levelEvent(LevelEvent.PARTICLES_SPELL_POTION_SPLASH, blockPosition(), PARTICLE_COLOR);
 
@@ -80,7 +81,7 @@ public class EntityEnderAirBottle extends ThrowableProjectile implements ItemSup
 		if (level.isClientSide) {
 			return;
 		}
-		convertStone(result.getBlockPos());
+		convertBlock(result.getBlockPos());
 		discard();
 	}
 
@@ -119,7 +120,7 @@ public class EntityEnderAirBottle extends ThrowableProjectile implements ItemSup
 				item.setDeltaMovement(item.getDeltaMovement().add(vec.scale(0.4)));
 			}
 		} else {
-			convertStone(new BlockPos(result.getLocation()));
+			convertBlock(new BlockPos(result.getLocation()));
 		}
 		discard();
 	}
@@ -132,7 +133,7 @@ public class EntityEnderAirBottle extends ThrowableProjectile implements ItemSup
 		for (BlockPos bPos : BlockPos.betweenClosed(pos.offset(-range, -rangeY, -range),
 				pos.offset(range, rangeY, range))) {
 			BlockState state = level.getBlockState(bPos);
-			if (state.is(Blocks.STONE)) {
+			if (state.is(ModTags.Blocks.ENDER_AIR_CONVERTABLE)) {
 				possibleCoords.add(bPos.immutable());
 			}
 		}

--- a/Common/src/main/java/vazkii/botania/common/lib/ModTags.java
+++ b/Common/src/main/java/vazkii/botania/common/lib/ModTags.java
@@ -185,6 +185,11 @@ public class ModTags {
 		 */
 		public static final Tag.Named<Block> TERRA_PLATE_BASE = tag("terra_plate_base");
 
+		/**
+		 * Blocks in this tag can be turned into end stone by ender air
+		 */
+		public static final Tag.Named<Block> ENDER_AIR_CONVERTABLE = tag("ender_air_convertable");
+
 		private static Tag.Named<Block> tag(String name) {
 			return IXplatAbstractions.INSTANCE.blockTag(prefix(name));
 		}

--- a/Common/src/main/java/vazkii/botania/data/BlockTagProvider.java
+++ b/Common/src/main/java/vazkii/botania/data/BlockTagProvider.java
@@ -157,6 +157,8 @@ public class BlockTagProvider extends BlockTagsProvider {
 
 		tag(BlockTags.CLIMBABLE).add(ModBlocks.solidVines);
 
+		tag(ModTags.Blocks.ENDER_AIR_CONVERTABLE).add(Blocks.STONE, Blocks.DEEPSLATE, Blocks.GRANITE, Blocks.DIORITE, Blocks.ANDESITE);
+
 		registerMiningTags();
 	}
 

--- a/Common/src/main/java/vazkii/botania/data/recipes/OrechidProvider.java
+++ b/Common/src/main/java/vazkii/botania/data/recipes/OrechidProvider.java
@@ -56,14 +56,14 @@ public class OrechidProvider extends BotaniaRecipeProvider {
 		consumer.accept(stone(Blocks.LAPIS_ORE, 1079));
 		consumer.accept(stone(Blocks.DIAMOND_ORE, 883));
 
-		consumer.accept(deepslate(Blocks.DEEPSLATE_COAL_ORE, 67415));
-		consumer.accept(deepslate(Blocks.DEEPSLATE_IRON_ORE, 29371));
-		consumer.accept(deepslate(Blocks.DEEPSLATE_REDSTONE_ORE, 7654));
-		consumer.accept(deepslate(Blocks.DEEPSLATE_COPPER_ORE, 7000));
-		consumer.accept(deepslate(Blocks.DEEPSLATE_GOLD_ORE, 2647));
-		consumer.accept(deepslate(Blocks.DEEPSLATE_EMERALD_ORE, 1239));
-		consumer.accept(deepslate(Blocks.DEEPSLATE_LAPIS_ORE, 1079));
-		consumer.accept(deepslate(Blocks.DEEPSLATE_DIAMOND_ORE, 883));
+		consumer.accept(deepslate(Blocks.DEEPSLATE_COAL_ORE, 75));
+		consumer.accept(deepslate(Blocks.DEEPSLATE_IRON_ORE, 250));
+		consumer.accept(deepslate(Blocks.DEEPSLATE_REDSTONE_ORE, 150));
+		consumer.accept(deepslate(Blocks.DEEPSLATE_COPPER_ORE, 75));
+		consumer.accept(deepslate(Blocks.DEEPSLATE_GOLD_ORE, 125));
+		consumer.accept(deepslate(Blocks.DEEPSLATE_EMERALD_ORE, 50));
+		consumer.accept(deepslate(Blocks.DEEPSLATE_LAPIS_ORE, 175));
+		consumer.accept(deepslate(Blocks.DEEPSLATE_DIAMOND_ORE, 100));
 
 		consumer.accept(netherrack(Blocks.NETHER_QUARTZ_ORE, 19600));
 		consumer.accept(netherrack(Blocks.NETHER_GOLD_ORE, 3635));

--- a/Common/src/main/java/vazkii/botania/data/recipes/PureDaisyProvider.java
+++ b/Common/src/main/java/vazkii/botania/data/recipes/PureDaisyProvider.java
@@ -41,7 +41,7 @@ public class PureDaisyProvider extends BotaniaRecipeProvider {
 		consumer.accept(new FinishedRecipe(id("livingwood"), StateIngredientHelper.of(BlockTags.LOGS), ModBlocks.livingwood.defaultBlockState()));
 
 		consumer.accept(new FinishedRecipe(id("cobblestone"), StateIngredientHelper.of(Blocks.NETHERRACK), Blocks.COBBLESTONE.defaultBlockState()));
-		consumer.accept(new FinishedRecipe(id("end_stone_to_cobblestone"), StateIngredientHelper.of(Blocks.END_STONE), Blocks.COBBLESTONE.defaultBlockState(), FinishedRecipe.DEFAULT_TIME, prefix("ender_air_release")));
+		consumer.accept(new FinishedRecipe(id("end_stone_to_cobbled_deepslate"), StateIngredientHelper.of(Blocks.END_STONE), Blocks.COBBLED_DEEPSLATE.defaultBlockState(), FinishedRecipe.DEFAULT_TIME, prefix("ender_air_release")));
 		consumer.accept(new FinishedRecipe(id("sand"), StateIngredientHelper.of(Blocks.SOUL_SAND), Blocks.SAND.defaultBlockState()));
 		consumer.accept(new FinishedRecipe(id("packed_ice"), StateIngredientHelper.of(Blocks.ICE), Blocks.PACKED_ICE.defaultBlockState()));
 		consumer.accept(new FinishedRecipe(id("blue_ice"), StateIngredientHelper.of(Blocks.PACKED_ICE), Blocks.BLUE_ICE.defaultBlockState()));


### PR DESCRIPTION
Changes:
- Changed pure daisy recipe from end stone->cobblestone to end stone->cobbled deepslate
- Made a tag for blocks that can be converted to end stone by ender air. It contains stone, deepslate, and the 1.8 stones
- Changed the weigths of deepslate ore recipes to make diamond viable to use for flowers for rafflowsia
- Changed the mana output of rafflowsia to make sense with the iron and diamond deepslate orechid rates