### PR TITLE
Fix water bottle filling not working in the end dimension

### DIFF
--- a/web/changelog.md
+++ b/web/changelog.md
@@ -34,6 +34,7 @@ and start a new "Upcoming" section.
 * Fix: Made Teru Teru Bozu truely happy during clear weather again (Wormbo)
 * Fix: Leaves placed by Worldshaper's Astrolabe no longer decay
 * Fix: Some items being missing from Forge equipment tags and Fabric bow tag
+* Fix: Using an empty bottle in the end will not attempt to pick up Ender Air if the player is aiming at a liquid (Wormbo)
 * Fix: Horn of the Canopy breaking persistent leaves
 * Fix: Thermalily not updating comparators properly
 * Fix: Kindle Lens not creating Soul Fire when it should


### PR DESCRIPTION
Fix for #4273. Botania's logic for creating ender air bottles is skipped if the player aims at water.
(Grabbing fluids from blocks, e.g. getting honey bottles from full bee nests, was not affected.)