### PR TITLE
Tweak the Tiny Potato's inventory

### DIFF
--- a/Common/src/main/java/vazkii/botania/common/block/decor/BlockTinyPotato.java
+++ b/Common/src/main/java/vazkii/botania/common/block/decor/BlockTinyPotato.java
@@ -60,6 +60,20 @@ public class BlockTinyPotato extends BlockModWaterloggable implements EntityBloc
 	}
 
 	@Override
+	public boolean hasAnalogOutputSignal(BlockState state) {
+		return true;
+	}
+
+	@Override
+	public int getAnalogOutputSignal(BlockState state, Level level, BlockPos pos) {
+		if (level.getBlockEntity(pos) instanceof TileTinyPotato tater) {
+			return tater.getAnalogOutputSignal();
+		} else {
+			return 0;
+		}
+	}
+
+	@Override
 	public void onRemove(@Nonnull BlockState state, @Nonnull Level world, @Nonnull BlockPos pos, @Nonnull BlockState newState, boolean isMoving) {
 		if (!state.is(newState.getBlock())) {
 			BlockEntity be = world.getBlockEntity(pos);

--- a/Common/src/main/java/vazkii/botania/common/block/tile/TileTinyPotato.java
+++ b/Common/src/main/java/vazkii/botania/common/block/tile/TileTinyPotato.java
@@ -21,6 +21,7 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.Nameable;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
@@ -40,11 +41,13 @@ import static vazkii.botania.common.lib.ResourceLocationHelper.prefix;
 
 public class TileTinyPotato extends TileExposedSimpleInventory implements Nameable {
 	private static final String TAG_NAME = "name";
+	private static final String TAG_SIGNAL = "signal";
 	private static final int JUMP_EVENT = 0;
 
 	public int jumpTicks = 0;
 	public Component name = new TextComponent("");
 	private int nextDoIt = 0;
+	private int comparatorSignal = 0;
 
 	public TileTinyPotato(BlockPos pos, BlockState state) {
 		super(ModTiles.TINY_POTATO, pos, state);
@@ -134,22 +137,27 @@ public class TileTinyPotato extends TileExposedSimpleInventory implements Nameab
 	public void writePacketNBT(CompoundTag cmp) {
 		super.writePacketNBT(cmp);
 		cmp.putString(TAG_NAME, Component.Serializer.toJson(name));
+		cmp.putInt(TAG_SIGNAL, comparatorSignal);
 	}
 
 	@Override
 	public void readPacketNBT(CompoundTag cmp) {
 		super.readPacketNBT(cmp);
 		name = Component.Serializer.fromJson(cmp.getString(TAG_NAME));
+		comparatorSignal = cmp.getInt(TAG_SIGNAL);
 	}
 
 	@Override
 	protected SimpleContainer createItemHandler() {
-		return new SimpleContainer(6) {
+		SimpleContainer container = new SimpleContainer(6) {
 			@Override
 			public int getMaxStackSize() {
 				return 1;
 			}
 		};
+
+		container.addListener(cont -> comparatorSignal = AbstractContainerMenu.getRedstoneSignalFromContainer(cont));
+		return container;
 	}
 
 	@Nonnull
@@ -168,5 +176,9 @@ public class TileTinyPotato extends TileExposedSimpleInventory implements Nameab
 	@Override
 	public Component getDisplayName() {
 		return hasCustomName() ? getCustomName() : getName();
+	}
+
+	public int getAnalogOutputSignal() {
+		return comparatorSignal;
 	}
 }

--- a/Common/src/main/java/vazkii/botania/common/block/tile/TileTinyPotato.java
+++ b/Common/src/main/java/vazkii/botania/common/block/tile/TileTinyPotato.java
@@ -144,7 +144,12 @@ public class TileTinyPotato extends TileExposedSimpleInventory implements Nameab
 
 	@Override
 	protected SimpleContainer createItemHandler() {
-		return new SimpleContainer(6);
+		return new SimpleContainer(6) {
+			@Override
+			public int getMaxStackSize() {
+				return 1;
+			}
+		};
 	}
 
 	@Nonnull


### PR DESCRIPTION
### Nerf tiny potatoes

I noticed that you can use a hopper to insert and remove items from a Tiny Potato. This is, without a doubt, one of the features of all time. Possibly ever.

However! Automation can insert full stacks of 64 items into each of the six slots of the tiny potato inventory, but a player right clicking can only add one item per slot. I found this really confusing because if you hopped items into a Tiny Potato it looked like they were disappearing.

So the first commit only allows tiny potatoes to hold 1 item per slot. This makes Tiny Potatoes much less effective as a mass storage solution, and I predict it will drastically upset the Tiny Potato meta. But it brings their automation-side interface closer to what people would expect it to be, based on how it feels to interact with the block.

### Buff tiny potatoes

Ok, so now comparators can read the fill-level of the tiny potato inventory. Why the hell not