### PR TITLE
Add tooltips for livingwood/livingrock

### DIFF
--- a/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/basics/pure_daisy.json
+++ b/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/basics/pure_daisy.json
@@ -35,11 +35,23 @@
   "extra_recipe_mappings": {
     "botania:floating_pure_daisy": 1,
     "botania:livingrock": 1,
+    "botania:livingrock_wall": 1,
+    "botania:livingrock_stairs": 1,
+    "botania:livingrock_slab": 1,
     "botania:livingwood": 1,
     "botania:livingwood_log": 1,
-    "minecraft:snow": 1,
-    "minecraft:packed_ice": 1,
-    "minecraft:blue_ice": 1,
-    "minecraft:obsidian": 1
+    "botania:stripped_livingwood_slab": 1,
+    "botania:livingwood_slab": 1,
+    "botania:livingwood_stairs": 1,
+    "botania:livingwood_wall": 1,
+    "botania:stripped_livingwood_log": 1,
+    "botania:stripped_livingwood_wall": 1,
+    "botania:stripped_livingwood": 1,
+    "botania:stripped_livingwood_stairs": 1,
+    "minecraft:cobblestone": 3,
+    "minecraft:snow_block": 3,
+    "minecraft:packed_ice": 3,
+    "minecraft:blue_ice": 3,
+    "minecraft:obsidian": 3
   }
 }

--- a/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/misc/decorative_blocks.json
+++ b/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/misc/decorative_blocks.json
@@ -92,5 +92,19 @@
       "text": "botania.page.decorativeBlocks23",
       "recipe": "botania:quartz_sunny"
     }
-  ]
+  ],
+  "extra_recipe_mappings": {
+    "botania:livingrock_bricks_stairs": 1,
+    "botania:livingrock_bricks_slab": 1,
+    "botania:livingrock_bricks_wall": 1,
+    "botania:mossy_livingrock_bricks_wall": 2,
+    "botania:mossy_livingrock_bricks_stairs": 2,
+    "botania:mossy_livingrock_bricks_slab": 2,
+    "botania:livingwood_fence": 5,
+    "botania:livingwood_planks_stairs": 5,
+    "botania:livingwood_fence_gate": 5,
+    "botania:livingwood_planks_slab": 5,
+    "botania:glimmering_stripped_livingwood_log": 9,
+    "botania:glimmering_stripped_livingwood": 9
+  }
 }


### PR DESCRIPTION
Some blocks were missing some `extra_recipe_mappings`.

<br>

Blocks on the same line have the same mappings.

<br>

![image](https://user-images.githubusercontent.com/43409914/197624862-ebb2055e-7bb5-443f-9c28-43e4aa16d99e.png)

![image](https://user-images.githubusercontent.com/43409914/197625176-1ff7d99e-501a-487a-90e1-d3fe800c4b80.png)

