### PR TITLE
Remove all duplicate translation keys

### DIFF
--- a/Xplat/src/main/resources/assets/botania/lang/nl_nl.json
+++ b/Xplat/src/main/resources/assets/botania/lang/nl_nl.json
@@ -132,7 +132,6 @@
   "botania.wings1": "Vleugels: Flügel",
   "botania.wings2": "Vleugels: Enkelgevleugelde Engel",
   "botania.wings3": "Vleugels: Ijs Fee",
-  "botania.wings4": "Vleugels: Feniks",
   "botania.wings4": "Vleugels: Vuurmeester",
   "botania.wings5": "Vleugels: Zwarte Sneeuw Prinses",
   "botania.wings6": "Vleugels: Meester der Schacht",

--- a/Xplat/src/main/resources/assets/botania/lang/pt_br.json
+++ b/Xplat/src/main/resources/assets/botania/lang/pt_br.json
@@ -239,7 +239,6 @@
   "flowerTextures.alt": "Texturas alternativas em flores",
   "matrixMode.enabled": "Permitir Modo Matrix",
   "references.enabled": "Permitir referências na tooltip do item",
-  "shaders.enabled": "Permitir Shaders do mod",
   "spreader.posShift": "Mudança de posição do Dispersor",
   "versionChecking.enabled": "Permitir checagem de versões",
   "shaders.enabled": "Permitir shaders",


### PR DESCRIPTION
While writing & testing some other script related javascript i noticed that my native language had a duplicate key.

So i wrote this small thing which found just one more in another language, so i have remove that one as well.

Leaving the script used here as text, since committing it doesn't make much sense since it was single use.

```js
const fs = require('fs')

const lang_directory = `${__dirname}/../Xplat/src/main/resources/assets/botania/lang`;
const files = fs.readdirSync(lang_directory);

files.forEach(function (file) {

  const encountered_keys = {};

  console.log(file);

  const lines = fs.readFileSync(`${lang_directory}/${file}`, 'utf8').split('\n');
  const new_lines = []

  lines.forEach((line, i) => {
    if (line.startsWith('  "')) {
      const [,key] = /^  "(.*)": "/.exec(line);

      if (encountered_keys[key] == undefined) {
        encountered_keys[key] = true
      } else {
        console.log(`- ${key}`)
      }
    }
  })
});
```

```
$ node scripts/duplicate_lang_keys.js
de_de.json
en_us.json
es_ar.json
es_es.json
fr_fr.json
ja_jp.json
ko_kr.json
nl_nl.json
- botania.wings4
pt_br.json
- shaders.enabled
ru_ru.json
zh_cn.json
zh_tw.json
```