### PR TITLE
Fix two autocrafting bugs regarding Crafty Crate & Black Hole Talisman

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/CraftyCrateBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/CraftyCrateBlockEntity.java
@@ -170,6 +170,14 @@ public class CraftyCrateBlockEntity extends OpenCrateBlockEntity implements Wand
 		matchingRecipe.ifPresent(recipe -> {
 			craftResult = recipe.assemble(craft);
 
+			// Given some mods can return air by a bad implementation of their recipe handler,
+			// check for air before continuting on.
+			if (craftResult.isEmpty()) {
+				// We have air, do not continue.
+				matchFailed = true;
+				return;
+			}
+
 			Container handler = getItemHandler();
 			List<ItemStack> remainders = recipe.getRemainingItems(craft);
 
@@ -188,7 +196,8 @@ public class CraftyCrateBlockEntity extends OpenCrateBlockEntity implements Wand
 		}
 
 		level.getProfiler().pop();
-		return matchingRecipe.isPresent();
+		// Return only if present and not air.
+		return matchingRecipe.isPresent() && !craftResult.isEmpty();
 	}
 
 	private Optional<CraftingRecipe> getMatchingRecipe(CraftingContainer craft) {

--- a/Xplat/src/main/java/vazkii/botania/common/crafting/recipe/BlackHoleTalismanExtractRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/common/crafting/recipe/BlackHoleTalismanExtractRecipe.java
@@ -39,6 +39,13 @@ public class BlackHoleTalismanExtractRecipe extends CustomRecipe {
 			ItemStack stack = inv.getItem(i);
 			if (!stack.isEmpty()) {
 				if (stack.is(BotaniaItems.blackHoleTalisman) && !foundTalisman) {
+
+					// Avoid returning true for empty talismans
+					int count = BlackHoleTalismanItem.getBlockCount(stack);
+					if (count <= 0) {
+						return false;
+					}
+
 					foundTalisman = true;
 				} else {
 					return false;


### PR DESCRIPTION
Two bugs that together caused an item deletion glitch has been fixed.

 - Fixed Crafty Crate allowing an empty result on a matched recipe to continue crafting, which vanilla would not allow.
 - Fixed Black Hole Talisman matching when empty, then returning air for all, allowing Crafty Crate and other non-compliant crafting interfaces to delete it entirely.

Fixes #4227