### PR TITLE
Config for agricarnation white list

### DIFF
--- a/Fabric/src/main/java/vazkii/botania/fabric/FiberBotaniaConfig.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/FiberBotaniaConfig.java
@@ -275,6 +275,7 @@ public final class FiberBotaniaConfig {
 		public final PropertyMirror<Integer> gogIslandScaleMultiplier = PropertyMirror.create(INTEGER);
 		public final PropertyMirror<List<String>> rannuncarpusItemBlacklist = PropertyMirror.create(ConfigTypes.makeList(STRING));
 		public final PropertyMirror<List<String>> rannuncarpusModBlacklist = PropertyMirror.create(ConfigTypes.makeList(STRING));
+		public final PropertyMirror<List<String>> agricarnationWhitelist = PropertyMirror.create(ConfigTypes.makeList(STRING));
 
 		public ConfigTree configure(ConfigTreeBuilder builder) {
 			builder.fork("blockBreakingParticles")
@@ -346,7 +347,11 @@ public final class FiberBotaniaConfig {
 					.beginValue("rannuncarpusModBlacklist", ConfigTypes.makeList(STRING), Collections.singletonList("storagedrawers"))
 					.withComment("List of mod names for rannuncarpuses to ignore.\n" +
 							"Ignores Storage Drawers by default due to crashes with placing drawer blocks without player involvement.")
-					.finishValue(rannuncarpusModBlacklist::mirror);
+					.finishValue(rannuncarpusModBlacklist::mirror)
+
+					.beginValue("agricarnationWhitelist", ConfigTypes.makeList(STRING), Collections.emptyList())
+					.withComment("List of item registry names that will be speeded up growth by agricarnations.")
+					.finishValue(agricarnationWhitelist::mirror);
 
 			return builder.build();
 		}
@@ -424,6 +429,11 @@ public final class FiberBotaniaConfig {
 		@Override
 		public List<String> rannuncarpusModBlacklist() {
 			return rannuncarpusModBlacklist.getValue();
+		}
+
+		@Override
+		public List<String> agricarnationWhitelist() {
+			return agricarnationWhitelist.getValue();
 		}
 	}
 

--- a/Forge/src/main/java/vazkii/botania/forge/ForgeBotaniaConfig.java
+++ b/Forge/src/main/java/vazkii/botania/forge/ForgeBotaniaConfig.java
@@ -232,6 +232,8 @@ public final class ForgeBotaniaConfig {
 		public final ForgeConfigSpec.ConfigValue<List<? extends String>> rannuncarpusItemBlacklist;
 		public final ForgeConfigSpec.ConfigValue<List<? extends String>> rannuncarpusModBlacklist;
 
+		public final ForgeConfigSpec.ConfigValue<List<? extends String>> agricarnationWhitelist;
+
 		public Common(ForgeConfigSpec.Builder builder) {
 			builder.push("blockBreakingParticles");
 			blockBreakParticles = builder
@@ -302,6 +304,9 @@ public final class ForgeBotaniaConfig {
 					.comment("List of mod names for rannuncarpuses to ignore.\n" +
 							"Ignores Storage Drawers by default due to crashes with placing drawer blocks without player involvement.")
 					.defineList("rannuncarpus.modBlacklist", Collections.singletonList("storagedrawers"), o -> o instanceof String s && ResourceLocation.tryParse(s + ":test") != null);
+			agricarnationWhitelist = builder
+					.comment("List of item registry names that will be speeded up growth by agricarnations.")
+					.defineList("argicarnation.whiteList", Collections.emptyList(), o -> o instanceof String s && ResourceLocation.tryParse(s) != null);
 		}
 
 		@Override
@@ -379,6 +384,12 @@ public final class ForgeBotaniaConfig {
 		@Override
 		public List<String> rannuncarpusModBlacklist() {
 			return (List<String>) rannuncarpusModBlacklist.get();
+		}
+
+		@SuppressWarnings("unchecked") // NightConfig's types are weird
+		@Override
+		public List<String> agricarnationWhitelist() {
+			return (List<String>) agricarnationWhitelist.get();
 		}
 	}
 

--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/AgricarnationBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/AgricarnationBlockEntity.java
@@ -90,8 +90,9 @@ public class AgricarnationBlockEntity extends FunctionalFlowerBlockEntity {
 		Block block = state.getBlock();
 
 		ResourceLocation id = BuiltInRegistries.BLOCK.getKey(block);
-		if (BotaniaConfig.common().agricarnationWhitelist().contains(id.toString()))
+		if (BotaniaConfig.common().agricarnationWhitelist().contains(id.toString())) {
 			return !(block instanceof BonemealableBlock mealable) || mealable.isValidBonemealTarget(getLevel(), pos, state, getLevel().isClientSide);
+		}
 
 		// Spreads when ticked
 		if (block instanceof SpreadingSnowyDirtBlock) {

--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/AgricarnationBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/AgricarnationBlockEntity.java
@@ -9,6 +9,8 @@
 package vazkii.botania.common.block.flower.functional;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.level.block.*;
@@ -86,6 +88,10 @@ public class AgricarnationBlockEntity extends FunctionalFlowerBlockEntity {
 	private boolean isPlant(BlockPos pos) {
 		BlockState state = getLevel().getBlockState(pos);
 		Block block = state.getBlock();
+
+		ResourceLocation id = BuiltInRegistries.BLOCK.getKey(block);
+		if (BotaniaConfig.common().agricarnationWhitelist().contains(id.toString()))
+			return true;
 
 		// Spreads when ticked
 		if (block instanceof SpreadingSnowyDirtBlock) {

--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/AgricarnationBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/AgricarnationBlockEntity.java
@@ -91,7 +91,7 @@ public class AgricarnationBlockEntity extends FunctionalFlowerBlockEntity {
 
 		ResourceLocation id = BuiltInRegistries.BLOCK.getKey(block);
 		if (BotaniaConfig.common().agricarnationWhitelist().contains(id.toString()))
-			return true;
+			return !(block instanceof BonemealableBlock mealable) || mealable.isValidBonemealTarget(getLevel(), pos, state, getLevel().isClientSide);
 
 		// Spreads when ticked
 		if (block instanceof SpreadingSnowyDirtBlock) {

--- a/Xplat/src/main/java/vazkii/botania/test/DelegatingConfigAccess.java
+++ b/Xplat/src/main/java/vazkii/botania/test/DelegatingConfigAccess.java
@@ -95,5 +95,7 @@ public class DelegatingConfigAccess implements BotaniaConfig.ConfigAccess {
 	}
 
 	@Override
-	public List<String> agricarnationWhitelist() { return inner.agricarnationWhitelist(); }
+	public List<String> agricarnationWhitelist() {
+		return inner.agricarnationWhitelist();
+	}
 }

--- a/Xplat/src/main/java/vazkii/botania/test/DelegatingConfigAccess.java
+++ b/Xplat/src/main/java/vazkii/botania/test/DelegatingConfigAccess.java
@@ -93,4 +93,7 @@ public class DelegatingConfigAccess implements BotaniaConfig.ConfigAccess {
 	public List<String> rannuncarpusModBlacklist() {
 		return inner.rannuncarpusModBlacklist();
 	}
+
+	@Override
+	public List<String> agricarnationWhitelist() { return inner.agricarnationWhitelist(); }
 }

--- a/Xplat/src/main/java/vazkii/botania/xplat/BotaniaConfig.java
+++ b/Xplat/src/main/java/vazkii/botania/xplat/BotaniaConfig.java
@@ -22,6 +22,7 @@ public class BotaniaConfig {
 		int gogIslandScaleMultiplier();
 		List<String> rannuncarpusItemBlacklist();
 		List<String> rannuncarpusModBlacklist();
+		List<String> agricarnationWhitelist();
 	}
 
 	public interface ClientConfigAccess {


### PR DESCRIPTION
Add config white list for agricarnation, to solve issues like "why agricarnations don't work on something" (such as #3815).

(although we can't judge which block is actually "a crop", players or modpack authors can control it by such a config)