### PR TITLE
Fix mana infusion tooltip

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/client/patchouli/processor/ManaInfusionProcessor.java
+++ b/Xplat/src/main/java/vazkii/botania/client/patchouli/processor/ManaInfusionProcessor.java
@@ -88,6 +88,8 @@ public class ManaInfusionProcessor implements IComponentProcessor {
 			case "dropTip1":
 				Component drop = Component.keybind("key.drop").withStyle(ChatFormatting.GREEN);
 				return IVariable.from(Component.translatable("botaniamisc." + key, drop));
+			case "dropTip3":
+				return IVariable.from(Component.translatable("botaniamisc." + key));
 		}
 		return null;
 	}


### PR DESCRIPTION
# JSON
```json
  "botaniamisc.dropTip2": "Tip: Press %s to drop",
  "botaniamisc.dropTip3": "items from your inventory",
  "botaniamisc.dropTip1": "CTRL-%s will drop a full stack",
```

<br>

# In-game

![drop1](https://user-images.githubusercontent.com/43409914/200185712-0782877f-6b52-4fbe-888a-475b7779823c.PNG)

<br>

# Context

I misunderstod willie's suggestion, and did an invalid fix.

![dropTip](https://user-images.githubusercontent.com/43409914/200185715-f6447bb4-1bce-48c8-8598-a4c610cca55d.PNG)

