### PR TITLE
Delay Runic Altar picking up it's outputs, and allow Hopperhocks to pick up outputs quicker

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/RunicAltarBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/RunicAltarBlockEntity.java
@@ -49,6 +49,7 @@ import vazkii.botania.common.item.BotaniaItems;
 import vazkii.botania.common.item.WandOfTheForestItem;
 import vazkii.botania.common.item.material.RuneItem;
 import vazkii.botania.common.proxy.Proxy;
+import vazkii.botania.xplat.XplatAbstractions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -163,7 +164,8 @@ public class RunicAltarBlockEntity extends SimpleInventoryBlockEntity implements
 		if (self.manaToGet == 0) {
 			List<ItemEntity> items = level.getEntitiesOfClass(ItemEntity.class, new AABB(worldPosition, worldPosition.offset(1, 1, 1)));
 			for (ItemEntity item : items) {
-				if (item.isAlive() && !item.getItem().isEmpty() && !item.getItem().is(BotaniaBlocks.livingrock.asItem())) {
+				if (item.isAlive() && !item.getItem().isEmpty() && !item.getItem().is(BotaniaBlocks.livingrock.asItem())
+						&& XplatAbstractions.INSTANCE.itemFlagsComponent(item).getRunicAltarCooldown() == 0) {
 					ItemStack stack = item.getItem();
 					if (self.addItem(null, stack, null)) {
 						EntityHelper.syncItem(item);
@@ -278,6 +280,7 @@ public class RunicAltarBlockEntity extends SimpleInventoryBlockEntity implements
 				receiveMana(-mana);
 				ItemStack output = recipe.assemble(getItemHandler());
 				ItemEntity outputItem = new ItemEntity(level, worldPosition.getX() + 0.5, worldPosition.getY() + 1.5, worldPosition.getZ() + 0.5, output);
+				XplatAbstractions.INSTANCE.itemFlagsComponent(outputItem).markAltarOutput();
 				level.addFreshEntity(outputItem);
 				currentRecipe = null;
 				level.blockEvent(getBlockPos(), BotaniaBlocks.runeAltar, SET_COOLDOWN_EVENT, 60);
@@ -289,6 +292,7 @@ public class RunicAltarBlockEntity extends SimpleInventoryBlockEntity implements
 					if (!stack.isEmpty()) {
 						if (stack.getItem() instanceof RuneItem && (player == null || !player.getAbilities().instabuild)) {
 							ItemEntity outputRune = new ItemEntity(level, getBlockPos().getX() + 0.5, getBlockPos().getY() + 1.5, getBlockPos().getZ() + 0.5, stack.copy());
+							XplatAbstractions.INSTANCE.itemFlagsComponent(outputRune).markAltarOutput();
 							level.addFreshEntity(outputRune);
 						}
 

--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/HopperhockBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/HopperhockBlockEntity.java
@@ -81,8 +81,14 @@ public class HopperhockBlockEntity extends FunctionalFlowerBlockEntity implement
 				return false;
 			}
 
+			final ItemFlagsComponent flags = XplatAbstractions.INSTANCE.itemFlagsComponent(item);
+
 			// Flat 5 tick delay for newly infused items
-			var manaInfusionCooldown = XplatAbstractions.INSTANCE.itemFlagsComponent(item).getManaInfusionCooldown();
+			final int runicAltarCooldown = flags.getRunicAltarCooldown();
+			if (runicAltarCooldown > 0) {
+				return runicAltarCooldown <= ItemFlagsComponent.INITIAL_RUNIC_ALTAR_COOLDOWN - 5;
+			}
+			var manaInfusionCooldown = flags.getManaInfusionCooldown();
 			if (manaInfusionCooldown > 0) {
 				return manaInfusionCooldown <= ItemFlagsComponent.INITIAL_MANA_INFUSION_COOLDOWN - 5;
 			}

--- a/Xplat/src/main/java/vazkii/botania/common/internal_caps/ItemFlagsComponent.java
+++ b/Xplat/src/main/java/vazkii/botania/common/internal_caps/ItemFlagsComponent.java
@@ -29,7 +29,12 @@ public class ItemFlagsComponent extends SerializableComponent {
 	 * Used so certain mechanics don't interact with items immediately after they're produced.
 	 */
 	private int manaInfusionCooldown = 0;
+	/**
+	 * Similar to {@link #manaInfusionCooldown} but for the Runic Altar.
+	 */
+	private int runicAltarCooldown = 0;
 	public static final int INITIAL_MANA_INFUSION_COOLDOWN = 25;
+	public static final int INITIAL_RUNIC_ALTAR_COOLDOWN = 15;
 
 	@Override
 	public void readFromNbt(CompoundTag tag) {
@@ -37,6 +42,7 @@ public class ItemFlagsComponent extends SerializableComponent {
 		apothecarySpawned = tag.getBoolean(PetalApothecaryBlockEntity.ITEM_TAG_APOTHECARY_SPAWNED);
 		timeCounter = tag.getInt("timeCounter");
 		manaInfusionCooldown = tag.getInt("manaInfusionCooldown");
+		runicAltarCooldown = tag.getInt("runicAltarCooldown");
 	}
 
 	@Override
@@ -45,12 +51,16 @@ public class ItemFlagsComponent extends SerializableComponent {
 		tag.putBoolean(PetalApothecaryBlockEntity.ITEM_TAG_APOTHECARY_SPAWNED, apothecarySpawned);
 		tag.putInt("timeCounter", timeCounter);
 		tag.putInt("manaInfusionCooldown", manaInfusionCooldown);
+		tag.putInt("runicAltarCooldown", runicAltarCooldown);
 	}
 
 	public void tick() {
 		timeCounter++;
 		if (manaInfusionCooldown > 0) {
 			manaInfusionCooldown--;
+		}
+		if (runicAltarCooldown > 0) {
+			runicAltarCooldown--;
 		}
 	}
 
@@ -60,5 +70,13 @@ public class ItemFlagsComponent extends SerializableComponent {
 
 	public void markNewlyInfused() {
 		manaInfusionCooldown = INITIAL_MANA_INFUSION_COOLDOWN;
+	}
+
+	public int getRunicAltarCooldown() {
+		return runicAltarCooldown;
+	}
+
+	public void markAltarOutput() {
+		runicAltarCooldown = INITIAL_RUNIC_ALTAR_COOLDOWN;
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/internal_caps/ItemFlagsComponent.java
+++ b/Xplat/src/main/java/vazkii/botania/common/internal_caps/ItemFlagsComponent.java
@@ -34,7 +34,7 @@ public class ItemFlagsComponent extends SerializableComponent {
 	 */
 	private int runicAltarCooldown = 0;
 	public static final int INITIAL_MANA_INFUSION_COOLDOWN = 25;
-	public static final int INITIAL_RUNIC_ALTAR_COOLDOWN = 15;
+	public static final int INITIAL_RUNIC_ALTAR_COOLDOWN = 25;
 
 	@Override
 	public void readFromNbt(CompoundTag tag) {


### PR DESCRIPTION
Brings behavior more in line with Mana infusions, making automation easier by not needing an Influence lens on a pulse spreader to move the items before the Altar picks them back up. Looking at older YouTube videos it seems like this is how it worked in the past, and at some point something changed to where you now need an Influence lens.

edit: I've noticed that Runic Altars already have their own cooldown, but I still think this change is good both for allowing Hopperhocks to pick up outputs more quickly and for preventing nearby altars from grabbing each other's outputs accidentally. It also might make sense to reduce that cooldown from the current 60 ticks along with this change?