### PR TITLE
Fixed Mana Enchanter formation and validation assuming opposite rotations

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/ManaEnchanterBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/ManaEnchanterBlockEntity.java
@@ -475,8 +475,8 @@ public class ManaEnchanterBlockEntity extends BotaniaBlockEntity implements Mana
 
 	private static Rotation getAxisRotation(Direction.Axis axis) {
 		return switch (axis) {
-			case X -> Rotation.NONE;
-			case Z -> Rotation.CLOCKWISE_90;
+			case Z -> Rotation.NONE;
+			case X -> Rotation.CLOCKWISE_90;
 			default -> throw new IllegalStateException("Enchanter should only ever be facing in X or Z direction");
 		};
 	}


### PR DESCRIPTION
This fixes a bug introduced in PR #4465 where the validation mapping between an axis and the multiblock rotation were the opposite of the mapping defined when forming the enchanter multiblock.