### PR TITLE
Add sortnum to intro entries

### DIFF
--- a/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/baubles/intro.json
+++ b/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/baubles/intro.json
@@ -3,6 +3,7 @@
   "category": "botania:baubles",
   "icon": "botania:cosmetic_questgiver_mark",
   "priority": true,
+  "sortnum": -10,
   "pages": [
     {
       "type": "text",

--- a/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/functional_flowers/intro.json
+++ b/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/functional_flowers/intro.json
@@ -4,6 +4,7 @@
   "icon": "botania:cosmetic_questgiver_mark",
   "priority": true,
   "advancement": "botania:main/mana_pool_pickup_lexicon",
+  "sortnum": -10,
   "pages": [
     {
       "type": "text",

--- a/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/mana/intro.json
+++ b/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/mana/intro.json
@@ -4,6 +4,7 @@
   "icon": "botania:cosmetic_questgiver_mark",
   "priority": true,
   "advancement": "botania:main/pure_daisy_pickup",
+  "sortnum": -10,
   "pages": [
     {
       "type": "text",


### PR DESCRIPTION
[High priority entries are sorted alphabetically](https://vazkiimods.github.io/Patchouli/docs/reference/entry-json), which means that in some langages (french, japanese, ...) the entry "intro" will not be the first one.

Exemple : 
![image](https://user-images.githubusercontent.com/43409914/183270977-40352361-8fc9-49d8-b70c-5d8c3b613189.png)
