### PR TITLE
Vitreous Pickaxe silktouches glass panes

### DIFF
--- a/Fabric/src/main/java/vazkii/botania/fabric/xplat/FabricXplatImpl.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/xplat/FabricXplatImpl.java
@@ -552,10 +552,11 @@ public class FabricXplatImpl implements XplatAbstractions {
 	// No standard so we have to check both :wacko:
 	private final TagKey<Block> cGlass = TagKey.create(Registries.BLOCK, new ResourceLocation("c", "glass"));
 	private final TagKey<Block> cGlassBlocks = TagKey.create(Registries.BLOCK, new ResourceLocation("c", "glass_blocks"));
+	private final TagKey<Block> cGlassPanes = TagKey.create(Registries.BLOCK, new ResourceLocation("c", "glass_panes"));
 
 	@Override
 	public boolean isInGlassTag(BlockState state) {
-		return state.is(cGlass) || state.is(cGlassBlocks);
+		return state.is(cGlass) || state.is(cGlassBlocks) || state.is(cGlassPanes);
 	}
 
 	@Override

--- a/Forge/src/main/java/vazkii/botania/forge/xplat/ForgeXplatImpl.java
+++ b/Forge/src/main/java/vazkii/botania/forge/xplat/ForgeXplatImpl.java
@@ -523,7 +523,7 @@ public class ForgeXplatImpl implements XplatAbstractions {
 
 	@Override
 	public boolean isInGlassTag(BlockState state) {
-		return state.is(Tags.Blocks.GLASS);
+		return state.is(Tags.Blocks.GLASS) || state.is(Tags.Blocks.GLASS_PANES);
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #4496 by adding the `c:glass_panes` (Fabric) and `forge:glass_panes` (Forge) block tags to the respective implementations of `XplatAbstractions.isInGlassTag` implementations.