### PR TITLE
Replace some default titles

### DIFF
--- a/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/basics/wand.json
+++ b/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/basics/wand.json
@@ -19,6 +19,7 @@
     },
     {
       "type": "crafting",
+      "title":"botania.entry.wand",
       "text": "botania.page.wand3",
       "recipe": "botania:twig_wand"
     }

--- a/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/functional_flowers/marimorphosis.json
+++ b/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/functional_flowers/marimorphosis.json
@@ -23,6 +23,7 @@
     },
     {
       "type": "botania:crafting_multi",
+      "heading":"botania.entry.apothecary",
       "text": "botania.page.marimorphosis3",
       "recipes": [
         "botania:apothecary_forest",

--- a/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/mana/spark_upgrades.json
+++ b/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/mana/spark_upgrades.json
@@ -27,6 +27,7 @@
     },
     {
       "type": "botania:crafting_multi",
+      "heading":"botania.entry.sparkUpgrades",
       "text": "botania.page.sparkUpgrades5",
       "recipes": [
         "botania:spark_upgrade_dispersive",

--- a/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/misc/mushrooms.json
+++ b/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/misc/mushrooms.json
@@ -10,6 +10,7 @@
     },
     {
       "type": "botania:crafting_multi",
+      "heading":"botania.entry.mushrooms",
       "text": "botania.page.mushrooms1",
       "recipes": [
         "botania:mushroom_0",

--- a/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/misc/pavement.json
+++ b/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/misc/pavement.json
@@ -9,6 +9,7 @@
     },
     {
       "type": "botania:crafting_multi",
+      "heading":"botania.entry.pavement",
       "text": "botania.page.pavement1",
       "recipes": [
         "botania:white_pavement",

--- a/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/tools/grass_seeds.json
+++ b/Common/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/tools/grass_seeds.json
@@ -29,6 +29,7 @@
     },
     {
       "type": "botania:crafting_multi",
+      "heading":"botania.entry.grassSeeds",
       "text": "botania.page.grassSeeds5",
       "recipes": [
         "botania:dry_seeds",


### PR DESCRIPTION
**crafting_multi** and **mana_infusion** will use the first element when no **heading** is provided, which sometimes creates weird titles.

Below are the elements i would have liked to change.

But i didn't change them because i preferred to re-use existing (and already translated) entries.

If you think that's not a big deal to add new un-translated entries, i can add those as well.

<br>

### crafting_multi

| Resource | Heading |
| ------------- | ------------- |
| misc/shiny_flowers.json | Glimmering Flower |
| misc/shiny_flowers.json | Floating Flower |
| basics/flowers.json | Mystical Petal |
| devices/craft_crate.json | Crafting Pattern |

<br>

### mana_infusion

| Resource | Heading |
| ------------- | ------------- |
| mana_conjuration.json | Leaves |
| mana/pool.json | Manasteel |
| devices/mana_alchemy.json | Seeds |
| devices/mana_alchemy.json | Stone |
| devices/mana_alchemy.json | Grass |
| devices/mana_alchemy.json | Wood |
| devices/mana_alchemy.json | Sapling |
| devices/mana_alchemy.json | Quartz |
| devices/mana_alchemy.json | Vine & Lilypad |
| devices/mana_alchemy.json | Slimeball & Cactus |
| devices/mana_alchemy.json | Glowstone & Redstone |
| devices/mana_alchemy.json | Clay & Brick |
| devices/mana_alchemy.json | Flower |
| devices/mana_alchemy.json | Apple & Berries |
