### PR TITLE
Makes stone of temperance toggleable by right clicking it in the inventory.

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/item/StoneOfTemperanceItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/StoneOfTemperanceItem.java
@@ -13,7 +13,10 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.Container;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResultHolder;
+import net.minecraft.world.entity.SlotAccess;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ClickAction;
+import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
@@ -37,8 +40,7 @@ public class StoneOfTemperanceItem extends Item {
 	@Override
 	public InteractionResultHolder<ItemStack> use(Level world, Player player, @NotNull InteractionHand hand) {
 		ItemStack stack = player.getItemInHand(hand);
-		ItemNBTHelper.setBoolean(stack, TAG_ACTIVE, !ItemNBTHelper.getBoolean(stack, TAG_ACTIVE, false));
-		world.playSound(null, player.getX(), player.getY(), player.getZ(), BotaniaSounds.temperanceStoneConfigure, SoundSource.NEUTRAL, 1F, 1F);
+		toggleActive(stack, player, world);
 		return InteractionResultHolder.success(stack);
 	}
 
@@ -61,6 +63,22 @@ public class StoneOfTemperanceItem extends Item {
 		}
 
 		return false;
+	}
+
+	@Override
+	public boolean overrideOtherStackedOnMe(ItemStack stack, ItemStack cursor, Slot slot, ClickAction click, Player player, SlotAccess access) {
+		Level world = player.getLevel();
+		if (click == ClickAction.SECONDARY && slot.allowModification(player) && cursor.isEmpty()) {
+			toggleActive(stack, player, world);
+			access.set(cursor);
+			return true;
+		}
+		return false;
+	}
+
+	private void toggleActive(ItemStack stack, Player player, Level world) {
+		ItemNBTHelper.setBoolean(stack, TAG_ACTIVE, !ItemNBTHelper.getBoolean(stack, TAG_ACTIVE, false));
+		world.playSound(player, player.getX(), player.getY(), player.getZ(), BotaniaSounds.temperanceStoneConfigure, SoundSource.NEUTRAL, 1F, 1F);
 	}
 
 }

--- a/Xplat/src/main/resources/assets/botania/lang/en_us.json
+++ b/Xplat/src/main/resources/assets/botania/lang/en_us.json
@@ -2850,7 +2850,7 @@
 
   "botania.entry.temperanceStone": "Stone of Temperance",
   "botania.tagline.temperanceStone": "A limiter for the power of the Terrasteel Tools",
-  "botania.page.temperanceStone0": "The $(l:tools/terra_pick)$(item)Terra Shatterer$(0)$(/l) can tear through huge tracts of land like lightning when charged to its maximum potential; however, this might not always be the user's intention. A small, 3x3 region might be more fitting in certain cases; thus, an active $(item)Stone of Temperance$(0) will prevent a $(l:tools/terra_pick)$(item)Terra Shatterer$(0)$(/l) in the inventory from breaking any wider areas. This also affects the $(l:tools/terra_axe)$(item)Terra Truncator$(0)$(/l). The stone can be toggled on/off with a sneak-right click.",
+  "botania.page.temperanceStone0": "The $(l:tools/terra_pick)$(item)Terra Shatterer$(0)$(/l) can tear through huge tracts of land like lightning when charged to its maximum potential; however, this might not always be the user's intention. A small, 3x3 region might be more fitting in certain cases; thus, an active $(item)Stone of Temperance$(0) in the inventory will prevent a $(l:tools/terra_pick)$(item)Terra Shatterer$(0)$(/l) from breaking any wider areas. This also affects the $(l:tools/terra_axe)$(item)Terra Truncator$(0)$(/l) and the $(l:tools/exchange_rod)$(item)Rod of the Shifting Crust$(0)$(/l). The stone can be toggled on/off by right clicking it, either in your inventory or your hand.",
   "botania.page.temperanceStone1": "Don't lose it",
 
   "botania.entry.terraAxe": "Terra Truncator",


### PR DESCRIPTION
stone of temperance can be activated and deactivated by right clicking it in the inventory with an empty cursor

Also updated its lexica description.
The desc was outdated, it said you need sneak + right click but that's not correct, it also didn't mentioned the rod of exchange.