### PR TITLE
Reuse original piston pushing logic instead of a copy (fix for #4178)

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/helper/ForcePushHelper.java
+++ b/Xplat/src/main/java/vazkii/botania/common/helper/ForcePushHelper.java
@@ -1,0 +1,20 @@
+package vazkii.botania.common.helper;
+
+import org.apache.commons.lang3.mutable.MutableInt;
+
+public class ForcePushHelper implements AutoCloseable {
+	private static final ThreadLocal<MutableInt> forcePushCounter = ThreadLocal.withInitial(MutableInt::new);
+
+	public static boolean isForcePush() {
+		return forcePushCounter.get().intValue() > 0;
+	}
+
+	public ForcePushHelper() {
+		forcePushCounter.get().increment();
+	}
+
+	@Override
+	public void close() {
+		forcePushCounter.get().decrement();
+	}
+}

--- a/Xplat/src/main/java/vazkii/botania/common/item/lens/ForceLens.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/lens/ForceLens.java
@@ -8,32 +8,18 @@
  */
 package vazkii.botania.common.item.lens;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.sounds.SoundEvents;
-import net.minecraft.sounds.SoundSource;
-import net.minecraft.tags.BlockTags;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.piston.MovingPistonBlock;
-import net.minecraft.world.level.block.piston.PistonStructureResolver;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 
 import vazkii.botania.api.internal.ManaBurst;
-import vazkii.botania.common.helper.EthicalTntHelper;
-
-import java.util.List;
-import java.util.Map;
+import vazkii.botania.common.helper.ForcePushHelper;
+import vazkii.botania.mixin.PistonBaseBlockAccessor;
 
 public class ForceLens extends Lens {
 
@@ -50,98 +36,11 @@ public class ForceLens extends Lens {
 		return shouldKill;
 	}
 
-	public static BlockState unWaterlog(BlockState state) {
-		if (state.hasProperty(BlockStateProperties.WATERLOGGED)) {
-			return state.setValue(BlockStateProperties.WATERLOGGED, false);
-		} else {
-			return state;
-		}
-	}
-
-	// [VanillaCopy] Based on PistonBaseBlock
+	@SuppressWarnings("try")
 	public static boolean moveBlocks(Level level, BlockPos pistonPos, Direction direction) {
-		PistonStructureResolver pistonStructureResolver = new PistonStructureResolver(level, pistonPos, direction, true);
-		if (pistonStructureResolver.resolve()) {
-			// this could produce unethical TNT entities, so perform appropriate checks
-			if (!level.isClientSide()) {
-				EthicalTntHelper.startTrackingTntEntities();
-			}
-			Map<BlockPos, BlockState> map = Maps.newHashMap();
-			List<BlockPos> positionsToPush = pistonStructureResolver.getToPush();
-			List<BlockState> statesToPush = Lists.newArrayList();
-
-			for (BlockPos posToPush : positionsToPush) {
-				BlockState state = level.getBlockState(posToPush);
-				statesToPush.add(state);
-				map.put(posToPush, state);
-			}
-
-			List<BlockPos> positionsToDestroy = pistonStructureResolver.getToDestroy();
-			BlockState[] affectedStates = new BlockState[positionsToPush.size() + positionsToDestroy.size()];
-			int affectedStatesPtr = 0;
-
-			for (int k = positionsToDestroy.size() - 1; k >= 0; --k) {
-				BlockPos posToDestroy = positionsToDestroy.get(k);
-				BlockState state = level.getBlockState(posToDestroy);
-				BlockEntity blockEntity = state.hasBlockEntity() ? level.getBlockEntity(posToDestroy) : null;
-				Block.dropResources(state, level, posToDestroy, blockEntity);
-				level.setBlock(posToDestroy, Blocks.AIR.defaultBlockState(), 18);
-				if (!state.is(BlockTags.FIRE)) {
-					level.addDestroyBlockEffect(posToDestroy, state);
-				}
-
-				affectedStates[affectedStatesPtr++] = state;
-			}
-
-			for (int l = positionsToPush.size() - 1; l >= 0; --l) {
-				BlockPos pos = positionsToPush.get(l);
-				BlockState state = level.getBlockState(pos);
-				pos = pos.relative(direction);
-				map.remove(pos);
-				BlockState movingPiston = Blocks.MOVING_PISTON.defaultBlockState().setValue(MovingPistonBlock.FACING, direction);
-				level.setBlock(pos, movingPiston, 68);
-				level.setBlockEntity(MovingPistonBlock.newMovingBlockEntity(pos, movingPiston, statesToPush.get(l), direction, true, false));
-				affectedStates[affectedStatesPtr++] = state;
-			}
-
-			BlockState air = Blocks.AIR.defaultBlockState();
-
-			for (BlockPos blockPos6 : map.keySet()) {
-				level.setBlock(blockPos6, air, 82);
-			}
-
-			for (Map.Entry<BlockPos, BlockState> entry : map.entrySet()) {
-				BlockPos blockPos7 = entry.getKey();
-				BlockState blockState8 = entry.getValue();
-				blockState8.updateIndirectNeighbourShapes(level, blockPos7, 2);
-				air.updateNeighbourShapes(level, blockPos7, 2);
-				air.updateIndirectNeighbourShapes(level, blockPos7, 2);
-			}
-
-			affectedStatesPtr = 0;
-
-			for (int m = positionsToDestroy.size() - 1; m >= 0; --m) {
-				BlockState state = affectedStates[affectedStatesPtr++];
-				BlockPos posToDestroy = positionsToDestroy.get(m);
-				state.updateIndirectNeighbourShapes(level, posToDestroy, 2);
-				level.updateNeighborsAt(posToDestroy, state.getBlock());
-			}
-
-			for (int n = positionsToPush.size() - 1; n >= 0; --n) {
-				level.updateNeighborsAt(positionsToPush.get(n), affectedStates[affectedStatesPtr++].getBlock());
-			}
-
-			if (!level.isClientSide) {
-				level.playSound(null, pistonPos, SoundEvents.PISTON_EXTEND, SoundSource.BLOCKS, 0.5F, level.random.nextFloat() * 0.25F + 0.6F);
-			}
-
-			if (!level.isClientSide()) {
-				EthicalTntHelper.endTrackingTntEntitiesAndCheck();
-			}
-			return true;
+		try (var ignored = new ForcePushHelper()) {
+			return ((PistonBaseBlockAccessor) Blocks.PISTON).botania_moveBlocks(level, pistonPos, direction, true);
 		}
-
-		return false;
 	}
 
 }

--- a/Xplat/src/main/java/vazkii/botania/mixin/PistonBaseBlockAccessor.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/PistonBaseBlockAccessor.java
@@ -1,0 +1,15 @@
+package vazkii.botania.mixin;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.piston.PistonBaseBlock;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(PistonBaseBlock.class)
+public interface PistonBaseBlockAccessor {
+	@Invoker("moveBlocks")
+	boolean botania_moveBlocks(Level level, BlockPos pistonPos, Direction direction, boolean extending);
+}

--- a/Xplat/src/main/java/vazkii/botania/mixin/PistonBaseBlockMixin.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/PistonBaseBlockMixin.java
@@ -8,17 +8,27 @@ import net.minecraft.world.level.block.piston.PistonBaseBlock;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import vazkii.botania.common.helper.EthicalTntHelper;
+import vazkii.botania.common.helper.ForcePushHelper;
 
-@Mixin(PistonBaseBlock.class)
-public class PistonBaseBlockMixin {
+/**
+ * Additional logic for pistons:
+ * <ul>
+ * <li>Detection for "unethical" (duplicated) TNT</li>
+ * <li>Hooks for Force Lens and Force Relay pushing behavior. (Reusing piston pushing code instead of copying it allows
+ * us to inherit Movable Block Entities modifications by mods like Quark or Carpet.)</li>
+ * </ul>
+ */
+@Mixin(value = PistonBaseBlock.class, priority = 999 /* before MBE implementations like Quark or Carpet */)
+public abstract class PistonBaseBlockMixin {
 	@Inject(
 		at = @At("HEAD"),
 		method = "moveBlocks(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/Direction;Z)Z"
 	)
-	private void preMoveBlocks(Level level, BlockPos pos, Direction dir, boolean retract,
+	private void preMoveBlocks(Level level, BlockPos pos, Direction dir, boolean extending,
 			CallbackInfoReturnable<Boolean> cir) {
 		if (!level.isClientSide()) {
 			EthicalTntHelper.startTrackingTntEntities();
@@ -29,10 +39,24 @@ public class PistonBaseBlockMixin {
 		at = @At(value = "RETURN"),
 		method = "moveBlocks(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/Direction;Z)Z"
 	)
-	private void postMoveBlocks(Level level, BlockPos pos, Direction dir, boolean retract,
+	private void postMoveBlocks(Level level, BlockPos pos, Direction dir, boolean extending,
 			CallbackInfoReturnable<Boolean> cir) {
 		if (!level.isClientSide()) {
 			EthicalTntHelper.endTrackingTntEntitiesAndCheck();
 		}
+	}
+
+	/**
+	 * When force-pushing, set the {@code extending} parameter to {@code false} right before the {@code if} block that
+	 * creates a moving piston head. This will skip all the code we don't want to execute.
+	 */
+	@ModifyVariable(
+		method = "moveBlocks",
+		at = @At(value = "LOAD", ordinal = 4), // 4th read access within target method (1-based count)
+		ordinal = 0, // first local variable (0-based count, including arguments) matching mixin method's argument type
+		argsOnly = true // only from among method arguments
+	)
+	private boolean isExtendingNonForcePusher(boolean extending) {
+		return !ForcePushHelper.isForcePush() && extending;
 	}
 }

--- a/Xplat/src/main/resources/botania_xplat.mixins.json
+++ b/Xplat/src/main/resources/botania_xplat.mixins.json
@@ -38,6 +38,7 @@
     "NaturalSpawnerMixin",
     "NearestAttackableTargetGoalAccessor",
     "NoiseChunkAccessor",
+    "PistonBaseBlockAccessor",
     "PistonBaseBlockMixin",
     "PlayerMixin",
     "PollinateGoalMixin",


### PR DESCRIPTION
This allows Botania to inherit Movable Block Entity implementations from mods like Quark or Carpet for block structures pushed by a Force Relay or by a mana burst with the Force lens behavior.