### PR TITLE
Add priority to "Basics of Corporea" (#4105)

### DIFF
--- a/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/ender/corporea.json
+++ b/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/ender/corporea.json
@@ -2,6 +2,7 @@
   "name": "botania.entry.corporea",
   "category": "botania:ender",
   "icon": "botania:corporea_spark",
+  "priority": true,
   "entry_color": "aa00",
   "advancement": "botania:main/elf_lexicon_pickup",
   "pages": [


### PR DESCRIPTION
If `Basics of Corporea` is just like `Introduction to Mana` or `An Introduction to Function`, then it would be better to use the tag "priority" to make sure it appears first (_once the entry is unlocked_).

Indirectly related to https://github.com/VazkiiMods/Botania/pull/4105.