### PR TITLE
Fix flower rendering crash

### DIFF
--- a/Forge/src/main/java/vazkii/botania/forge/client/ForgeFloatingFlowerModel.java
+++ b/Forge/src/main/java/vazkii/botania/forge/client/ForgeFloatingFlowerModel.java
@@ -169,7 +169,7 @@ public class ForgeFloatingFlowerModel implements IUnbakedGeometry<ForgeFloatingF
 		@NotNull
 		@Override
 		public List<BakedModel> getRenderPasses(@NotNull ItemStack stack, boolean fabulous) {
-			return List.of(flower, islands.get(FloatingFlower.IslandType.GRASS));
+			return List.of(flower);
 		}
 
 		@NotNull


### PR DESCRIPTION
The first time a functional/generating flower item entity is rendered in the world, it will cause a crash because islands doesn't contain a value for FloatingFlower.IslandType.GRASS. I don't know what the "correct" fix is, but this stops the game from crashing