### PR TITLE
Enable opened icon for trinket case

### DIFF
--- a/Xplat/src/generated/resources/.cache/b6cea893089e2fd8d5149eb101d8c4ec4cb454ff
+++ b/Xplat/src/generated/resources/.cache/b6cea893089e2fd8d5149eb101d8c4ec4cb454ff
@@ -45,7 +45,8 @@ eb9c959e8d6d9115af38062f1560f7cb47706f92 assets/botania/models/item/azulejo_6.js
 218adeef5f2a912a4cdce349d8e9b9721d6a71ce assets/botania/models/item/azulejo_8.json
 753de4d1f575e59a5b86dec105ec3fec2aa5b495 assets/botania/models/item/azulejo_9.json
 bee061b7738b9e4ba0fec8470969096d904910a9 assets/botania/models/item/balance_cloak.json
-418bc91e3105b1b19bfe6af9d39ec109b87942b9 assets/botania/models/item/bauble_box.json
+8179e7c39e1113fa431cd6d429d80ef9565d6078 assets/botania/models/item/bauble_box.json
+e07fd05e7be9087c5f29f226b033f28b88417cc7 assets/botania/models/item/bauble_box_open.json
 0754a108c9dd2fcbb2b63f675cba103bce8c83b3 assets/botania/models/item/bellethorn.json
 48b75ab2f607d7ed241fd0ed17e826050ebc90eb assets/botania/models/item/bellethorn_chibi.json
 610f7e31086b03157d61a062a93c7e0026ffeeb1 assets/botania/models/item/bellows.json

--- a/Xplat/src/generated/resources/assets/botania/models/item/bauble_box.json
+++ b/Xplat/src/generated/resources/assets/botania/models/item/bauble_box.json
@@ -1,5 +1,13 @@
 {
   "parent": "minecraft:item/generated",
+  "overrides": [
+    {
+      "model": "botania:item/bauble_box_open",
+      "predicate": {
+        "botania:open": 1.0
+      }
+    }
+  ],
   "textures": {
     "layer0": "botania:item/bauble_box"
   }

--- a/Xplat/src/generated/resources/assets/botania/models/item/bauble_box_open.json
+++ b/Xplat/src/generated/resources/assets/botania/models/item/bauble_box_open.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "botania:item/bauble_box_open"
+  }
+}

--- a/Xplat/src/main/java/vazkii/botania/client/BotaniaItemProperties.java
+++ b/Xplat/src/main/java/vazkii/botania/client/BotaniaItemProperties.java
@@ -27,6 +27,8 @@ import static vazkii.botania.common.lib.ResourceLocationHelper.prefix;
 
 public final class BotaniaItemProperties {
 	public static void init(TriConsumer<ItemLike, ResourceLocation, ClampedItemPropertyFunction> consumer) {
+		consumer.accept(BotaniaItems.baubleBox, prefix("open"),
+				(stack, world, entity, seed) -> ItemNBTHelper.getBoolean(stack, BaubleBoxItem.TAG_OPEN, false) ? 1 : 0);
 		consumer.accept(BotaniaItems.blackHoleTalisman, prefix("active"),
 				(stack, world, entity, seed) -> ItemNBTHelper.getBoolean(stack, BlackHoleTalismanItem.TAG_ACTIVE, false) ? 1 : 0);
 		consumer.accept(BotaniaItems.manaBottle, prefix("swigs_taken"),

--- a/Xplat/src/main/java/vazkii/botania/client/gui/box/BaubleBoxContainer.java
+++ b/Xplat/src/main/java/vazkii/botania/client/gui/box/BaubleBoxContainer.java
@@ -124,7 +124,9 @@ public class BaubleBoxContainer extends AbstractContainerMenu {
 
 	@Override
 	public void removed(@NotNull Player player) {
-		ItemNBTHelper.setBoolean(box, BaubleBoxItem.TAG_OPEN, false);
+		if (!player.level.isClientSide) {
+			ItemNBTHelper.setBoolean(box, BaubleBoxItem.TAG_OPEN, false);
+		}
 		super.removed(player);
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/client/gui/box/BaubleBoxContainer.java
+++ b/Xplat/src/main/java/vazkii/botania/client/gui/box/BaubleBoxContainer.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.NotNull;
 
 import vazkii.botania.client.gui.SlotLocked;
 import vazkii.botania.common.handler.EquipmentHandler;
+import vazkii.botania.common.helper.ItemNBTHelper;
 import vazkii.botania.common.item.BaubleBoxItem;
 import vazkii.botania.common.item.BotaniaItems;
 
@@ -121,4 +122,9 @@ public class BaubleBoxContainer extends AbstractContainerMenu {
 		return itemstack;
 	}
 
+	@Override
+	public void removed(@NotNull Player player) {
+		ItemNBTHelper.setBoolean(box, BaubleBoxItem.TAG_OPEN, false);
+		super.removed(player);
+	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/item/BaubleBoxItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/BaubleBoxItem.java
@@ -28,12 +28,14 @@ import org.jetbrains.annotations.NotNull;
 import vazkii.botania.client.gui.box.BaubleBoxContainer;
 import vazkii.botania.common.handler.EquipmentHandler;
 import vazkii.botania.common.helper.InventoryHelper;
+import vazkii.botania.common.helper.ItemNBTHelper;
 import vazkii.botania.xplat.XplatAbstractions;
 
 import java.util.stream.IntStream;
 
 public class BaubleBoxItem extends Item {
 	public static final int SIZE = 24;
+	public static final String TAG_OPEN = "open";
 
 	public BaubleBoxItem(Properties props) {
 		super(props);
@@ -53,6 +55,7 @@ public class BaubleBoxItem extends Item {
 	public InteractionResultHolder<ItemStack> use(Level world, Player player, @NotNull InteractionHand hand) {
 		if (!world.isClientSide) {
 			ItemStack stack = player.getItemInHand(hand);
+			ItemNBTHelper.setBoolean(stack, TAG_OPEN, true);
 			XplatAbstractions.INSTANCE.openMenu((ServerPlayer) player, new MenuProvider() {
 				@Override
 				public Component getDisplayName() {

--- a/Xplat/src/main/java/vazkii/botania/data/ItemModelProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/data/ItemModelProvider.java
@@ -198,6 +198,9 @@ public class ItemModelProvider implements DataProvider {
 		items.remove(livingwoodBow);
 		items.remove(crystalBow);
 
+		singleGeneratedSuffixOverride(baubleBox, "_open", prefix("open"), 1.0, consumer);
+		items.remove(baubleBox);
+
 		singleGeneratedSuffixOverride(blackHoleTalisman, "_active", prefix("active"), 1.0, consumer);
 		items.remove(blackHoleTalisman);
 

--- a/web/changelog.md
+++ b/web/changelog.md
@@ -21,6 +21,7 @@ and start a new "Upcoming" section.
 * Add: Mana pools with pylons on top of them will now play a small particle effect when trading items in the alfheim portal
 * Add: Looking at a Spark while holding a Wand of the Forest will now render a HUD showing information like augments (for mana sparks) and network color (both mana and corporea sparks)
 * Add: Terra Truncator can now propagate its chopping through Mangrove Roots
+* Add: Trinket case uses special open icon while its GUI is open 
 * Change: Instead of always cooling down for 5 minutes, thermalilies now have a random cooldown between 20 seconds and 5 minutes. For automation, you can read how long the cooldown is with a comparator
 * Change: Entropinnyum's "unethical TNT" detection was changed, it's now more accurate and shouldn't cause any false positives
 * Change: Flower pouches now render missing flowers transparently, and render a "1" next to stacks with one item


### PR DESCRIPTION
When a trinket case is opened, its icon changes to the opened version. This change should also be visible to other players, when the case is in the main hand or off-hand. (implements #3439 )