### PR TITLE
Hotfix #4022 (crash when inserting unstackable items with corporea)

### DIFF
--- a/Fabric/src/main/java/vazkii/botania/fabric/xplat/FabricXplatImpl.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/xplat/FabricXplatImpl.java
@@ -311,6 +311,11 @@ public class FabricXplatImpl implements IXplatAbstractions {
 
 	@Override
 	public ItemStack insertToInventory(Level level, BlockPos pos, Direction sideOfPos, ItemStack toInsert, boolean simulate) {
+		if (toInsert.isEmpty()) {
+			//It is valid for Storage#insert implementations to crash when provided empty variants
+			return toInsert;
+		}
+
 		var state = level.getBlockState(pos);
 		var be = level.getBlockEntity(pos);
 		var storage = ItemStorage.SIDED.find(level, pos, state, be, sideOfPos);


### PR DESCRIPTION
This PR as a patch: https://patch-diff.githubusercontent.com/raw/VazkiiMods/Botania/pull/4038.patch

This prevents attempting to insert `ItemStack.EMPTY` into an inventory crashing on Fabric.

One reason that this might be attempted is because an unstackable item was requested out of a chest over corporea, because corporea also reports an additional `ItemStack.EMPTY` result when that happens, for some reason (which is also what causes the missing-texture corporea particles.) Not sure why.

This PR does not fix the root cause, but it at least fixes the crash (we got into a real bad crash loop on Blanketcon)