### PR TITLE
Tweak models for framed livingwood/dreamwood

### DIFF
--- a/Common/src/generated/resources/assets/botania/blockstates/framed_dreamwood.json
+++ b/Common/src/generated/resources/assets/botania/blockstates/framed_dreamwood.json
@@ -1,16 +1,13 @@
 {
   "variants": {
     "axis=x": {
-      "model": "botania:block/framed_dreamwood_horizontal",
-      "x": 90,
-      "y": 90
+      "model": "botania:block/framed_dreamwood_horizontal_x"
     },
     "axis=y": {
       "model": "botania:block/framed_dreamwood"
     },
     "axis=z": {
-      "model": "botania:block/framed_dreamwood_horizontal",
-      "x": 90
+      "model": "botania:block/framed_dreamwood_horizontal_z"
     }
   }
 }

--- a/Common/src/generated/resources/assets/botania/blockstates/framed_livingwood.json
+++ b/Common/src/generated/resources/assets/botania/blockstates/framed_livingwood.json
@@ -1,16 +1,13 @@
 {
   "variants": {
     "axis=x": {
-      "model": "botania:block/framed_livingwood_horizontal",
-      "x": 90,
-      "y": 90
+      "model": "botania:block/framed_livingwood_horizontal_x"
     },
     "axis=y": {
       "model": "botania:block/framed_livingwood"
     },
     "axis=z": {
-      "model": "botania:block/framed_livingwood_horizontal",
-      "x": 90
+      "model": "botania:block/framed_livingwood_horizontal_z"
     }
   }
 }

--- a/Common/src/generated/resources/assets/botania/models/block/framed_dreamwood_horizontal_x.json
+++ b/Common/src/generated/resources/assets/botania/models/block/framed_dreamwood_horizontal_x.json
@@ -1,5 +1,5 @@
 {
-  "parent": "minecraft:block/cube_column_horizontal",
+  "parent": "botania:block/shapes/cube_column_horizontal_x",
   "textures": {
     "end": "botania:block/pattern_framed_dreamwood",
     "side": "botania:block/framed_dreamwood"

--- a/Common/src/generated/resources/assets/botania/models/block/framed_dreamwood_horizontal_z.json
+++ b/Common/src/generated/resources/assets/botania/models/block/framed_dreamwood_horizontal_z.json
@@ -1,0 +1,7 @@
+{
+  "parent": "botania:block/shapes/cube_column_horizontal_z",
+  "textures": {
+    "end": "botania:block/pattern_framed_dreamwood",
+    "side": "botania:block/framed_dreamwood"
+  }
+}

--- a/Common/src/generated/resources/assets/botania/models/block/framed_livingwood_horizontal_x.json
+++ b/Common/src/generated/resources/assets/botania/models/block/framed_livingwood_horizontal_x.json
@@ -1,5 +1,5 @@
 {
-  "parent": "minecraft:block/cube_column_horizontal",
+  "parent": "botania:block/shapes/cube_column_horizontal_x",
   "textures": {
     "end": "botania:block/pattern_framed_livingwood",
     "side": "botania:block/framed_livingwood"

--- a/Common/src/generated/resources/assets/botania/models/block/framed_livingwood_horizontal_z.json
+++ b/Common/src/generated/resources/assets/botania/models/block/framed_livingwood_horizontal_z.json
@@ -1,0 +1,7 @@
+{
+  "parent": "botania:block/shapes/cube_column_horizontal_z",
+  "textures": {
+    "end": "botania:block/pattern_framed_livingwood",
+    "side": "botania:block/framed_livingwood"
+  }
+}

--- a/Common/src/generated/resources/assets/botania/models/item/framed_dreamwood.json
+++ b/Common/src/generated/resources/assets/botania/models/item/framed_dreamwood.json
@@ -1,3 +1,3 @@
 {
-  "parent": "botania:block/framed_dreamwood_horizontal_x"
+  "parent": "botania:block/framed_dreamwood_horizontal_z"
 }

--- a/Common/src/generated/resources/assets/botania/models/item/framed_dreamwood.json
+++ b/Common/src/generated/resources/assets/botania/models/item/framed_dreamwood.json
@@ -1,3 +1,3 @@
 {
-  "parent": "botania:block/framed_dreamwood"
+  "parent": "botania:block/framed_dreamwood_horizontal_x"
 }

--- a/Common/src/generated/resources/assets/botania/models/item/framed_livingwood.json
+++ b/Common/src/generated/resources/assets/botania/models/item/framed_livingwood.json
@@ -1,3 +1,3 @@
 {
-  "parent": "botania:block/framed_livingwood"
+  "parent": "botania:block/framed_livingwood_horizontal_x"
 }

--- a/Common/src/generated/resources/assets/botania/models/item/framed_livingwood.json
+++ b/Common/src/generated/resources/assets/botania/models/item/framed_livingwood.json
@@ -1,3 +1,3 @@
 {
-  "parent": "botania:block/framed_livingwood_horizontal_x"
+  "parent": "botania:block/framed_livingwood_horizontal_z"
 }

--- a/Common/src/main/java/vazkii/botania/data/ItemModelProvider.java
+++ b/Common/src/main/java/vazkii/botania/data/ItemModelProvider.java
@@ -366,6 +366,11 @@ public class ItemModelProvider implements DataProvider {
 			consumer.accept(ModelLocationUtils.getModelLocation(i), new DelegatedModel(prefix("block/petal_block")));
 		});
 
+		takeAll(itemBlocks, ModBlocks.livingwoodFramed.asItem(), ModBlocks.dreamwoodFramed.asItem()).forEach(i -> {
+			String name = i == ModBlocks.livingwoodFramed.asItem() ? "livingwood" : "dreamwood";
+			consumer.accept(ModelLocationUtils.getModelLocation(i), new DelegatedModel(prefix("block/framed_" + name + "_horizontal_x")));
+		});
+
 		takeAll(itemBlocks, i -> i.getBlock() instanceof IronBarsBlock).forEach(i -> {
 			String name = Registry.ITEM.getKey(i).getPath();
 			String baseName = name.substring(0, name.length() - "_pane".length());

--- a/Common/src/main/java/vazkii/botania/data/ItemModelProvider.java
+++ b/Common/src/main/java/vazkii/botania/data/ItemModelProvider.java
@@ -368,7 +368,7 @@ public class ItemModelProvider implements DataProvider {
 
 		takeAll(itemBlocks, ModBlocks.livingwoodFramed.asItem(), ModBlocks.dreamwoodFramed.asItem()).forEach(i -> {
 			String name = i == ModBlocks.livingwoodFramed.asItem() ? "livingwood" : "dreamwood";
-			consumer.accept(ModelLocationUtils.getModelLocation(i), new DelegatedModel(prefix("block/framed_" + name + "_horizontal_x")));
+			consumer.accept(ModelLocationUtils.getModelLocation(i), new DelegatedModel(prefix("block/framed_" + name + "_horizontal_z")));
 		});
 
 		takeAll(itemBlocks, i -> i.getBlock() instanceof IronBarsBlock).forEach(i -> {

--- a/Common/src/main/java/vazkii/botania/data/ItemModelProvider.java
+++ b/Common/src/main/java/vazkii/botania/data/ItemModelProvider.java
@@ -371,6 +371,11 @@ public class ItemModelProvider implements DataProvider {
 			consumer.accept(ModelLocationUtils.getModelLocation(i), new DelegatedModel(prefix("block/framed_" + name + "_horizontal_z")));
 		});
 
+		consumer.accept(ModelLocationUtils.getModelLocation(ModBlocks.livingwoodFramed.asItem()), new DelegatedModel(prefix("block/framed_livingwood_horizontal_z")));
+		consumer.accept(ModelLocationUtils.getModelLocation(ModBlocks.dreamwoodFramed.asItem()), new DelegatedModel(prefix("block/framed_dreamwood_horizontal_z")));
+		itemBlocks.remove(ModBlocks.livingwoodFramed.asItem());
+		itemBlocks.remove(ModBlocks.dreamwoodFramed.asItem());
+
 		takeAll(itemBlocks, i -> i.getBlock() instanceof IronBarsBlock).forEach(i -> {
 			String name = Registry.ITEM.getKey(i).getPath();
 			String baseName = name.substring(0, name.length() - "_pane".length());

--- a/Common/src/main/resources/assets/botania/models/block/shapes/cube_column_horizontal_x.json
+++ b/Common/src/main/resources/assets/botania/models/block/shapes/cube_column_horizontal_x.json
@@ -1,0 +1,21 @@
+{
+  "__comment": "Horizontal-oriented column",
+  "parent": "block/block",
+  "textures": {
+    "particle": "#side"
+  },
+  "elements": [
+    {
+      "from": [0, 0, 0],
+      "to": [16, 16, 16],
+      "faces": {
+        "down": { "texture": "#side", "rotation": 90, "uv": [0, 16, 16, 0], "cullface": "down" },
+        "up": { "texture": "#side", "rotation": 90, "uv": [0, 16, 16, 0], "cullface": "up" },
+        "north": { "texture": "#side", "rotation": 90, "uv": [0, 16, 16, 0], "cullface": "north" },
+        "south": { "texture": "#side", "rotation": 90, "uv": [0, 16, 16, 0], "cullface": "south" },
+        "west": { "texture": "#end", "cullface": "west" },
+        "east": { "texture": "#end", "cullface": "east" }
+      }
+    }
+  ]
+}

--- a/Common/src/main/resources/assets/botania/models/block/shapes/cube_column_horizontal_z.json
+++ b/Common/src/main/resources/assets/botania/models/block/shapes/cube_column_horizontal_z.json
@@ -1,0 +1,21 @@
+{
+  "__comment": "Horizontal-oriented column",
+  "parent": "block/block",
+  "textures": {
+    "particle": "#side"
+  },
+  "elements": [
+    {
+      "from": [0, 0, 0],
+      "to": [16, 16, 16],
+      "faces": {
+        "down": { "texture": "#side", "cullface": "down" },
+        "up": { "texture": "#side", "cullface": "up" },
+        "north": { "texture": "#end", "cullface": "north" },
+        "south": { "texture": "#end", "cullface": "south" },
+        "west": { "texture": "#side", "rotation": 90, "uv": [0, 16, 16, 0], "cullface": "west" },
+        "east": { "texture": "#side", "rotation": 90, "uv": [0, 16, 16, 0], "cullface": "east" }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Rotated all textures to face the right way, so they always match up with nearby planks (Before, it looked really weird when you'd get for example two lines of dark pixels next to eachother across a block border)
- Item model rotated sideways to more easily distinguish from pattern framed variant