### PR TITLE
Munchdew eating order weighted by distance from logs

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileMunchdew.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/subtile/generating/SubTileMunchdew.java
@@ -61,13 +61,13 @@ public class SubTileMunchdew extends TileEntityGeneratingFlower {
 				List<BlockPos> coords = new ArrayList<>();
 				BlockPos pos = getEffectivePos();
 
-				nextCoord: for (BlockPos pos_ : BlockPos.betweenClosed(pos.offset(-RANGE, 0, -RANGE),
+				for (BlockPos pos_ : BlockPos.betweenClosed(pos.offset(-RANGE, 0, -RANGE),
 						pos.offset(RANGE, RANGE_Y, RANGE))) {
 					if (getLevel().getBlockState(pos_).is(BlockTags.LEAVES)) {
 						for (Direction dir : Direction.values()) {
 							if (getLevel().isEmptyBlock(pos_.relative(dir))) {
 								coords.add(pos_.immutable());
-								break nextCoord;
+								break;
 							}
 						}
 					}


### PR DESCRIPTION
This change makes the Munchdew randomly select leaves to eat from among those that are furthest away from logs (as specified via their distance property), rather than strictly iterating over X/Y/Z coordinates. The selection weighting contains an added amount of randomness to deviate a bit from strict Manhattan distance. The requirement for leaves to have air exposure before being selected remains untouched.