### PR TITLE
Ensure red-stringed containers always report an accessible inventory

### DIFF
--- a/Fabric/src/main/java/vazkii/botania/fabric/internal_caps/RedStringContainerStorage.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/internal_caps/RedStringContainerStorage.java
@@ -66,7 +66,8 @@ public class RedStringContainerStorage implements Storage<ItemVariant> {
 
 	@Override
 	public boolean supportsInsertion() {
-		return getStorage().supportsInsertion();
+		// Since the binding target could change we can't know if "absolutely always 0" is correct.
+		return true;
 	}
 
 	@Override
@@ -76,7 +77,9 @@ public class RedStringContainerStorage implements Storage<ItemVariant> {
 
 	@Override
 	public boolean supportsExtraction() {
-		return getStorage().supportsExtraction();
+		// Since the binding target could change we can't know if "absolutely always 0" is correct.
+		// Corporea spark attachment also depends on this returning true for the UP direction.
+		return true;
 	}
 
 	@Override

--- a/Forge/src/main/java/vazkii/botania/forge/internal_caps/RedStringContainerCapProvider.java
+++ b/Forge/src/main/java/vazkii/botania/forge/internal_caps/RedStringContainerCapProvider.java
@@ -31,10 +31,9 @@ public class RedStringContainerCapProvider implements ICapabilityProvider {
 				LazyOptional<?> optional = binding.getCapability(cap, side);
 				if (optional.isPresent()) {
 					return optional.cast();
-				} else {
-					return EMPTY.cast();
 				}
 			}
+			return EMPTY.cast();
 		}
 		return LazyOptional.empty();
 	}


### PR DESCRIPTION
Fix for Botania issue #4062, as suggested.

For Forge, the red stringed container reports an empty inventory even when it's not bound to an inventory.

For Fabric, this was already the case, but the inventory reported that it absolutely never supports extraction, which is what Corporea sparks check for the up direction. Since even vanilla Minecraft supports dynamically adding and removing inventory blocks (shulker boxes) in the line of sight of the red stringed container, the block's inventory access options could change at any time and cause e.g. some kind of pipe-like connection to break. The obvious downside is that a player could make pipe-like connections or place a Corporea spark on a red stringed container without the bound inventory actually allowing access from that side.