### PR TITLE
Fix Click consumption on PA and RA

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/PetalApothecaryBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/PetalApothecaryBlock.java
@@ -113,8 +113,7 @@ public class PetalApothecaryBlock extends BotaniaBlock implements EntityBlock {
 		boolean mainHandEmpty = player.getMainHandItem().isEmpty();
 
 		if (apothecary.canAddLastRecipe() && mainHandEmpty) {
-			apothecary.trySetLastRecipe(player);
-			return InteractionResult.SUCCESS;
+			return apothecary.trySetLastRecipe(player);
 		} else if (!apothecary.isEmpty() && mainHandEmpty) {
 			InventoryHelper.withdrawFromInventory(apothecary, player);
 			VanillaPacketDispatcher.dispatchTEToNearbyPlayers(apothecary);

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/PetalApothecaryBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/PetalApothecaryBlockEntity.java
@@ -166,7 +166,7 @@ public class PetalApothecaryBlockEntity extends SimpleInventoryBlockEntity imple
 		if (!isEmpty()) {
 			VanillaPacketDispatcher.dispatchTEToNearbyPlayers(this);
 		}
-		return lastRecipe == null || lastRecipe.isEmpty() ? InteractionResult.CONSUME : InteractionResult.SUCCESS;
+		return lastRecipe == null || lastRecipe.isEmpty() ? InteractionResult.PASS : InteractionResult.SUCCESS;
 	}
 
 	public boolean isEmpty() {

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/PetalApothecaryBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/PetalApothecaryBlockEntity.java
@@ -17,6 +17,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
@@ -159,12 +160,13 @@ public class PetalApothecaryBlockEntity extends SimpleInventoryBlockEntity imple
 		level.blockEvent(getBlockPos(), getBlockState().getBlock(), SET_KEEP_TICKS_EVENT, 400);
 	}
 
-	public void trySetLastRecipe(Player player) {
+	public InteractionResult trySetLastRecipe(Player player) {
 		InventoryHelper.tryToSetLastRecipe(player, getItemHandler(), lastRecipe,
 				SoundEvents.GENERIC_SPLASH);
 		if (!isEmpty()) {
 			VanillaPacketDispatcher.dispatchTEToNearbyPlayers(this);
 		}
+		return lastRecipe == null || lastRecipe.isEmpty() ? InteractionResult.CONSUME : InteractionResult.SUCCESS;
 	}
 
 	public boolean isEmpty() {

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/RunicAltarBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/RunicAltarBlockEntity.java
@@ -18,6 +18,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
@@ -232,11 +233,12 @@ public class RunicAltarBlockEntity extends SimpleInventoryBlockEntity implements
 		level.blockEvent(getBlockPos(), BotaniaBlocks.runeAltar, SET_KEEP_TICKS_EVENT, 400);
 	}
 
-	public void trySetLastRecipe(Player player) {
+	public InteractionResult trySetLastRecipe(Player player) {
 		InventoryHelper.tryToSetLastRecipe(player, getItemHandler(), lastRecipe, null);
 		if (!isEmpty()) {
 			VanillaPacketDispatcher.dispatchTEToNearbyPlayers(this);
 		}
+		return lastRecipe == null || lastRecipe.isEmpty() ? InteractionResult.CONSUME : InteractionResult.SUCCESS;
 	}
 
 	@Override

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/RunicAltarBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/RunicAltarBlockEntity.java
@@ -238,7 +238,7 @@ public class RunicAltarBlockEntity extends SimpleInventoryBlockEntity implements
 		if (!isEmpty()) {
 			VanillaPacketDispatcher.dispatchTEToNearbyPlayers(this);
 		}
-		return lastRecipe == null || lastRecipe.isEmpty() ? InteractionResult.CONSUME : InteractionResult.SUCCESS;
+		return lastRecipe == null || lastRecipe.isEmpty() ? InteractionResult.PASS : InteractionResult.SUCCESS;
 	}
 
 	@Override

--- a/Xplat/src/main/java/vazkii/botania/common/block/mana/RunicAltarBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/mana/RunicAltarBlock.java
@@ -56,10 +56,6 @@ public class RunicAltarBlock extends BotaniaWaterloggedBlock implements EntityBl
 
 	@Override
 	public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
-		if (world.isClientSide) {
-			return InteractionResult.SUCCESS;
-		}
-
 		if (!(world.getBlockEntity(pos) instanceof RunicAltarBlockEntity altar)) {
 			return InteractionResult.PASS;
 		}
@@ -67,9 +63,7 @@ public class RunicAltarBlock extends BotaniaWaterloggedBlock implements EntityBl
 		boolean mainHandEmpty = player.getMainHandItem().isEmpty();
 
 		if (altar.canAddLastRecipe() && mainHandEmpty) {
-			altar.trySetLastRecipe(player);
-			VanillaPacketDispatcher.dispatchTEToNearbyPlayers(altar);
-			return InteractionResult.SUCCESS;
+			return altar.trySetLastRecipe(player);
 		} else if (!altar.isEmpty() && mainHandEmpty) {
 			if (altar.manaToGet == 0) {
 				InventoryHelper.withdrawFromInventory(altar, player);


### PR DESCRIPTION
Makes Runic Altar and Petal Apothecary don't trigger the swing animation when not needed.

Fixes #4195