### PR TITLE
Add toggle option to Manufactory Halo

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/handler/BotaniaSounds.java
+++ b/Xplat/src/main/java/vazkii/botania/common/handler/BotaniaSounds.java
@@ -80,6 +80,7 @@ public final class BotaniaSounds {
 	public static final SoundEvent smeltRodSimmer = makeSoundEvent("smelt_rod_simmer");
 	public static final SoundEvent starcaller = makeSoundEvent("starcaller");
 	public static final SoundEvent temperanceStoneConfigure = makeSoundEvent("temperance_stone_configure");
+	public static final SoundEvent manufactoryHaloConfigure = makeSoundEvent("manufactory_halo_configure");
 	public static final SoundEvent terraBlade = makeSoundEvent("terrablade");
 	public static final SoundEvent terraPickMode = makeSoundEvent("terra_pick_mode");
 	public static final SoundEvent terraformRod = makeSoundEvent("terraform_rod");

--- a/Xplat/src/main/java/vazkii/botania/common/item/AssemblyHaloItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/AssemblyHaloItem.java
@@ -216,7 +216,7 @@ public class AssemblyHaloItem extends Item {
 		return false;
 	}
 
-	private static int getSegmentLookedAt(ItemStack stack, LivingEntity living) {
+	protected static int getSegmentLookedAt(ItemStack stack, LivingEntity living) {
 		float yaw = getCheckingAngle(living, getRotationBase(stack));
 
 		int angles = 360;
@@ -336,7 +336,7 @@ public class AssemblyHaloItem extends Item {
 		ItemNBTHelper.setFloat(stack, TAG_ROTATION_BASE, rotation);
 	}
 
-	public ResourceLocation getGlowResource() {
+	public ResourceLocation getGlowResource(ItemStack stack) {
 		return glowTexture;
 	}
 
@@ -348,7 +348,6 @@ public class AssemblyHaloItem extends Item {
 				return;
 			}
 
-			Minecraft mc = Minecraft.getInstance();
 			MultiBufferSource.BufferSource bufferSource = buffers.bufferSource();
 
 			double renderPosX = camera.getPosition().x();
@@ -379,7 +378,7 @@ public class AssemblyHaloItem extends Item {
 
 			int segmentLookedAt = getSegmentLookedAt(stack, player);
 			AssemblyHaloItem item = (AssemblyHaloItem) stack.getItem();
-			RenderType layer = RenderHelper.getHaloLayer(item.getGlowResource());
+			RenderType layer = RenderHelper.getHaloLayer(item.getGlowResource(stack));
 
 			for (int seg = 0; seg < SEGMENTS; seg++) {
 				boolean inside = false;

--- a/Xplat/src/main/java/vazkii/botania/common/item/ManufactoryHaloItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/ManufactoryHaloItem.java
@@ -8,16 +8,32 @@
  */
 package vazkii.botania.common.item;
 
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.SlotAccess;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ClickAction;
+import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 
+import org.jetbrains.annotations.NotNull;
+
 import vazkii.botania.client.lib.ResourcesLib;
+import vazkii.botania.common.handler.BotaniaSounds;
+import vazkii.botania.common.helper.ItemNBTHelper;
+
+import java.util.List;
 
 public class ManufactoryHaloItem extends AssemblyHaloItem {
+	public static final String TAG_ACTIVE = "active";
 
 	private static final ResourceLocation glowTexture = new ResourceLocation(ResourcesLib.MISC_GLOW_CYAN);
 
@@ -29,7 +45,7 @@ public class ManufactoryHaloItem extends AssemblyHaloItem {
 	public void inventoryTick(ItemStack stack, Level world, Entity entity, int pos, boolean equipped) {
 		super.inventoryTick(stack, world, entity, pos, equipped);
 
-		if (!world.isClientSide && entity instanceof Player player && !equipped) {
+		if (!world.isClientSide && entity instanceof Player player && !equipped && isActive(stack)) {
 
 			for (int i = 1; i < SEGMENTS; i++) {
 				tryCraft(player, stack, i, false);
@@ -38,8 +54,51 @@ public class ManufactoryHaloItem extends AssemblyHaloItem {
 	}
 
 	@Override
-	public ResourceLocation getGlowResource() {
-		return glowTexture;
+	public ResourceLocation getGlowResource(ItemStack stack) {
+		return isActive(stack) ? glowTexture : super.getGlowResource(stack);
 	}
 
+	@Override
+	public void appendHoverText(@NotNull ItemStack stack, Level world, @NotNull List<Component> stacks, @NotNull TooltipFlag flags) {
+		if (isActive(stack)) {
+			stacks.add(Component.translatable("botaniamisc.active"));
+		} else {
+			stacks.add(Component.translatable("botaniamisc.inactive"));
+		}
+	}
+
+	@NotNull
+	@Override
+	public InteractionResultHolder<ItemStack> use(Level world, Player player, @NotNull InteractionHand hand) {
+		ItemStack stack = player.getItemInHand(hand);
+		if (getSegmentLookedAt(stack, player) == 0 && player.isSecondaryUseActive()) {
+			togglePassive(stack, player, world);
+			return InteractionResultHolder.sidedSuccess(stack, world.isClientSide());
+		}
+
+		return super.use(world, player, hand);
+	}
+
+	@Override
+	public boolean overrideOtherStackedOnMe(@NotNull ItemStack stack, @NotNull ItemStack cursor, @NotNull Slot slot,
+			@NotNull ClickAction click, Player player, @NotNull SlotAccess access) {
+		Level world = player.getLevel();
+		if (click == ClickAction.SECONDARY && slot.allowModification(player) && cursor.isEmpty()) {
+			togglePassive(stack, player, world);
+			access.set(cursor);
+			return true;
+		}
+		return false;
+	}
+
+	private void togglePassive(ItemStack stack, LivingEntity living, Level world) {
+		ItemNBTHelper.setBoolean(stack, TAG_ACTIVE, !isActive(stack));
+		if (living instanceof Player player && world != null) {
+			world.playSound(player, player.getX(), player.getY(), player.getZ(), BotaniaSounds.manufactoryHaloConfigure, SoundSource.NEUTRAL, 1F, 1F);
+		}
+	}
+
+	private static boolean isActive(ItemStack stack) {
+		return ItemNBTHelper.getBoolean(stack, TAG_ACTIVE, true);
+	}
 }

--- a/Xplat/src/main/resources/assets/botania/lang/en_us.json
+++ b/Xplat/src/main/resources/assets/botania/lang/en_us.json
@@ -2898,7 +2898,7 @@
   "botania.entry.autocraftingHalo": "Manufactory Halo",
   "botania.tagline.autocraftingHalo": "An Assembly Halo that crafts for you",
   "botania.page.autocraftingHalo0": "The $(item)Manufactory Halo$(0) is an upgrade of the $(l:tools/crafting_halo)$(item)Assembly Halo$(0)$(/l): aside from doing all that the $(l:tools/crafting_halo)$(item)Assembly Halo$(0)$(/l) can do, the $(item)Manufactory Halo$(0) will (when $(o)not$() held) automatically craft all possible saved recipes.$(p)Automatic compression of ores while mining is just one of many applications this upgrade has.",
-  "botania.page.autocraftingHalo1": "Halo Now Launcher",
+  "botania.page.autocraftingHalo1": "Halo Now Launcher$(p)Automatic crafting can be toggled on/off by right-clicking the $(item)Manufactory Halo$(0) in your inventory, or by right-clicking its $(item)Crafting Table$(0) segment while sneaking.",
 
   "botania.entry.sextant": "Worldshaper's Sextant",
   "botania.tagline.sextant": "A tool to help create circles",
@@ -3544,6 +3544,7 @@
   "botania.subtitle.spreaderFire": "Spreader fwooshes",
   "botania.subtitle.starcaller": "Stars descend from the sky",
   "botania.subtitle.temperanceStoneConfigure": "Stone of Temperance dings",
+  "botania.subtitle.manufactoryHaloConfigure": "Manufactory Halo dings",
   "botania.subtitle.terraBlade": "Terrasteel Sword activates",
   "botania.subtitle.terraPickMode": "Terra Shatterer empowers",
   "botania.subtitle.terraformRod": "Land terraforms",

--- a/Xplat/src/main/resources/assets/botania/sounds.json
+++ b/Xplat/src/main/resources/assets/botania/sounds.json
@@ -629,6 +629,17 @@
 		],
 		"subtitle": "botania.subtitle.temperanceStoneConfigure"
 	},
+	"manufactory_halo_configure": {
+		"sounds": [
+			{
+				"type": "event",
+				"name": "minecraft:entity.experience_orb.pickup",
+				"volume": 0.3,
+				"pitch": 0.1
+			}
+		],
+		"subtitle": "botania.subtitle.manufactoryHaloConfigure"
+	},
 	"terra_pick_mode": {
 		"sounds": [
 			{

--- a/web/changelog.md
+++ b/web/changelog.md
@@ -19,6 +19,7 @@ and start a new "Upcoming" section.
 {% include changelog_header.html version="Upcoming" %}
 
 * Add: The Worldshaper's Sextant can now generate spheres as well (Wormbo)
+* Add: Manufactory Halo's auto-crafting can be toggled by shift+right-clicking the crafting table segment or right-clicking the item in an inventory screen
 * Change: The Worldshaper's Sextant provides more control over the exact shape of circles by having the radius selection snap to the block grind instead of only allowing integers (Wormbo)
 
 ---


### PR DESCRIPTION
Auto-crafting can be toggled similar to the Stone of Temperance's effect, either by right-clicking the Manufactory Halo in an inventory screen, or by sneak right-clicking on the crafting table segment while holding it, as suggested in issue #4277.
The auto-crafting status is visualized via tooltip (like for the Stone of Temperance) and via the color of the crafting segments when holding it (with auto-crafting disabled, the segment background color switches to that of the Assembly Halo). It'd probably be nice to also modify the item's icon, but there's currently no separate texture and I think reusing the Assembly Halo's icon might be a bit confusing.