### PR TITLE
Update Item matching to fix corporea blocks.

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/helper/ItemNBTHelper.java
+++ b/Xplat/src/main/java/vazkii/botania/common/helper/ItemNBTHelper.java
@@ -193,7 +193,7 @@ public final class ItemNBTHelper {
 				return ItemStack.matches(duplicateAndClearMana(stack1), duplicateAndClearMana(stack2));
 			}
 		}
-		return ItemStack.matches(stack1, stack2);
+		return ItemStack.isSameItemSameTags(stack1, stack2);
 	}
 
 	/**


### PR DESCRIPTION
ItemStack.matches() will return false if the two item stacks don't have the same number of items, which breaks corporea blocks. ItemStack.isSameItemSameTags() will check the tags only.