### PR TITLE
Fix rafflowsia streak and buffer size

### DIFF
--- a/Common/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileRafflowsia.java
+++ b/Common/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileRafflowsia.java
@@ -47,7 +47,7 @@ public class SubTileRafflowsia extends TileEntityGeneratingFlower {
 	}
 
 	private int getMaxStreak() {
-		return STREAK_OUTPUTS.length - 1;
+		return STREAK_OUTPUTS.length;
 	}
 
 	private int getValueForStreak(int index) {
@@ -145,7 +145,7 @@ public class SubTileRafflowsia extends TileEntityGeneratingFlower {
 
 	@Override
 	public int getMaxMana() {
-		return 100000;
+		return  STREAK_OUTPUTS[STREAK_OUTPUTS.length - 1];
 	}
 
 }

--- a/Common/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileRafflowsia.java
+++ b/Common/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileRafflowsia.java
@@ -145,7 +145,7 @@ public class SubTileRafflowsia extends TileEntityGeneratingFlower {
 
 	@Override
 	public int getMaxMana() {
-		return  STREAK_OUTPUTS[STREAK_OUTPUTS.length - 1];
+		return STREAK_OUTPUTS[STREAK_OUTPUTS.length - 1];
 	}
 
 }


### PR DESCRIPTION
- `getMaxStreak` seemed to be wrong and hubry agreed
- Max mana was never adjusted for the max streak reward