### PR TITLE
Allow the flower model for floating flowers to use forges model extensions.

### DIFF
--- a/Forge/src/main/java/vazkii/botania/forge/client/ForgeFloatingFlowerModel.java
+++ b/Forge/src/main/java/vazkii/botania/forge/client/ForgeFloatingFlowerModel.java
@@ -20,6 +20,7 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.client.ChunkRenderTypeSet;
 import net.minecraftforge.client.model.data.ModelData;
 import net.minecraftforge.client.model.data.ModelProperty;
 import net.minecraftforge.client.model.geometry.IGeometryBakingContext;
@@ -168,6 +169,9 @@ public class ForgeFloatingFlowerModel implements IUnbakedGeometry<ForgeFloatingF
 				type = extraData.get(FLOATING_PROPERTY).getIslandType();
 			}
 
+			if (renderType != null && state != null && !this.flower.getRenderTypes(state, rand, extraData).contains(renderType)) {
+				return islands.get(type).getQuads(state, side, rand, ModelData.EMPTY, renderType);
+			}
 			List<BakedQuad> flower = this.flower.getQuads(state, side, rand, ModelData.EMPTY, renderType);
 			List<BakedQuad> island = islands.get(type).getQuads(state, side, rand, ModelData.EMPTY, renderType);
 			List<BakedQuad> ret = new ArrayList<>(flower.size() + island.size());
@@ -180,6 +184,12 @@ public class ForgeFloatingFlowerModel implements IUnbakedGeometry<ForgeFloatingF
 		@Override
 		public List<BakedModel> getRenderPasses(@NotNull ItemStack stack, boolean fabulous) {
 			return List.of(flower, islands.get(FloatingFlower.IslandType.GRASS));
+		}
+
+		@NotNull
+		@Override
+		public ChunkRenderTypeSet getRenderTypes(@NotNull BlockState state, @NotNull RandomSource rand, @NotNull ModelData data) {
+			return ChunkRenderTypeSet.union(BakedModel.super.getRenderTypes(state, rand, data), this.flower.getRenderTypes(state, rand, data));
 		}
 	}
 


### PR DESCRIPTION
This changes `ForgeFloatingFlowerModel` such that it uses the `ChunkRenderTypeSet` from the flower model to construct its block render types. Also as the floating flower model may add more render types to the flower model it makes sure, that `getQuads` is only called on the flower model if the flower model supports the queried render type.

This change allows `SimpleBakedModel` instances with a render type as well as multi-rendertype models to be used with the floating flower model loader.