### PR TITLE
Rannuncarpus fills empty spaces before adding to existing blocks

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/RannuncarpusBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/RannuncarpusBlockEntity.java
@@ -156,8 +156,8 @@ public class RannuncarpusBlockEntity extends FunctionalFlowerBlockEntity impleme
 		int rangePlaceY = getVerticalPlaceRange();
 		BlockPos center = getEffectivePos();
 		BlockState filter = getUnderlyingBlock();
-		List<BlockPos> primary = new ArrayList<>();
-		List<BlockPos> secondary = new ArrayList<>();
+		List<BlockPos> emptyPositions = new ArrayList<>();
+		List<BlockPos> additivePositions = new ArrayList<>();
 
 		for (BlockPos pos : BlockPos.betweenClosed(center.offset(-rangePlace, -rangePlaceY, -rangePlace),
 				center.offset(rangePlace, rangePlaceY, rangePlace))) {
@@ -173,16 +173,21 @@ public class RannuncarpusBlockEntity extends FunctionalFlowerBlockEntity impleme
 			}
 
 			if (matches) {
-				if (up.isAir() || up.getMaterial().isReplaceable()) {
-					primary.add(pos.immutable());
+				if (isAirOrDifferentReplaceableBlock(up, stack)) {
+					emptyPositions.add(pos.immutable());
 				} else if (up.canBeReplaced(getBlockPlaceContext(stack, placementPos))) {
-					secondary.add(pos.immutable());
+					// same block type, but can still place more
+					additivePositions.add(pos.immutable());
 				}
 			}
 		}
 
-		return !primary.isEmpty() ? primary.get(rand.nextInt(primary.size()))
-				: !secondary.isEmpty() ? secondary.get(rand.nextInt(secondary.size())) : null;
+		return !emptyPositions.isEmpty() ? emptyPositions.get(rand.nextInt(emptyPositions.size()))
+				: !additivePositions.isEmpty() ? additivePositions.get(rand.nextInt(additivePositions.size())) : null;
+	}
+
+	private static boolean isAirOrDifferentReplaceableBlock(BlockState state, ItemStack stack) {
+		return state.isAir() || state.getMaterial().isReplaceable() && !stack.is(state.getBlock().asItem());
 	}
 
 	@Override

--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/RannuncarpusBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/RannuncarpusBlockEntity.java
@@ -156,7 +156,8 @@ public class RannuncarpusBlockEntity extends FunctionalFlowerBlockEntity impleme
 		int rangePlaceY = getVerticalPlaceRange();
 		BlockPos center = getEffectivePos();
 		BlockState filter = getUnderlyingBlock();
-		List<BlockPos> ret = new ArrayList<>();
+		List<BlockPos> primary = new ArrayList<>();
+		List<BlockPos> secondary = new ArrayList<>();
 
 		for (BlockPos pos : BlockPos.betweenClosed(center.offset(-rangePlace, -rangePlaceY, -rangePlace),
 				center.offset(rangePlace, rangePlaceY, rangePlace))) {
@@ -171,13 +172,17 @@ public class RannuncarpusBlockEntity extends FunctionalFlowerBlockEntity impleme
 				matches = state.is(filter.getBlock());
 			}
 
-			if (matches && (up.isAir() || up.getMaterial().isReplaceable()
-					|| up.canBeReplaced(getBlockPlaceContext(stack, placementPos)))) {
-				ret.add(pos.immutable());
+			if (matches) {
+				if (up.isAir() || up.getMaterial().isReplaceable()) {
+					primary.add(pos.immutable());
+				} else if (up.canBeReplaced(getBlockPlaceContext(stack, placementPos))) {
+					secondary.add(pos.immutable());
+				}
 			}
 		}
 
-		return ret.isEmpty() ? null : ret.get(rand.nextInt(ret.size()));
+		return !primary.isEmpty() ? primary.get(rand.nextInt(primary.size()))
+				: !secondary.isEmpty() ? secondary.get(rand.nextInt(secondary.size())) : null;
 	}
 
 	@Override


### PR DESCRIPTION
This allows the Rannuncarpus to e.g. create a desired number of single-candle blocks with the minimum number of required items. (as per comments on #4329 fixes #4306 in a better way)