### PR TITLE
Add composting support

### DIFF
--- a/Fabric/src/main/java/vazkii/botania/fabric/FabricCommonInitializer.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/FabricCommonInitializer.java
@@ -30,6 +30,7 @@ import net.fabricmc.fabric.api.networking.v1.EntityTrackingEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
 import net.fabricmc.fabric.api.object.builder.v1.entity.MinecartComparatorLogicRegistry;
+import net.fabricmc.fabric.api.registry.CompostingChanceRegistry;
 import net.fabricmc.fabric.api.registry.FlattenableBlockRegistry;
 import net.fabricmc.fabric.api.registry.FuelRegistry;
 import net.fabricmc.fabric.api.registry.TillableBlockRegistry;
@@ -125,6 +126,7 @@ public class FabricCommonInitializer implements ModInitializer {
 		registryInit();
 
 		PaintableData.init();
+		CompostingData.init(CompostingChanceRegistry.INSTANCE::add);
 		DefaultCorporeaMatchers.init();
 
 		PatchouliAPI.get().registerMultiblock(BuiltInRegistries.BLOCK.getKey(BotaniaBlocks.alfPortal), AlfheimPortalBlockEntity.MULTIBLOCK.get());

--- a/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
+++ b/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
@@ -27,6 +27,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.*;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.ComposterBlock;
 import net.minecraft.world.level.block.entity.AbstractFurnaceBlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -147,6 +148,7 @@ public class ForgeCommonInitializer {
 		evt.enqueueWork(BotaniaBlocks::addDispenserBehaviours);
 		BotaniaBlocks.addAxeStripping();
 		PaintableData.init();
+		CompostingData.init((itemLike, chance) -> ComposterBlock.COMPOSTABLES.putIfAbsent(itemLike.asItem(), (float) chance));
 		DefaultCorporeaMatchers.init();
 
 		PatchouliAPI.get().registerMultiblock(BuiltInRegistries.BLOCK.getKey(BotaniaBlocks.alfPortal), AlfheimPortalBlockEntity.MULTIBLOCK.get());

--- a/Xplat/src/main/java/vazkii/botania/common/handler/CompostingData.java
+++ b/Xplat/src/main/java/vazkii/botania/common/handler/CompostingData.java
@@ -1,0 +1,31 @@
+package vazkii.botania.common.handler;
+
+import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.level.ItemLike;
+
+import vazkii.botania.common.block.BotaniaBlocks;
+import vazkii.botania.common.item.BotaniaItems;
+
+import java.util.function.BiConsumer;
+
+public class CompostingData {
+	public static void init(BiConsumer<ItemLike, Float> registrationMethod) {
+		// common vanilla composting chances:
+		final float chanceLowest = 0.3f;
+		final float chanceLow = 0.5f;
+		final float chanceMid = 0.65f;
+		final float chanceHigh = 0.85f;
+		// unused here: final float chanceHighest = 1.0f;
+
+		// see https://github.com/VazkiiMods/Botania/issues/4263#issuecomment-1529130978
+		for (final var dyeColor : DyeColor.values()) {
+			registrationMethod.accept(BotaniaItems.getPetal(dyeColor), chanceLowest);
+			registrationMethod.accept(BotaniaBlocks.getPetalBlock(dyeColor), chanceLow);
+			registrationMethod.accept(BotaniaBlocks.getFlower(dyeColor), chanceMid);
+			registrationMethod.accept(BotaniaBlocks.getDoubleFlower(dyeColor), chanceMid);
+			registrationMethod.accept(BotaniaBlocks.getMushroom(dyeColor), chanceMid);
+		}
+
+		registrationMethod.accept(BotaniaBlocks.cellBlock, chanceHigh);
+	}
+}


### PR DESCRIPTION
Fixes #4263 by adding composter support for mystical flowers (small and tall), petals, petal blocks, shimmering mushrooms and cellular blocks, as per my comment on that issue.