### PR TITLE
Minor update

### DIFF
--- a/Common/src/main/resources/assets/botania/lang/en_us.json
+++ b/Common/src/main/resources/assets/botania/lang/en_us.json
@@ -2159,7 +2159,7 @@
 
   "botania.entry.spectranthemum": "Spectranthemum",
   "botania.tagline.spectranthemum": "Teleports items",
-  "botania.page.spectranthemum0": "Long-distance item transport can be an arduous task; at some point, water channels and $(l:functional_flowers/daffomill)$(item)Daffomills$(0)$(/l) just won't cut it. The $(item)Spectranthemum$(0) uses $(thing)Mana$(0) to warp the fabric of reality around any items near it, teleporting them elsewhere in the world. Note that $(thing)Mana-containing and already-teleported items interfere with the warp; neither of these can be teleported.",
+  "botania.page.spectranthemum0": "Long-distance item transport can be an arduous task; at some point, water channels and $(l:functional_flowers/daffomill)$(item)Daffomills$(0)$(/l) just won't cut it. The $(item)Spectranthemum$(0) uses $(thing)Mana$(0) to warp the fabric of reality around any items near it, teleporting them elsewhere in the world. Note that $(thing)Mana$(0)-containing and already-teleported items interfere with the warp; neither of these can be teleported.",
   "botania.page.spectranthemum1": "To specify the destination of warped items, use a $(l:basics/wand)$(item)Wand of the Forest$(0)$(/l) in $(thing)Bind Mode$(0) to bind the flower to a location within 12 blocks, the same way one would to a pool. To view what block the flower is bound to (as opposed to the pool it's pulling $(thing)Mana$(0) from), sneak while looking at it with a wand.",
   "botania.page.spectranthemum2": "This flower is bound by the $(thing)axiom of chunkloading$(0); i.e. it won't send items to unloaded chunks. This topic, however, is beyond the scope of this lexicon.",
   "botania.page.spectranthemum3": "$(o)(n)spooky(n+2)me$().",

--- a/Common/src/main/resources/assets/botania/lang/en_us.json
+++ b/Common/src/main/resources/assets/botania/lang/en_us.json
@@ -45,7 +45,6 @@
   "botaniamisc.shardLevel": "Shard Power %s",
   "botaniamisc.shardRange": "Radius: %s",
   "botaniamisc.lexiconIndex": "Lexicon Index",
-  "botaniamisc.hasIvy": "Has Timeless Ivy",
   "botaniamisc.drop": "Drop",
   "botaniamisc.dropTip0": "Tip: You can press %s over an item in your inventory to drop one of it",
   "botaniamisc.dropTip1": "CTRL-%s will drop a full stack",
@@ -1291,7 +1290,6 @@
   "item.botania.spark_upgrade_isolated": "Spark Augment: Isolated",
   "item.botania.divining_rod": "Rod of the Plentiful Mantle",
   "item.botania.gravity_rod": "Rod of the Shaded Mesa",
-  "item.botania.regenivy": "Timeless Ivy",
   "item.botania.vial": "Managlass Vial",
   "item.botania.flask": "Alfglass Flask",
   "item.botania.brew_vial": "Vial of %s (%s)",
@@ -2056,7 +2054,7 @@
 
   "botania.entry.bellethorne": "Bellethorne",
   "botania.tagline.bellethorne": "Damages mobs",
-  "botania.page.bellethorne0": "The $(item)Bellethorne$(0) is a malevelous flower. It twists any $(thing)Mana$(0) provided to slowly inflict harm in any living beings (save for $(thing)players$(0)) around it.",
+  "botania.page.bellethorne0": "The $(item)Bellethorne$(0) is a malevolent flower. It twists any $(thing)Mana$(0) provided to slowly inflict harm in any living beings (save for $(thing)players$(0)) around it.",
   "botania.page.bellethorne1": "$(o)Every rose has its thorn$().",
 
   "botania.entry.dreadthorne": "Dreadthorne",
@@ -3258,9 +3256,9 @@
   "botania.page.elvenLore2": "It began when Nidavellir was struck by an earthquake that collapsed the majority of the realm. While the Dwarves' incredible strength and durability allowed them to survive and preserve certain things, most of their technology and culture was lost to the void between worlds.",
   "botania.page.elvenLore3": "This disturbance caused Muspelheim to break free from its tether on the World Tree herself. It crashed into the far realm of Midgard, fusing with it in a storm of fire that left no life remaining there. Many of us believe that the goddess Hel had a hand in Muspelheim's fall, but no concrete evidence was ever found.",
   "botania.page.elvenLore4": "The quakes managed to reach Jotunheim, cracking the earth and massacring the Giants. We do not know whether they have truly died out, but the Giants have not resurfaced since. Niflheim remained perfectly still, despite Muspelheim's fall-- a major factor in the theories about Hel. However, since it contains no known life besides the goddess herself, we are unworried about any damage incurred there.",
-  "botania.page.elvenLore5": "We of Alfheim were dealt a great blow, but some worse than others. As the Salamander and Undine clans depend greatly on their respective volcanic and aquatic environments, the disroption of those environments decimated the population. Conversely, the Sylph, being a nomadic clan who preferred the sky to the land, remained largely unscathed. Their cousins the Spriggan, nomads as well, were also able to survive relatively intact.",
+  "botania.page.elvenLore5": "We of Alfheim were dealt a great blow, but some worse than others. As the Salamander and Undine clans depend greatly on their respective volcanic and aquatic environments, the disruption of those environments decimated the population. Conversely, the Sylph, being a nomadic clan who preferred the sky to the land, remained largely unscathed. Their cousins the Spriggan, nomads as well, were also able to survive relatively intact.",
   "botania.page.elvenLore5a": "At that time, we had little true structure to our civilization, living in simple huts of Dreamwood. This made rebuilding little more than a chore of gathering materials, especially as we had prior warning.",
-  "botania.page.elvenLore6": "Our Sylph emmissary to Asgard, Allewyn, witnessed the beginning of it all: Thor turning Mjölnir upon the Bifrost, shattering it. Her command to evacute our entire Midgardian population saved thousands of lives. Although she seemed outwardly unharmed as she arrived on the crest of a wave of crumbling Bifrost to warn us, the toll of the journey caused her to pass away shortly after.",
+  "botania.page.elvenLore6": "Our Sylph emissary to Asgard, Allewyn, witnessed the beginning of it all: Thor turning Mjölnir upon the Bifrost, shattering it. Her command to evacuate our entire Midgardian population saved thousands of lives. Although she seemed outwardly unharmed as she arrived on the crest of a wave of crumbling Bifrost to warn us, the toll of the journey caused her to pass away shortly after.",
   "botania.page.elvenLore7": "What concerns us now is the state of Midgard. As the Bifrost can no longer give us access to that world, we cannot observe it directly. However, the Mana left behind as we fled surely has brought about new life, as it always does. Whether it be animal, floral, or fungal, and whether it be natural or magical in nature, we hope that life will be intelligent enough to harness what we left behind.",
 
   "botania.entry.decorativeBlocks": "Decorative Blocks",

--- a/Common/src/main/resources/assets/botania/lang/en_us.json
+++ b/Common/src/main/resources/assets/botania/lang/en_us.json
@@ -2154,7 +2154,7 @@
 
   "botania.entry.vinculotus": "Vinculotus",
   "botania.tagline.vinculotus": "Intercepts Enderman teleportation",
-  "botania.page.vinculotus0": "The $(item)Vinculotus$(0) uses $(5)Mana$(0) to hijack the powers of any $(thing)Enderman$(0) within a large radius around it. Whenever an $(thing)Enderman$(0) attempts a teleport within said radius, it's instead forced to the location of the $(item)Vinculotus$(0).",
+  "botania.page.vinculotus0": "The $(item)Vinculotus$(0) uses $(thing)Mana$(0) to hijack the powers of any $(thing)Enderman$(0) within a large radius around it. Whenever an $(thing)Enderman$(0) attempts a teleport within said radius, it's instead forced to the location of the $(item)Vinculotus$(0).",
   "botania.page.vinculotus1": "$(o)Touch this black lotus with your fingers$().",
 
   "botania.entry.spectranthemum": "Spectranthemum",

--- a/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/basics/rune_altar.json
+++ b/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/basics/rune_altar.json
@@ -36,6 +36,7 @@
       "text": "botania.page.runeAltar22"
     },
     {
+      "anchor": "rune",
       "type": "botania:runic_altar",
       "text": "botania.page.runeAltar4",
       "recipe": "botania:runic_altar/water"

--- a/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/baubles/intro.json
+++ b/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/baubles/intro.json
@@ -1,7 +1,7 @@
 {
   "name": "botania.entry.bIntro",
   "category": "botania:baubles",
-  "icon": "minecraft:air",
+  "icon": "botania:cosmetic_questgiver_mark",
   "priority": true,
   "pages": [
     {

--- a/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/functional_flowers/flower_shrinking.json
+++ b/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/functional_flowers/flower_shrinking.json
@@ -21,8 +21,10 @@
     "botania:floating_bubbell_chibi": 1,
     "botania:floating_clayconia_chibi": 1,
     "botania:floating_hopperhock_chibi": 1,
+    "botania:floating_jiyuulia_chibi": 1,
     "botania:floating_marimorphosis_chibi": 1,
     "botania:floating_rannuncarpus_chibi": 1,
-    "botania:floating_solegnolia_chibi": 1
+    "botania:floating_solegnolia_chibi": 1,
+    "botania:floating_tangleberrie_chibi": 1
   }
 }

--- a/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/functional_flowers/intro.json
+++ b/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/functional_flowers/intro.json
@@ -1,7 +1,7 @@
 {
   "name": "botania.entry.fIntro",
   "category": "botania:functional_flowers",
-  "icon": "minecraft:air",
+  "icon": "botania:cosmetic_questgiver_mark",
   "priority": true,
   "advancement": "botania:main/mana_pool_pickup_lexicon",
   "pages": [

--- a/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/generating_flowers/intro.json
+++ b/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/generating_flowers/intro.json
@@ -1,7 +1,7 @@
 {
   "name": "botania.entry.gIntro",
   "category": "botania:generating_flowers",
-  "icon": "minecraft:air",
+  "icon": "botania:cosmetic_questgiver_mark",
   "priority": true,
   "advancement": "botania:main/pure_daisy_pickup",
   "pages": [

--- a/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/mana/intro.json
+++ b/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/mana/intro.json
@@ -1,7 +1,7 @@
 {
   "name": "botania.entry.mIntro",
   "category": "botania:mana",
-  "icon": "minecraft:air",
+  "icon": "botania:cosmetic_questgiver_mark",
   "priority": true,
   "advancement": "botania:main/pure_daisy_pickup",
   "pages": [


### PR DESCRIPTION
- Standardizes one entry about Mana
- Fixes one entry about Mana
- Replaces the boring "minecraft:air" icon by the cooler "botania:cosmetic_questgiver_mark" icon
- Adds "rune" anchor (i'd like to have it for the french translation)
- Adds lexicon link for some floating chibi flowers
- Fixes entries about Elven lore