### PR TITLE
Tie Entropic Lens explosion interaction to TNT drop decay rule

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/item/lens/EntropicLens.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/lens/EntropicLens.java
@@ -32,7 +32,7 @@ public class EntropicLens extends Lens {
 
 			if (!entity.level().isClientSide && !burst.isFake() && !isManaBlock) {
 				entity.level().explode(entity, entity.getX(), entity.getY(), entity.getZ(),
-						burst.getMana() / 50F, Level.ExplosionInteraction.BLOCK);
+						burst.getMana() / 50F, Level.ExplosionInteraction.TNT);
 			}
 			return true;
 		}


### PR DESCRIPTION
This matches the 1.19 behavior with default game rule settings to always drop all blocks broken by the explosion, instead of applying the same drop decay rule as used for exploding beds or end crystals. (fixes #4468)