### PR TITLE
Disables entry about banners

### DIFF
--- a/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/misc/banners.json
+++ b/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/misc/banners.json
@@ -2,6 +2,7 @@
   "name": "botania.entry.banners",
   "category": "botania:misc",
   "icon": "botania:lexicon",
+  "flag": "debug",
   "pages": [
     {
       "type": "text",


### PR DESCRIPTION
In the version 1.18 of Botania, banner patterns are disabled.

So i feel like it would be better to hide this entry, otherwise players will think that the Lexica Botania is lying.

<br>

**Examples** :
- https://github.com/VazkiiMods/Botania/blob/1.18.x/Xplat/src/main/java/vazkii/botania/common/block/ModPatterns.java
- https://github.com/VazkiiMods/Botania/blob/1.18.x/Xplat/src/main/java/vazkii/botania/common/item/ItemModPattern.java