### PR TITLE
Make key of the king's law not hurt nonliving entities

### DIFF
--- a/Xplat/src/generated/resources/.cache/653944ae1edeea7f4ecf5f993d31cab4d4d4eca0
+++ b/Xplat/src/generated/resources/.cache/653944ae1edeea7f4ecf5f993d31cab4d4d4eca0
@@ -3,5 +3,6 @@
 ffb8bea773fc90c54cb94c895cc5f096428f1f8b data/botania/tags/entity_types/cocoon/common_aquatic.json
 a46ef61d2e442ecb1c477406cd1987f243197d77 data/botania/tags/entity_types/cocoon/rare.json
 1fbe94085d6760f4ab5055f72ed127a4568c9487 data/botania/tags/entity_types/cocoon/rare_aquatic.json
+8c959685fc06d7f6136dda4b884691469e9ed32a data/botania/tags/entity_types/key_immune.json
 36ad4c64bb218684802f4951c644eca848834ccc data/botania/tags/entity_types/shaded_mesa_blacklist.json
 8eb95c79e26cf634dcf3c8bc3e1f0b1c9664931c data/c/tags/entity_types/bosses.json

--- a/Xplat/src/generated/resources/data/botania/tags/entity_types/key_immune.json
+++ b/Xplat/src/generated/resources/data/botania/tags/entity_types/key_immune.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:item",
+    "minecraft:item_frame",
+    "minecraft:painting",
+    "minecraft:experience_orb"
+  ]
+}

--- a/Xplat/src/main/java/vazkii/botania/common/BotaniaDamageTypes.java
+++ b/Xplat/src/main/java/vazkii/botania/common/BotaniaDamageTypes.java
@@ -18,6 +18,8 @@ public class BotaniaDamageTypes {
 			ResourceKey.create(Registries.DAMAGE_TYPE, prefix("player_attack_armor_piercing"));
 	public static final ResourceKey<DamageType> RELIC_DAMAGE =
 			ResourceKey.create(Registries.DAMAGE_TYPE, prefix("relic_damage"));
+	public static final ResourceKey<DamageType> KEY_EXPLOSION =
+			ResourceKey.create(Registries.DAMAGE_TYPE, prefix("key_explosion"));
 
 	public static class Sources {
 

--- a/Xplat/src/main/java/vazkii/botania/common/entity/BabylonWeaponEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/entity/BabylonWeaponEntity.java
@@ -8,11 +8,15 @@
  */
 package vazkii.botania.common.entity;
 
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageType;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
@@ -28,6 +32,7 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
 
 import vazkii.botania.client.fx.WispParticleData;
+import vazkii.botania.common.BotaniaDamageTypes;
 import vazkii.botania.common.handler.BotaniaSounds;
 import vazkii.botania.common.helper.PlayerHelper;
 import vazkii.botania.common.helper.VecHelper;
@@ -179,7 +184,9 @@ public class BabylonWeaponEntity extends ThrowableCopyEntity {
 
 	private void explodeAndDie() {
 		if (!level().isClientSide) {
-			level().explode(this, getX(), getY(), getZ(), 3F, Level.ExplosionInteraction.NONE);
+			Holder<DamageType> type = level().registryAccess().registryOrThrow(Registries.DAMAGE_TYPE).getHolderOrThrow(BotaniaDamageTypes.KEY_EXPLOSION);
+			DamageSource source = new DamageSource(type, this, this.getOwner());
+			level().explode(this, source, null, getX(), getY(), getZ(), 3F, false, Level.ExplosionInteraction.NONE);
 			discard();
 		}
 	}

--- a/Xplat/src/main/java/vazkii/botania/common/lib/BotaniaTags.java
+++ b/Xplat/src/main/java/vazkii/botania/common/lib/BotaniaTags.java
@@ -247,6 +247,11 @@ public class BotaniaTags {
 		public static final TagKey<EntityType<?>> COCOON_COMMON_AQUATIC = tag("cocoon/common_aquatic");
 		public static final TagKey<EntityType<?>> COCOON_RARE_AQUATIC = tag("cocoon/rare_aquatic");
 
+		/**
+		 * Entities in this tag are immune to damage from the Key of the King's Law
+		 */
+		public static final TagKey<EntityType<?>> KEY_IMMUNE = tag("key_immune");
+
 		private static TagKey<EntityType<?>> tag(String name) {
 			return TagKey.create(Registries.ENTITY_TYPE, prefix(name));
 		}

--- a/Xplat/src/main/java/vazkii/botania/data/DamageTypeTagProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/data/DamageTypeTagProvider.java
@@ -41,5 +41,7 @@ public class DamageTypeTagProvider extends TagsProvider<DamageType> {
 		this.tag(DamageTypeTags.NO_IMPACT).add(BotaniaDamageTypes.RELIC_DAMAGE);
 		this.tag(DamageTypeTags.BYPASSES_EFFECTS).add(BotaniaDamageTypes.RELIC_DAMAGE);
 		this.tag(DamageTypeTags.BYPASSES_ENCHANTMENTS).add(BotaniaDamageTypes.RELIC_DAMAGE);
+
+		this.tag(DamageTypeTags.IS_EXPLOSION).add(BotaniaDamageTypes.KEY_EXPLOSION);
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/data/EntityTagProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/data/EntityTagProvider.java
@@ -49,6 +49,8 @@ public class EntityTagProvider extends IntrinsicHolderTagsProvider<EntityType<?>
 				BotaniaEntities.CORPOREA_SPARK, BotaniaEntities.DOPPLEGANGER, BotaniaEntities.FLAME_RING, BotaniaEntities.MAGIC_LANDMINE,
 				BotaniaEntities.MAGIC_MISSILE, BotaniaEntities.MANA_BURST, BotaniaEntities.PINK_WITHER, BotaniaEntities.SPARK, BotaniaEntities.PLAYER_MOVER);
 
+		tag(BotaniaTags.Entities.KEY_IMMUNE).add(EntityType.ITEM, EntityType.ITEM_FRAME, EntityType.PAINTING, EntityType.EXPERIENCE_ORB);
+
 		var bosses = TagKey.create(Registries.ENTITY_TYPE, new ResourceLocation("c", "bosses"));
 		tag(bosses).add(BotaniaEntities.DOPPLEGANGER);
 	}

--- a/Xplat/src/main/java/vazkii/botania/mixin/EntityMixin.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/EntityMixin.java
@@ -10,20 +10,30 @@ package vazkii.botania.mixin;
 
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import vazkii.botania.common.BotaniaDamageTypes;
 import vazkii.botania.common.item.EquestrianVirusItem;
 import vazkii.botania.common.item.equipment.bauble.CrimsonPendantItem;
+import vazkii.botania.common.lib.BotaniaTags;
 
 @Mixin(Entity.class)
-public class EntityMixin {
+public abstract class EntityMixin {
+
+	@Shadow
+	abstract EntityType<?> getType();
+
 	/**
 	 * Cancels some invulnerabilities conferred by items
+	 * 
+	 * Adds invulnerability to nonliving entities for key explosions
 	 */
 	@Inject(at = @At("HEAD"), method = "isInvulnerableTo", cancellable = true)
 	private void checkInvulnerabilities(DamageSource source, CallbackInfoReturnable<Boolean> cir) {
@@ -33,6 +43,9 @@ public class EntityMixin {
 			} else if (CrimsonPendantItem.onDamage(self, source)) {
 				cir.setReturnValue(true);
 			}
+		}
+		if (source.is(BotaniaDamageTypes.KEY_EXPLOSION) && this.getType().is(BotaniaTags.Entities.KEY_IMMUNE)) {
+			cir.setReturnValue(true);
 		}
 	}
 

--- a/Xplat/src/main/resources/assets/botania/lang/en_us.json
+++ b/Xplat/src/main/resources/assets/botania/lang/en_us.json
@@ -378,7 +378,8 @@
   "item.botania.dice.poem2": "The hidden laws of a probable outcome,",
   "item.botania.dice.poem3": "The numbers lead a dance.",
 
-  "death.attack.botania.relic": "%s was punished for using a relic that isn't theirs",
+  "death.attack.botania-relic": "%s was punished for using a relic that isn't theirs",
+  "death.attack.botania.key_explosion": "%2$s drowned %1$s in treasure",
 
   "entity.botania.mana_burst": "Mana Burst",
   "entity.botania.pixie": "Pixie",

--- a/Xplat/src/main/resources/data/botania/damage_type/key_explosion.json
+++ b/Xplat/src/main/resources/data/botania/damage_type/key_explosion.json
@@ -1,0 +1,5 @@
+{
+    "exhaustion": 0.1,
+    "message_id": "botania.key_explosion",
+    "scaling": "always"
+  }

--- a/web/changelog.md
+++ b/web/changelog.md
@@ -20,6 +20,7 @@ and start a new "Upcoming" section.
 
 * Port to 1.19.4
 * Add: Manufactory Halo shows active status in its icon (Wormbo)
+* Change: Key of the King's Law no longer hurts items or most other nonliving entities
 * Fix: Ender Air emission not being mentioned in Pure Daisy entry (Wormbo)
 
 


### PR DESCRIPTION
Data gen has not been run on this PR.  Also includes a new custom death message for the key.