### PR TITLE
[1.12] Fix log error spam from red string spoofers

### DIFF
--- a/src/main/java/vazkii/botania/api/internal/DummyMethodHandler.java
+++ b/src/main/java/vazkii/botania/api/internal/DummyMethodHandler.java
@@ -221,4 +221,9 @@ public class DummyMethodHandler implements IInternalMethodHandler {
 		return null;
 	}
 
+	@Override
+	public BlockPos getRealFlowerPos(TileEntity supertile) {
+		return supertile.getPos();
+	}
+
 }

--- a/src/main/java/vazkii/botania/api/internal/IInternalMethodHandler.java
+++ b/src/main/java/vazkii/botania/api/internal/IInternalMethodHandler.java
@@ -130,4 +130,6 @@ public interface IInternalMethodHandler {
 	 */
 	List<IWrappedInventory> wrapInventory(List<InvWithLocation> inventories);
 
+	public BlockPos getRealFlowerPos(TileEntity supertile);
+
 }

--- a/src/main/java/vazkii/botania/api/subtile/SubTileEntity.java
+++ b/src/main/java/vazkii/botania/api/subtile/SubTileEntity.java
@@ -96,7 +96,10 @@ public class SubTileEntity {
 	public void readFromPacketNBT(NBTTagCompound cmp) { }
 
 	public void sync() {
+		BlockPos effectivePos = supertile.getPos();
+		supertile.setPos(BotaniaAPI.internalHandler.getRealFlowerPos(supertile));
 		VanillaPacketDispatcher.dispatchTEToNearbyPlayers(supertile);
+		supertile.setPos(effectivePos);
 	}
 
 	public String getUnlocalizedName() {

--- a/src/main/java/vazkii/botania/common/block/tile/TileSpecialFlower.java
+++ b/src/main/java/vazkii/botania/common/block/tile/TileSpecialFlower.java
@@ -45,6 +45,7 @@ public class TileSpecialFlower extends TileMod implements IWandBindable, ISubTil
 
 	public String subTileName = "";
 	private SubTileEntity subTile;
+	private BlockPos originalFlowerPos;
 
 	@Override
 	public SubTileEntity getSubTile() {
@@ -82,10 +83,12 @@ public class TileSpecialFlower extends TileMod implements IWandBindable, ISubTil
 			if(tileBelow instanceof TileRedStringRelay) {
 				BlockPos coords = ((TileRedStringRelay) tileBelow).getBinding();
 				if(coords != null) {
+					originalFlowerPos = pos;
 					BlockPos currPos = pos;
 					setPos(coords);
 					subTile.onUpdate();
 					setPos(currPos);
+					originalFlowerPos = null;
 
 					world.profiler.endSection();
 					return;
@@ -105,6 +108,10 @@ public class TileSpecialFlower extends TileMod implements IWandBindable, ISubTil
 			subTile.overgrowthBoost = false;
 			world.profiler.endSection();
 		}
+	}
+
+	public BlockPos getRealFlowerPos() {
+		return originalFlowerPos != null ? originalFlowerPos : getPos();
 	}
 
 	public boolean isOnSpecialSoil() {

--- a/src/main/java/vazkii/botania/common/core/handler/InternalMethodHandler.java
+++ b/src/main/java/vazkii/botania/common/core/handler/InternalMethodHandler.java
@@ -54,6 +54,7 @@ import vazkii.botania.common.block.BlockModFlower;
 import vazkii.botania.common.block.ModBlocks;
 import vazkii.botania.common.block.decor.BlockFloatingFlower;
 import vazkii.botania.common.block.subtile.functional.SubTileSolegnolia;
+import vazkii.botania.common.block.tile.TileSpecialFlower;
 import vazkii.botania.common.integration.corporea.WrappedIInventory;
 import vazkii.botania.common.item.ModItems;
 import vazkii.botania.common.item.block.ItemBlockSpecialFlower;
@@ -281,4 +282,14 @@ public class InternalMethodHandler extends DummyMethodHandler {
 		}
 		return arrayList;
 	}
+
+	@Override
+	public BlockPos getRealFlowerPos(TileEntity supertile) {
+		if (supertile instanceof TileSpecialFlower) {
+			return ((TileSpecialFlower) supertile).getRealFlowerPos();
+		} else {
+			return supertile.getPos();
+		}
+	}
+
 }


### PR DESCRIPTION
Red string spoofers spam the log files with lines like this:
`[23:59:59] [Client thread/ERROR] [net.minecraft.client.network.NetHandlerPlayClient]: Received invalid update packet for null tile entity at BlockPos{x=-625, y=81, z=-1314} with data: {subTileCmp:{poolZ:-1314,poolX:-625,poolY:78,mana:200,ticksExisted:1132000},subTileName:"agricarnationChibi"}`

Each time a spoofed flower calls sync(), it sends a TE update packet with the wrong position, which prints the error. It's probably harmless, but I got a bit annoyed by the waste of disk, so I made this fix. It makes sync() temporarily setPos() it back to the original position.

I know 1.12 already had two "final" releases. So I'll understand if you don't make another one. I made this to scratch my own itch and I'm sharing it just in case it's useful.