### PR TITLE
Added small cooldown to pickaxes when they place torches

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/manasteel/ManasteelPickaxeItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/manasteel/ManasteelPickaxeItem.java
@@ -40,6 +40,8 @@ public class ManasteelPickaxeItem extends PickaxeItem implements CustomDamageIte
 
 	private static final int MANA_PER_DAMAGE = 60;
 
+	private static final int TIME = 5;
+
 	public ManasteelPickaxeItem(Properties props) {
 		this(BotaniaAPI.instance().getManasteelItemTier(), props, -2.8F);
 	}
@@ -72,11 +74,13 @@ public class ManasteelPickaxeItem extends PickaxeItem implements CustomDamageIte
 					if (did.consumesAction() && !ctx.getLevel().isClientSide) {
 						ItemsRemainingRenderHandler.send(player, displayStack, TORCH_PATTERN);
 					}
-					return did;
+					if (did != InteractionResult.FAIL) {
+						player.getCooldowns().addCooldown(this, TIME);
+						return did;
+					}
 				}
 			}
 		}
-
 		return InteractionResult.PASS;
 	}
 

--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/manasteel/ManasteelPickaxeItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/manasteel/ManasteelPickaxeItem.java
@@ -71,10 +71,10 @@ public class ManasteelPickaxeItem extends PickaxeItem implements CustomDamageIte
 				if (!stackAt.isEmpty() && TORCH_PATTERN.matcher(stackAt.getItem().getDescriptionId()).find()) {
 					ItemStack displayStack = stackAt.copy();
 					InteractionResult did = PlayerHelper.substituteUse(ctx, stackAt);
-					if (did.consumesAction() && !ctx.getLevel().isClientSide) {
-						ItemsRemainingRenderHandler.send(player, displayStack, TORCH_PATTERN);
-					}
-					if (did != InteractionResult.FAIL) {
+					if (did.consumesAction()) {
+						if (!ctx.getLevel().isClientSide) {
+							ItemsRemainingRenderHandler.send(player, displayStack, TORCH_PATTERN);
+						}
 						player.getCooldowns().addCooldown(this, TIME);
 						return did;
 					}


### PR DESCRIPTION
Pickaxes has now a small cooldown when used to play torches.
This also fixes picks not letting use shields in the offhand when there was torches in the inventory.
The cooldown is the minimum amount of time required to trigger the shield (or other off hand non block item) use.