### PR TITLE
Document fractional radius and sphere mode for Worldshaper's Sextant

### DIFF
--- a/Xplat/src/main/resources/assets/botania/lang/en_us.json
+++ b/Xplat/src/main/resources/assets/botania/lang/en_us.json
@@ -2910,7 +2910,7 @@
   "botania.page.sextant0": "In a world of cubes, the secrets of creating circles is a lost art coveted by many-- so much so, in fact, that some to turn to the unholy act of \"tabbing out\" to learn the proper procedures.$(p)The $(item)Worldshaper's Sextant$(0), however, provides a ready alternative to such an act. ",
   "botania.page.sextant1": "To use the item, simply right-click and hold at a block to choose a circle's center, and look around to choose its radius; a blue circle will appear in the world as a preview of the circle's shape. Upon release of the sextant, a mirage of $(item)Cobblestone$(0) blocks will appear as a building guide.$(p)Sneak-right clicking the sextant will remove the circle.",
   "botania.page.sextant2": "You sketch a circle, filling you with determination",
-  "botania.page.sextant3": "There are usually multiple ways to draw a blocky circle touching the inside of any given square. By snapping to any point on the horizontal block grid from the starting point, the sextant allows experimenting with different shapes for the same general size.$(p)And if two dimensions are not enough, sneak-right clicking while no shape is displayed switches the shape mode.",
+  "botania.page.sextant_modes": "There are usually multiple ways to draw a blocky circle touching the inside of any given square. By snapping to any point on the horizontal block grid from the starting point, the sextant allows experimenting with different shapes for the same general size.$(p)And if two dimensions are not enough, sneak-right clicking while no shape is displayed switches the shape mode.",
 
   "botania.entry.astrolabe": "Worldshaper's Astrolabe",
   "botania.tagline.astrolabe": "A tool to help create planes",

--- a/Xplat/src/main/resources/assets/botania/lang/en_us.json
+++ b/Xplat/src/main/resources/assets/botania/lang/en_us.json
@@ -2910,6 +2910,7 @@
   "botania.page.sextant0": "In a world of cubes, the secrets of creating circles is a lost art coveted by many-- so much so, in fact, that some to turn to the unholy act of \"tabbing out\" to learn the proper procedures.$(p)The $(item)Worldshaper's Sextant$(0), however, provides a ready alternative to such an act. ",
   "botania.page.sextant1": "To use the item, simply right-click and hold at a block to choose a circle's center, and look around to choose its radius; a blue circle will appear in the world as a preview of the circle's shape. Upon release of the sextant, a mirage of $(item)Cobblestone$(0) blocks will appear as a building guide.$(p)Sneak-right clicking the sextant will remove the circle.",
   "botania.page.sextant2": "You sketch a circle, filling you with determination",
+  "botania.page.sextant3": "There are usually multiple ways to draw a blocky circle touching the inside of any given square. By snapping to any point on the horizontal block grid from the starting point, the sextant allows experimenting with different shapes for the same general size.$(p)And if two dimensions are not enough, sneak-right clicking while no shape is displayed switches the shape mode.",
 
   "botania.entry.astrolabe": "Worldshaper's Astrolabe",
   "botania.tagline.astrolabe": "A tool to help create planes",

--- a/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/tools/sextant.json
+++ b/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/tools/sextant.json
@@ -13,7 +13,12 @@
       "text": "botania.page.sextant1"
     },
     {
+      "type": "text",
+      "text": "botania.page.sextant3"
+    },
+    {
       "type": "crafting",
+      "title": "item.botania.sextant",
       "text": "botania.page.sextant2",
       "recipe": "botania:sextant"
     }

--- a/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/tools/sextant.json
+++ b/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/tools/sextant.json
@@ -14,7 +14,7 @@
     },
     {
       "type": "text",
-      "text": "botania.page.sextant3"
+      "text": "botania.page.sextant_modes"
     },
     {
       "type": "crafting",


### PR DESCRIPTION
Inserts additional lexicon page mentioning circle shape adjustment option via fractional radius and the way to switch to sphere mode. Also fixes recipe caption showing "(circle mode)" and thus overflowing the page width. (closes #4398)