### PR TITLE
Add support for Ears

### DIFF
--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -82,6 +82,13 @@ repositories {
         name = "ParchmentMC"
         url = "https://maven.parchmentmc.net/"
     }
+    maven {
+        name = "Unascribed"
+        url "https://repo.unascribed.com" // for ears
+        content {
+            includeGroup "com.unascribed"
+        }
+    }
 }
 
 dependencies {
@@ -130,6 +137,8 @@ dependencies {
     modCompileOnly 'teamreborn:energy:2.1.0'
 
     modCompileOnly 'com.blamejared.crafttweaker:CraftTweaker-fabric-1.18.2:9.1.123'
+
+    modCompileOnly 'com.unascribed:ears-api:1.4.5'
 }
 
 compileJava {

--- a/Fabric/src/main/java/vazkii/botania/fabric/client/FabricClientInitializer.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/client/FabricClientInitializer.java
@@ -44,6 +44,7 @@ import vazkii.botania.client.gui.ManaBarTooltipComponent;
 import vazkii.botania.client.gui.TooltipHandler;
 import vazkii.botania.client.gui.bag.GuiFlowerBag;
 import vazkii.botania.client.gui.box.GuiBaubleBox;
+import vazkii.botania.client.integration.ears.EarsIntegration;
 import vazkii.botania.client.model.ModLayerDefinitions;
 import vazkii.botania.client.model.armor.ArmorModels;
 import vazkii.botania.client.render.BlockRenderLayers;
@@ -117,6 +118,10 @@ public class FabricClientInitializer implements ClientModInitializer {
 
 		registerArmors();
 		registerCapabilities();
+
+		if (IXplatAbstractions.INSTANCE.isModLoaded("ears")) {
+			EarsIntegration.register();
+		}
 	}
 
 	private static void registerCapabilities() {

--- a/Forge/build.gradle
+++ b/Forge/build.gradle
@@ -42,6 +42,13 @@ repositories {
         name = "C4"
         url = "https://maven.theillusivec4.top/"
     }
+    maven {
+        name = "Unascribed"
+        url "https://repo.unascribed.com" // for ears
+        content {
+            includeGroup "com.unascribed"
+        }
+    }
 }
 
 minecraft {
@@ -107,6 +114,8 @@ dependencies {
     runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:1.18.2-5.0.6.3")
 
     compileOnly fg.deobf('com.blamejared.crafttweaker:CraftTweaker-forge-1.18.2:9.1.123')
+
+    compileOnly fg.deobf('com.unascribed:ears-api:1.4.5')
 }
 
 compileJava {

--- a/Forge/src/main/java/vazkii/botania/forge/client/ForgeClientInitializer.java
+++ b/Forge/src/main/java/vazkii/botania/forge/client/ForgeClientInitializer.java
@@ -47,6 +47,7 @@ import vazkii.botania.client.gui.ManaBarTooltipComponent;
 import vazkii.botania.client.gui.TooltipHandler;
 import vazkii.botania.client.gui.bag.GuiFlowerBag;
 import vazkii.botania.client.gui.box.GuiBaubleBox;
+import vazkii.botania.client.integration.ears.EarsIntegration;
 import vazkii.botania.client.model.ModLayerDefinitions;
 import vazkii.botania.client.render.BlockRenderLayers;
 import vazkii.botania.client.render.ColorHandler;
@@ -143,6 +144,10 @@ public class ForgeClientInitializer {
 		ClientProxy.initSeasonal();
 		ClientProxy.initKeybindings(ClientRegistry::registerKeyBinding);
 		MinecraftForge.EVENT_BUS.addGenericListener(BlockEntity.class, ForgeClientInitializer::attachBeCapabilities);
+
+		if (IXplatAbstractions.INSTANCE.isModLoaded("ears")) {
+			EarsIntegration.register();
+		}
 	}
 
 	private static final Supplier<Map<BlockEntityType<?>, Function<BlockEntity, IWandHUD>>> WAND_HUD = Suppliers.memoize(() -> {

--- a/Forge/src/main/resources/META-INF/mods.toml
+++ b/Forge/src/main/resources/META-INF/mods.toml
@@ -40,3 +40,8 @@ configBackground="botania:textures/block/livingrock_bricks.png" # background for
     modId="crafttweaker"
     mandatory=false
     versionRange="[9.1.116,)"
+
+[[dependencies.botania]]
+    modId="ears"
+    mandatory=false
+    versionRange="[1.4.5,)"

--- a/Xplat/build.gradle
+++ b/Xplat/build.gradle
@@ -19,6 +19,13 @@ repositories {
         name = "Jared"
         url = "https://maven.blamejared.com/"
     }
+    maven {
+        name = "Unascribed"
+        url "https://repo.unascribed.com" // for ears
+        content {
+            includeGroup "com.unascribed"
+        }
+    }
 }
 
 dependencies {
@@ -30,6 +37,8 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.1'
 
     compileOnly 'com.blamejared.crafttweaker:CraftTweaker-common-1.18.2:9.1.123'
+
+    compileOnly "com.unascribed:ears-api:1.4.5"
 
     annotationProcessor 'com.blamejared.crafttweaker:Crafttweaker_Annotation_Processors-1.18.2:2.0.0.123'
     annotationProcessor 'com.blamejared.crafttweaker:CraftTweaker-common-1.18.2:9.1.123'

--- a/Xplat/src/main/java/vazkii/botania/client/integration/ears/EarsIntegration.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/ears/EarsIntegration.java
@@ -1,19 +1,26 @@
 package vazkii.botania.client.integration.ears;
 
+import com.unascribed.ears.api.EarsFeatureType;
 import com.unascribed.ears.api.OverrideResult;
+import com.unascribed.ears.api.registry.EarsInhibitorRegistry;
 import com.unascribed.ears.api.registry.EarsStateOverriderRegistry;
 
+import net.minecraft.world.Container;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
 import vazkii.botania.api.item.IPhantomInkable;
+import vazkii.botania.common.handler.EquipmentHandler;
+import vazkii.botania.common.item.equipment.bauble.ItemFlightTiara;
+import vazkii.botania.common.lib.LibMisc;
 
 public class EarsIntegration {
-	public void register() {
-		EarsStateOverriderRegistry.register("botania", (state, peer) -> {
-			if (!(peer instanceof Player player))
+	public static void register() {
+		EarsStateOverriderRegistry.register(LibMisc.MOD_ID, (state, peer) -> {
+			if (!(peer instanceof Player player)) {
 				return OverrideResult.DEFAULT;
+			}
 
 			EquipmentSlot slot = null;
 			switch (state) {
@@ -22,16 +29,44 @@ public class EarsIntegration {
 				case WEARING_LEGGINGS -> slot = EquipmentSlot.LEGS;
 				case WEARING_BOOTS -> slot = EquipmentSlot.FEET;
 			}
-			if (slot == null)
+
+			if (slot == null) {
 				return OverrideResult.DEFAULT;
+			}
 
 			ItemStack stack = player.getItemBySlot(slot);
-			if (!(stack.getItem() instanceof IPhantomInkable item))
+			if (!(stack.getItem() instanceof IPhantomInkable item)) {
 				return OverrideResult.DEFAULT;
+			}
 
-			if (!item.hasPhantomInk(stack))
+			if (!item.hasPhantomInk(stack)) {
 				return OverrideResult.DEFAULT;
+			}
+
 			return OverrideResult.FALSE;
 		});
+
+		EarsInhibitorRegistry.register(LibMisc.MOD_ID, ((type, peer) -> {
+			if (type != EarsFeatureType.WINGS) {
+				return false;
+			}
+
+			if (!(peer instanceof Player player)) {
+				return false;
+			}
+
+			Container equipment = EquipmentHandler.getAllWorn(player);
+
+			for (int slot = 0; slot < equipment.getContainerSize(); slot++) {
+				ItemStack item = equipment.getItem(slot);
+				if (item.getItem() instanceof ItemFlightTiara tiara &&
+						tiara.hasRender(item, player) &&
+						ItemFlightTiara.getVariant(item) > 0) {
+					return true;
+				}
+			}
+
+			return false;
+		}));
 	};
 }

--- a/Xplat/src/main/java/vazkii/botania/client/integration/ears/EarsIntegration.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/ears/EarsIntegration.java
@@ -1,0 +1,37 @@
+package vazkii.botania.client.integration.ears;
+
+import com.unascribed.ears.api.OverrideResult;
+import com.unascribed.ears.api.registry.EarsStateOverriderRegistry;
+
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+import vazkii.botania.api.item.IPhantomInkable;
+
+public class EarsIntegration {
+	public void register() {
+		EarsStateOverriderRegistry.register("botania", (state, peer) -> {
+			if (!(peer instanceof Player player))
+				return OverrideResult.DEFAULT;
+
+			EquipmentSlot slot = null;
+			switch (state) {
+				case WEARING_HELMET -> slot = EquipmentSlot.HEAD;
+				case WEARING_CHESTPLATE -> slot = EquipmentSlot.CHEST;
+				case WEARING_LEGGINGS -> slot = EquipmentSlot.LEGS;
+				case WEARING_BOOTS -> slot = EquipmentSlot.FEET;
+			}
+			if (slot == null)
+				return OverrideResult.DEFAULT;
+
+			ItemStack stack = player.getItemBySlot(slot);
+			if (!(stack.getItem() instanceof IPhantomInkable item))
+				return OverrideResult.DEFAULT;
+
+			if (!item.hasPhantomInk(stack))
+				return OverrideResult.DEFAULT;
+			return OverrideResult.FALSE;
+		});
+	};
+}


### PR DESCRIPTION
This PR does the following when [Ears](https://ears.unascribed.com/) is installed:
- If phantom-inked armor is worn; Ears will act as if there isn't anything in that slot (feet claws will show with invisible boots, for example).
- If a Flügel tiara with wings is worn, Ears' wings will be hidden.
# Testing skin
This skin can be used to test compatibility. Simply use this as a normal Minecraft skin.
![test](https://user-images.githubusercontent.com/87955906/177235246-60a04780-03cb-4348-ab9e-4c6d79c462ca.png)