### PR TITLE
[1.12] Fix comparator signal of corporea crystal cubes after reloading

### DIFF
--- a/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaCrystalCube.java
+++ b/src/main/java/vazkii/botania/common/block/tile/corporea/TileCorporeaCrystalCube.java
@@ -134,6 +134,7 @@ public class TileCorporeaCrystalCube extends TileCorporeaBase implements ICorpor
 		NBTTagCompound cmp = par1nbtTagCompound.getCompoundTag(TAG_REQUEST_TARGET);
 		requestTarget = new ItemStack(cmp);
 		itemCount = par1nbtTagCompound.getInteger(TAG_ITEM_COUNT);
+		compValue = CorporeaHelper.signalStrengthForRequestSize(itemCount);
 		locked = par1nbtTagCompound.getBoolean(TAG_LOCK);
 	}
 


### PR DESCRIPTION
This fixes #3763, but for 1.12. Loosely based on f60aa3d348778755e62700ab4fcbacc59883f3ac by williewillus.

I know 1.12 already had two "final" releases. So I'll understand if you don't make another one. I made this to scratch my own itch and I'm sharing it just in case it's useful.