### PR TITLE
Fix description of Efficiency Lens

### DIFF
--- a/Xplat/src/main/resources/assets/botania/lang/en_us.json
+++ b/Xplat/src/main/resources/assets/botania/lang/en_us.json
@@ -2012,7 +2012,7 @@
   "botania.page.lens9": "Potency Lens",
   "botania.page.lens10": "The $(item)Resistance Lens$(0) will significantly increase the amount of time a $(thing)Mana Burst$(0) can go without starting to lose $(thing)Mana$(0), but slows it as well.",
   "botania.page.lens11": "Resistance Lens",
-  "botania.page.lens12": "The $(item)Efficiency Lens$(0) will decrease the amount of time it takes for a $(thing)Mana Burst$(0) to start losing its $(thing)Mana$(0), but will also decrease its rate of loss.",
+  "botania.page.lens12": "The $(item)Efficiency Lens$(0) will slightly increase the amount of time it takes for a $(thing)Mana Burst$(0) to start losing its $(thing)Mana$(0), and will also significantly decrease its rate of loss.",
   "botania.page.lens13": "Efficiency Lens",
   "botania.page.lens14": "The $(item)Bounce Lens$(0) will allow a $(thing)Mana Burst$(0) to bounce off walls, rather than dissipating on collision.",
   "botania.page.lens15": "Bounce Lens",


### PR DESCRIPTION
The lens actually increases the time to mana loss a bit instead of decreasing it. Its main feature probably is the significantly reduced mana loss rate, though.