### PR TITLE
Makes mana blasters don't have recoil if player is wearing a Tectonic Girdle

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/item/ManaBlasterItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/ManaBlasterItem.java
@@ -38,6 +38,7 @@ import vazkii.botania.client.gui.TooltipHandler;
 import vazkii.botania.common.advancements.ManaBlasterTrigger;
 import vazkii.botania.common.entity.ManaBurstEntity;
 import vazkii.botania.common.handler.BotaniaSounds;
+import vazkii.botania.common.handler.EquipmentHandler;
 import vazkii.botania.common.helper.ItemNBTHelper;
 import vazkii.botania.common.proxy.Proxy;
 
@@ -85,7 +86,7 @@ public class ManaBlasterItem extends Item {
 					world.addFreshEntity(burst);
 					ManaBlasterTrigger.INSTANCE.trigger((ServerPlayer) player, stack);
 					setCooldown(stack, effCd);
-				} else {
+				} else if (!EquipmentHandler.getAllWorn(player).hasAnyMatching(k -> k.is(BotaniaItems.knockbackBelt))) {
 					player.setDeltaMovement(player.getDeltaMovement().subtract(burst.getDeltaMovement().multiply(0.1, 0.3, 0.1)));
 				}
 			} else if (!world.isClientSide) {

--- a/Xplat/src/main/resources/assets/botania/lang/en_us.json
+++ b/Xplat/src/main/resources/assets/botania/lang/en_us.json
@@ -3132,7 +3132,7 @@
 
   "botania.entry.knockbackBelt": "Tectonic Girdle",
   "botania.tagline.knockbackBelt": "Prevent all knockback",
-  "botania.page.knockbackBelt0": "By harnessing the (relative) stability of tectonic forces, the $(item)Tectonic Girdle$(0) negates any $(thing)Knockback$(0) applied to its wearer from outside attacks and all recoil from the $(item)Mana Blaster$(0).",
+  "botania.page.knockbackBelt0": "By harnessing the (relative) stability of tectonic forces, the $(item)Tectonic Girdle$(0) negates any $(thing)Knockback$(0) applied to its wearer from outside attacks and all recoil from the $(l:tools/mana_blaster)$(item)Mana Blaster$(0)$(/l).",
   "botania.page.knockbackBelt1": "The Steve who couldn't be moved",
 
   "botania.entry.icePendant": "Snowflake Pendant",

--- a/Xplat/src/main/resources/assets/botania/lang/en_us.json
+++ b/Xplat/src/main/resources/assets/botania/lang/en_us.json
@@ -3132,7 +3132,7 @@
 
   "botania.entry.knockbackBelt": "Tectonic Girdle",
   "botania.tagline.knockbackBelt": "Prevent all knockback",
-  "botania.page.knockbackBelt0": "By harnessing the (relative) stability of tectonic forces, the $(item)Tectonic Girdle$(0) negates any $(thing)Knockback$(0) applied to its wearer from outside attacks.",
+  "botania.page.knockbackBelt0": "By harnessing the (relative) stability of tectonic forces, the $(item)Tectonic Girdle$(0) negates any $(thing)Knockback$(0) applied to its wearer from outside attacks and all recoil from the $(item)Mana Blaster$(0).",
   "botania.page.knockbackBelt1": "The Steve who couldn't be moved",
 
   "botania.entry.icePendant": "Snowflake Pendant",


### PR DESCRIPTION
New mechanic, asked Willie and he say yes (he actually said sure)

 
![willie_said_yes](https://user-images.githubusercontent.com/11804768/200392053-5a0a9bdf-2ff6-4892-acc8-d650d0e99ead.jpg)

This is undocumented.
Do I just need to update it the en_us.json or does Botania has a different way to generate this?