### PR TITLE
Fix assignment wtih Charms

### DIFF
--- a/Fabric/src/generated/resources/data/trinkets/tags/items/chest/necklace.json
+++ b/Fabric/src/generated/resources/data/trinkets/tags/items/chest/necklace.json
@@ -3,8 +3,6 @@
   "values": [
     "botania:blood_pendant",
     "botania:cloud_pendant",
-    "botania:diva_charm",
-    "botania:goddess_charm",
     "botania:ice_pendant",
     "botania:lava_pendant",
     "botania:super_cloud_pendant",

--- a/Fabric/src/generated/resources/data/trinkets/tags/items/hand/charm.json
+++ b/Fabric/src/generated/resources/data/trinkets/tags/items/hand/charm.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "botania:diva_charm",
+    "botania:goddess_charm"
+  ]
+}

--- a/Fabric/src/main/resources/data/trinkets/entities/botania.json
+++ b/Fabric/src/main/resources/data/trinkets/entities/botania.json
@@ -9,6 +9,7 @@
     "head/face",
     "head/hat",
     "legs/belt",
-    "offhand/ring"
+    "offhand/ring",
+    "hand/charm"
   ]
 }


### PR DESCRIPTION
Corrects a slight error wtih charms being put in the necklace slot when it shouldn't (on the basis that curio's have their own slot for charms)

makes it close to "parallel" features present in Curios

- Creates a Charm slot located in the main hand section
- Created a tag under hand/charm
- Migrate Diva Charm and Goddess Charm from necklace tag to charm tag