### PR TITLE
[1.20.x] Make `EntityHelper#syncItem` work without setting item to empty

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/helper/EntityHelper.java
+++ b/Xplat/src/main/java/vazkii/botania/common/helper/EntityHelper.java
@@ -16,13 +16,10 @@ public class EntityHelper {
 	 * Forces an item entity to resync its item to the client.
 	 *
 	 * Entity data only resyncs when the old/new values are not Object.equals().
-	 * Since stacks do not implement equals, and we're not changing the actual stack object,
-	 * the old/new values are == and thus the game doesn't resync.
-	 * We have to set a dummy value then set it back to tell the game to resync.
+	 * We have to set it as a new instance of the itemstack to tell the game to resync.
 	 */
 	public static void syncItem(ItemEntity entity) {
-		var save = entity.getItem();
-		entity.setItem(ItemStack.EMPTY);
+		var save = entity.getItem().copy();
 		entity.setItem(save);
 	}
 }


### PR DESCRIPTION
Hello there, 

The current behavior of `EntityHelper#syncItem` could create mod conflict with the mod that hooked on `ItemEntity#setItem`.
This can be done by setting it to a copy of the stack as well.

Similar behavior can be found in `ItemEntity#merge(ItemStack, ItemStack, int)`.