### PR TITLE
Worldshaper's Sextant sphere mode and finer radius control

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/client/core/proxy/ClientProxy.java
+++ b/Xplat/src/main/java/vazkii/botania/client/core/proxy/ClientProxy.java
@@ -20,6 +20,7 @@ import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 
@@ -36,6 +37,7 @@ import vazkii.patchouli.api.PatchouliAPI;
 
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.util.Locale;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -119,5 +121,12 @@ public class ClientProxy implements Proxy {
 	@Override
 	public HitResult getClientHit() {
 		return Minecraft.getInstance().hitResult;
+	}
+
+	@NotNull
+	@Override
+	public Locale getLocale() {
+		final String languageCode = Minecraft.getInstance().getLanguageManager().getSelected().getCode();
+		return Locale.forLanguageTag(languageCode);
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/item/WorldshaperssSextantItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/WorldshaperssSextantItem.java
@@ -38,6 +38,7 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
 
 import vazkii.botania.client.fx.WispParticleData;
+import vazkii.botania.common.handler.BotaniaSounds;
 import vazkii.botania.common.helper.ItemNBTHelper;
 import vazkii.botania.common.helper.MathHelper;
 import vazkii.botania.common.helper.VecHelper;
@@ -47,8 +48,12 @@ import vazkii.patchouli.api.IMultiblock;
 import vazkii.patchouli.api.IStateMatcher;
 import vazkii.patchouli.api.PatchouliAPI;
 
+import java.math.RoundingMode;
+import java.text.NumberFormat;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static vazkii.botania.common.lib.ResourceLocationHelper.prefix;
 
@@ -58,6 +63,7 @@ public class WorldshaperssSextantItem extends Item {
 	private static final String TAG_SOURCE_X = "sourceX";
 	private static final String TAG_SOURCE_Y = "sourceY";
 	private static final String TAG_SOURCE_Z = "sourceZ";
+	private static final String TAG_SPHERE_MODE = "sphereMode";
 
 	public WorldshaperssSextantItem(Properties builder) {
 		super(builder);
@@ -78,7 +84,7 @@ public class WorldshaperssSextantItem extends Item {
 	public void onUseTick(Level world, LivingEntity living, ItemStack stack, int count) {
 		if (getUseDuration(stack) - count < 10
 				|| !(living instanceof Player)
-				|| world.isClientSide) {
+				|| !world.isClientSide) {
 			return;
 		}
 
@@ -87,17 +93,64 @@ public class WorldshaperssSextantItem extends Item {
 		int z = ItemNBTHelper.getInt(stack, TAG_SOURCE_Z, 0);
 		if (y != Integer.MIN_VALUE) {
 			double radius = calculateRadius(stack, living);
-
-			if (count % 10 == 0) {
-				WispParticleData data = WispParticleData.wisp(0.3F, 0F, 1F, 1F, 1);
-				for (int i = 0; i < 360; i++) {
-					float radian = (float) (i * Math.PI / 180);
-					double xp = x + Math.cos(radian) * radius;
-					double zp = z + Math.sin(radian) * radius;
-					world.addParticle(data, xp + 0.5, y + 1, zp + 0.5, 0, - -0.01F, 0);
+			WispParticleData data = WispParticleData.wisp(0.3F, 0F, 1F, 1F, 1);
+			world.addParticle(data, x + 0.5, y + 1, z + 0.5, 0, 0.1, 0);
+			boolean sphereMode = getSphereMode(stack);
+			for (int i = count % 20; i < 360; i += 20) {
+				float radian = (float) (i * Math.PI / 180);
+				double cosR = Math.cos(radian) * radius;
+				double sinR = Math.sin(radian) * radius;
+				if (sphereMode) {
+					world.addParticle(data, x + cosR + 0.5, y + 1.3, z + sinR + 0.5, 0, 0.01, 0);
+					world.addParticle(data, x + sinR + 0.5, y + cosR + 1.5, z + 0.3, 0, 0, 0.01);
+					world.addParticle(data, x + 0.3, y + sinR + 1.5, z + cosR + 0.5, 0.01, 0, 0);
+				} else {
+					world.addParticle(data, x + cosR + 0.5, y + 1, z + sinR + 0.5, 0, 0.01, 0);
 				}
 			}
 		}
+	}
+
+	private static void makeSphere(IStateMatcher matcher, double radius, Map<BlockPos, IStateMatcher> map) {
+		// 3D version of Midpoint circle algorithm, based on https://stackoverflow.com/a/41666156/1331011
+		// This algorithm generates all combinations of X, Y, and Z components, where:
+		// - the X/Y/Z position is inside the sphere,
+		// - Z has the greatest (or tied for greatest) value of the three components,
+		// - making Z any larger would place the position outside the sphere, and
+		// - X, Y, and Z are all positive or zero.
+		final int maxR2 = (int) Math.floor(radius * radius);
+		int zMax = (int) Math.floor(radius);
+		for (int x = 0;; x++) {
+			while (x * x + zMax * zMax > maxR2 && zMax >= x) {
+				zMax--;
+			}
+			if (zMax < x) {
+				break; // with this x, z can't be largest
+			}
+			int z = zMax;
+			for (int y = 0;; y++) {
+				while (x * x + y * y + z * z > maxR2 && z >= x && z >= y) {
+					z--;
+				}
+				if (z < x || z < y) {
+					break; // with this x and y, z can't be largest
+				}
+				// By rotating the components and mirroring the resulting positions to the other seven octants,
+				// each set of values generates up to 24 blocks of the sphere.
+				generateMirroredPositions(x, y, z, map, matcher);
+				generateMirroredPositions(y, z, x, map, matcher);
+				generateMirroredPositions(z, x, y, map, matcher);
+			}
+		}
+	}
+
+	private static void generateMirroredPositions(int x, int y, int z, Map<BlockPos, IStateMatcher> map, IStateMatcher matcher) {
+		Stream.of(
+				new BlockPos(x, y, z), new BlockPos(-x, y, z),
+				new BlockPos(x, -y, z), new BlockPos(-x, -y, z),
+				new BlockPos(x, y, -z), new BlockPos(-x, y, -z),
+				new BlockPos(x, -y, -z), new BlockPos(-x, -y, -z)
+		).forEach(pos -> map.put(pos, matcher));
 	}
 
 	@Override
@@ -112,30 +165,65 @@ public class WorldshaperssSextantItem extends Item {
 			int x = ItemNBTHelper.getInt(stack, TAG_SOURCE_X, 0);
 			int y = ItemNBTHelper.getInt(stack, TAG_SOURCE_Y, Integer.MIN_VALUE);
 			int z = ItemNBTHelper.getInt(stack, TAG_SOURCE_Z, 0);
-			int iradius = (int) radius + 1;
+			boolean sphere = getSphereMode(stack);
 			if (y != Integer.MIN_VALUE) {
 				Map<BlockPos, IStateMatcher> map = new HashMap<>();
-				for (int i = 0; i < iradius * 2 + 1; i++) {
-					for (int j = 0; j < iradius * 2 + 1; j++) {
-						int xp = x + i - iradius;
-						int zp = z + j - iradius;
-
-						if ((int) Math.floor(MathHelper.pointDistancePlane(xp, zp, x, z)) == iradius - 1) {
-							map.put(new BlockPos(xp - x, 0, zp - z), matcher);
-						}
-					}
+				if (sphere) {
+					makeSphere(matcher, radius + 0.5, map);
+				} else {
+					makeCircle(matcher, radius + 0.5, map);
 				}
 				IMultiblock sparse = PatchouliAPI.get().makeSparseMultiblock(map).setId(MULTIBLOCK_ID);
-				Proxy.INSTANCE.showMultiblock(sparse, Component.literal("r = " + (int) radius), new BlockPos(x, y, z), Rotation.NONE);
+				Proxy.INSTANCE.showMultiblock(sparse, Component.literal("r = " + getRadiusString(radius)),
+						new BlockPos(x, y, z), Rotation.NONE);
 			}
 		}
 	}
 
-	private void reset(Level world, ItemStack stack) {
-		ItemNBTHelper.setInt(stack, TAG_SOURCE_Y, Integer.MIN_VALUE);
+	private static void makeCircle(IStateMatcher matcher, double radius, Map<BlockPos, IStateMatcher> map) {
+		// 2D version of makeSphere, assuming y=0 at all times
+		final int maxR2 = (int) Math.floor(radius * radius);
+		int z = (int) Math.floor(radius);
+		for (int x = 0;; x++) {
+			while (x * x + z * z > maxR2 && z >= x) {
+				z--;
+			}
+			if (z < x) {
+				break;
+			}
+			generateMirroredPositions(x, z, map, matcher);
+			generateMirroredPositions(z, x, map, matcher);
+		}
+	}
+
+	private static void generateMirroredPositions(int x, int z, Map<BlockPos, IStateMatcher> map, IStateMatcher matcher) {
+		Stream.of(
+				new BlockPos(x, 0, z), new BlockPos(-x, 0, z),
+				new BlockPos(x, 0, -z), new BlockPos(-x, 0, -z)
+		).forEach(pos -> map.put(pos, matcher));
+	}
+
+	private static boolean getSphereMode(ItemStack stack) {
+		return ItemNBTHelper.getBoolean(stack, TAG_SPHERE_MODE, false);
+	}
+
+	private void reset(Level world, Player player, ItemStack stack) {
+		if (ItemNBTHelper.getInt(stack, TAG_SOURCE_Y, Integer.MIN_VALUE) == Integer.MIN_VALUE) {
+			if (!world.isClientSide) {
+				setSphereMode(stack, !getSphereMode(stack));
+			} else {
+				player.playSound(BotaniaSounds.ding, 0.1F, 1F);
+			}
+		} else {
+			ItemNBTHelper.setInt(stack, TAG_SOURCE_Y, Integer.MIN_VALUE);
+		}
 		if (world.isClientSide) {
 			Proxy.INSTANCE.clearSextantMultiblock();
 		}
+	}
+
+	private static void setSphereMode(ItemStack stack, boolean sphereMode) {
+		ItemNBTHelper.setBoolean(stack, TAG_SPHERE_MODE, sphereMode);
 	}
 
 	@NotNull
@@ -155,7 +243,7 @@ public class WorldshaperssSextantItem extends Item {
 			}
 			return InteractionResultHolder.pass(stack);
 		} else {
-			reset(world, stack);
+			reset(world, player, stack);
 			return InteractionResultHolder.success(stack);
 		}
 	}
@@ -165,8 +253,6 @@ public class WorldshaperssSextantItem extends Item {
 		int y = ItemNBTHelper.getInt(stack, TAG_SOURCE_Y, Integer.MIN_VALUE);
 		int z = ItemNBTHelper.getInt(stack, TAG_SOURCE_Z, 0);
 		Vec3 source = new Vec3(x, y, z);
-		WispParticleData data = WispParticleData.wisp(0.2F, 1F, 0F, 0F, 1);
-		living.level.addParticle(data, source.x + 0.5, source.y + 1, source.z + 0.5, 0, - -0.1F, 0);
 
 		Vec3 centerVec = VecHelper.fromEntityCenter(living);
 		Vec3 diffVec = source.subtract(centerVec);
@@ -175,10 +261,12 @@ public class WorldshaperssSextantItem extends Item {
 		lookVec = lookVec.scale(mul).add(centerVec);
 
 		lookVec = new Vec3(net.minecraft.util.Mth.floor(lookVec.x),
-				lookVec.y,
+				net.minecraft.util.Mth.floor(lookVec.y),
 				net.minecraft.util.Mth.floor(lookVec.z));
 
-		return MathHelper.pointDistancePlane(source.x, source.z, lookVec.x, lookVec.z);
+		return getSphereMode(stack)
+				? MathHelper.pointDistanceSpace(source.x, source.y, source.z, lookVec.x, lookVec.y, lookVec.z)
+				: MathHelper.pointDistancePlane(source.x, source.z, lookVec.x, lookVec.z);
 	}
 
 	public static class Hud {
@@ -192,7 +280,7 @@ public class WorldshaperssSextantItem extends Item {
 				int x = Minecraft.getInstance().getWindow().getGuiScaledWidth() / 2 + 30;
 				int y = Minecraft.getInstance().getWindow().getGuiScaledHeight() / 2;
 
-				String s = Integer.toString((int) radius);
+				String s = getRadiusString(radius);
 				boolean inRange = 0 < radius && radius <= MAX_RADIUS;
 				if (!inRange) {
 					s = ChatFormatting.RED + s;
@@ -219,4 +307,35 @@ public class WorldshaperssSextantItem extends Item {
 		}
 	}
 
+	@Override
+	public Component getName(@NotNull ItemStack stack) {
+		Component mode = Component.literal(" (")
+				.append(Component.translatable(getModeString(stack)))
+				.append(")");
+		return super.getName(stack).plainCopy().append(mode);
+	}
+
+	public static String getModeString(ItemStack stack) {
+		return "botaniamisc.sextantMode." + (getSphereMode(stack) ? "sphere" : "circle");
+	}
+
+	private static String getRadiusString(double radius) {
+		NumberFormat format = getNumberFormat(1);
+
+		return format.format(radius);
+	}
+
+	// these two methods should probably move to a Locale helper class:
+	private static NumberFormat getNumberFormat(int numDigits) {
+		var format = NumberFormat.getInstance(getLocale());
+		format.setRoundingMode(RoundingMode.HALF_UP);
+		format.setMaximumFractionDigits(numDigits);
+		format.setMinimumFractionDigits(numDigits);
+		return format;
+	}
+
+	private static Locale getLocale() {
+		final String languageCode = Minecraft.getInstance().getLanguageManager().getSelected().getCode();
+		return Locale.forLanguageTag(languageCode);
+	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/proxy/Proxy.java
+++ b/Xplat/src/main/java/vazkii/botania/common/proxy/Proxy.java
@@ -17,6 +17,7 @@ import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import vazkii.botania.client.core.proxy.ClientProxy;
@@ -24,6 +25,7 @@ import vazkii.botania.common.entity.GaiaGuardianEntity;
 import vazkii.botania.xplat.XplatAbstractions;
 import vazkii.patchouli.api.IMultiblock;
 
+import java.util.Locale;
 import java.util.function.Supplier;
 
 public interface Proxy {
@@ -74,5 +76,10 @@ public interface Proxy {
 	@Nullable
 	default HitResult getClientHit() {
 		return null;
+	}
+
+	@NotNull
+	default Locale getLocale() {
+		return Locale.getDefault();
 	}
 }

--- a/Xplat/src/main/resources/assets/botania/lang/de_de.json
+++ b/Xplat/src/main/resources/assets/botania/lang/de_de.json
@@ -22,6 +22,8 @@
     "botaniamisc.creativePool0": "Kreatives Manabecken, hat unendlich Mana",
     "botaniamisc.creativePool1": "Eines Egoisten würdig",
     "botaniamisc.toolRank": "%s&7-Rang",
+    "botaniamisc.sextantMode.circle": "Kreismodus",
+    "botaniamisc.sextantMode.sphere": "Kugelmodus",
 
     "botania.color.rainbow": "Regenbogenfarben",
 

--- a/Xplat/src/main/resources/assets/botania/lang/en_us.json
+++ b/Xplat/src/main/resources/assets/botania/lang/en_us.json
@@ -49,6 +49,8 @@
   "botaniamisc.dropTip1": "CTRL-%s will drop a full stack",
   "botaniamisc.wandMode.bind": "Bind Mode",
   "botaniamisc.wandMode.function": "Function Mode",
+  "botaniamisc.sextantMode.circle": "Circle Mode",
+  "botaniamisc.sextantMode.sphere": "Sphere Mode",
   "botaniamisc.brewOf": "Brew of %s",
   "botaniamisc.needsCatalysts": "No matter how hard you try to push the Ingot into the Beacon, nothing seems to happen. Perhaps your configuration of catalyst pylons is off.",
   "botaniamisc.peacefulNoob": "You try to offer the Ingot to the Beacon, but the peaceful vibes of your world prevent you from doing so. Perhaps you should do something about that.",

--- a/web/changelog.md
+++ b/web/changelog.md
@@ -18,6 +18,9 @@ and start a new "Upcoming" section.
 
 {% include changelog_header.html version="Upcoming" %}
 
+* Add: The Worldshaper's Sextant can now generate spheres as well (Wormbo)
+* Change: The Worldshaper's Sextant provides more control over the exact shape of circles by having the radius selection snap to the block grind instead of only allowing integers (Wormbo)
+
 ---
 
 {% include changelog_header.html version="1.19.2-439" %}


### PR DESCRIPTION
Implementation for #4312.
- Sphere mode can be toggled by sneak+right-clicking while the sextant doesn't show a preview.
- Both the sphere *and* circle mode generate a thin shape now, containing only blocks that are visible from the outside. (The old version of the circle mode didn't necessarily do that all the time.) Since there are multiple reasonable ways to represent a voxel sphere or circle of the same general radius, the sextant now also accepts higher precision radii, which can cause the shape to vary slightly. Radius selection is still restricted to discrete values by snapping to a block-sized grid. (It did that before already, but also rounded down.)
- And finally, this PR restores the particle effects that should be displayed while selecting a radius and makes them slightly fancier. There also is a new version of the effect to be displayed while selecting a sphere radius:
![Sphere mode selection in progress](https://user-images.githubusercontent.com/7620864/232559522-ccaefef7-de70-4861-b425-723e6f115b9c.png)
