### PR TITLE
Narslimmus nerf for GoG

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/generating/NarslimmusBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/generating/NarslimmusBlockEntity.java
@@ -32,6 +32,8 @@ public class NarslimmusBlockEntity extends GeneratingFlowerBlockEntity {
 
 	private static final int RANGE = 2;
 	private static final int MAX_MANA = manaForSize(4);
+	public static final int MANA_BASE = 1200;
+	public static final int MANA_BASE_GOG = MANA_BASE / 4;
 
 	public NarslimmusBlockEntity(BlockPos pos, BlockState state) {
 		super(BotaniaFlowerBlocks.NARSLIMMUS, pos, state);
@@ -70,7 +72,7 @@ public class NarslimmusBlockEntity extends GeneratingFlowerBlockEntity {
 
 	private static int manaForSize(int size) {
 		size = Math.min(size, 4);
-		return 1200 * (int) Math.pow(2, size);
+		return (XplatAbstractions.INSTANCE.gogLoaded() ? MANA_BASE_GOG : MANA_BASE) * (int) Math.pow(2, size);
 	}
 
 	@Override


### PR DESCRIPTION
Reduces mana output with Garden of Glass to 25% of the usual amount. (implements #4372)