### PR TITLE
[1.12] Make exoflames a bit less laggy by searching for furnaces every 2 seconds

### DIFF
--- a/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileExoflame.java
+++ b/src/main/java/vazkii/botania/common/block/subtile/functional/SubTileExoflame.java
@@ -23,12 +23,17 @@ import vazkii.botania.api.lexicon.LexiconEntry;
 import vazkii.botania.api.subtile.RadiusDescriptor;
 import vazkii.botania.api.subtile.SubTileFunctional;
 import vazkii.botania.common.lexicon.LexiconData;
+import java.util.ArrayList;
+import java.util.List;
 
 public class SubTileExoflame extends SubTileFunctional {
 
 	private static final int RANGE = 5;
 	private static final int RANGE_Y = 2;
 	private static final int COST = 300;
+
+	private List<BlockPos> cachedPositions;
+	private int cachedPositionsTime = -1;
 
 	@Override
 	public void onUpdate() {
@@ -39,7 +44,20 @@ public class SubTileExoflame extends SubTileFunctional {
 
 		boolean did = false;
 
-		for(BlockPos pos : BlockPos.getAllInBox(getPos().add(-RANGE, -RANGE_Y, -RANGE), getPos().add(RANGE, RANGE_Y, RANGE))) {
+		if (cachedPositions == null || ticksExisted - cachedPositionsTime >= 40) {
+			cachedPositions = new ArrayList<BlockPos>();
+			cachedPositionsTime = ticksExisted;
+
+			for(BlockPos pos : BlockPos.getAllInBox(getPos().add(-RANGE, -RANGE_Y, -RANGE), getPos().add(RANGE, RANGE_Y, RANGE))) {
+				TileEntity tile = supertile.getWorld().getTileEntity(pos);
+				Block block = supertile.getWorld().getBlockState(pos).getBlock();
+				if (tile instanceof TileEntityFurnace || tile instanceof IExoflameHeatable) {
+					cachedPositions.add(pos);
+				}
+			}
+		}
+
+		for(BlockPos pos : cachedPositions) {
 			TileEntity tile = supertile.getWorld().getTileEntity(pos);
 			Block block = supertile.getWorld().getBlockState(pos).getBlock();
 			if(tile != null) {


### PR DESCRIPTION
This caches the list of block positions where an exoflame found a furnace. I made it because it irked me that my exoflames use more MSPT than any other TE when they aren't even doing anything.

I know 1.12 already had two "final" releases. So I'll understand if you don't make another one. I made this to scratch my own itch and I'm sharing it just in case it's useful. (And maybe somebody can port the idea to the current version...)

Performance test:
I made a void world with doMobSpawning disabled, a creative pool, 5x4x5 floating exoflames, and 1 furnace.
Before: "/forge tps" says 6.0-7.0 mspt overall. LagGoggles says sum of TileFloatingSpecialFlower is 5242 μs/t.
After: "/forge tps" says 1.5-2.4 mspt overall. LagGoggles says sum of TileFloatingSpecialFlower is 271 μs/t.
