### PR TITLE
1.20 adding charms in charm slots (Trinkets "fix")

### DIFF
--- a/Fabric/src/generated/resources/.cache/5e449fe289648869bd1f4d4d99715c8b4e0c057d
+++ b/Fabric/src/generated/resources/.cache/5e449fe289648869bd1f4d4d99715c8b4e0c057d
@@ -11,7 +11,8 @@ c3d9bfa84d88ef5deea5ad1f9b37fafb31297dad data/c/tags/items/wooden_chests.json
 94f96c69b63e660269e97982b78d7e6f54374c08 data/modern_industrialization/tags/items/replicator_blacklist.json
 bb7e6831696137af69ce475bbf164dd0cd8babf3 data/trinkets/tags/items/all.json
 eea867f5a1dcf993821e804195af53f5789ce613 data/trinkets/tags/items/chest/cape.json
-97a18698d3d4e04638d4787a638e33b77b450f25 data/trinkets/tags/items/chest/necklace.json
+20e51fa1c09698356074d3b37a61e3f8cb5eb8ff data/trinkets/tags/items/chest/necklace.json
+378361e248d598a38b7dfcc70a91e4a73898e129 data/trinkets/tags/items/hand/charm.json
 256e381daa579a2e6c23cc0897ac161120b2d936 data/trinkets/tags/items/hand/ring.json
 b1f83cb846b4c3d1578aba6ed515b5ad08aaa126 data/trinkets/tags/items/head/face.json
 bf5357b621fdcc974b60e76c82ec467fc0023268 data/trinkets/tags/items/head/hat.json

--- a/Fabric/src/generated/resources/data/trinkets/tags/items/chest/necklace.json
+++ b/Fabric/src/generated/resources/data/trinkets/tags/items/chest/necklace.json
@@ -3,8 +3,6 @@
   "values": [
     "botania:blood_pendant",
     "botania:cloud_pendant",
-    "botania:diva_charm",
-    "botania:goddess_charm",
     "botania:ice_pendant",
     "botania:lava_pendant",
     "botania:super_cloud_pendant",

--- a/Fabric/src/generated/resources/data/trinkets/tags/items/hand/charm.json
+++ b/Fabric/src/generated/resources/data/trinkets/tags/items/hand/charm.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "botania:diva_charm",
+    "botania:goddess_charm"
+  ]
+}

--- a/Fabric/src/main/java/vazkii/botania/fabric/data/FabricItemTagProvider.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/data/FabricItemTagProvider.java
@@ -70,8 +70,6 @@ public class FabricItemTagProvider extends ItemTagProvider {
 		this.tag(accessory("chest/necklace")).add(
 				bloodPendant,
 				cloudPendant,
-				divaCharm,
-				goddessCharm,
 				icePendant,
 				lavaPendant,
 				superCloudPendant,
@@ -97,6 +95,10 @@ public class FabricItemTagProvider extends ItemTagProvider {
 		};
 		this.tag(accessory("hand/ring")).add(rings);
 		this.tag(accessory("offhand/ring")).add(rings);
+		this.tag(accessory("hand/charm")).add(
+				divaCharm,
+				goddessCharm
+		);
 		this.tag(accessory("head/face")).add(
 				itemFinder,
 				monocle,

--- a/Fabric/src/main/resources/data/trinkets/entities/botania.json
+++ b/Fabric/src/main/resources/data/trinkets/entities/botania.json
@@ -6,6 +6,7 @@
     "chest/cape",
     "chest/necklace",
     "hand/ring",
+    "hand/charm",
     "head/face",
     "head/hat",
     "legs/belt",

--- a/Fabric/src/main/resources/data/trinkets/slots/hand/charm.json
+++ b/Fabric/src/main/resources/data/trinkets/slots/hand/charm.json
@@ -1,0 +1,3 @@
+{
+  "icon": "trinkets:gui/slots/charm"
+}


### PR DESCRIPTION
Add hand/charm and moved 	``divaCharm`` and ``goddessCharm`` to section (hopefuly I did this right)

Creates a new charm slot in the mainland section 

@williewillus NOTE: needs to be run like you said; I'm still fairly new to all of these things so I'm not sure how to go about running it. 

I also want to give the trinket case the needed trinket compatibility since it is missing as Curios has it but it is outside of my ability to implement such

Hopefully this will generate the other files as needed