### PR TITLE
Improve rotation support for various Botania blocks

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/FelPumpkinBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/FelPumpkinBlock.java
@@ -19,9 +19,13 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.ServerLevelAccessor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+
+import org.jetbrains.annotations.NotNull;
 
 import vazkii.botania.mixin.MobAccessor;
 
@@ -62,4 +66,15 @@ public class FelPumpkinBlock extends BotaniaBlock {
 		return defaultBlockState().setValue(BlockStateProperties.HORIZONTAL_FACING, context.getHorizontalDirection().getOpposite());
 	}
 
+	@NotNull
+	@Override
+	public BlockState mirror(@NotNull BlockState state, Mirror mirror) {
+		return state.setValue(BlockStateProperties.HORIZONTAL_FACING, mirror.mirror(state.getValue(BlockStateProperties.HORIZONTAL_FACING)));
+	}
+
+	@NotNull
+	@Override
+	public BlockState rotate(@NotNull BlockState state, Rotation rot) {
+		return state.setValue(BlockStateProperties.HORIZONTAL_FACING, rot.rotate(state.getValue(BlockStateProperties.HORIZONTAL_FACING)));
+	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/block/IncensePlateBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/IncensePlateBlock.java
@@ -22,6 +22,8 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -89,6 +91,18 @@ public class IncensePlateBlock extends BotaniaWaterloggedBlock implements Entity
 	@Override
 	public BlockState getStateForPlacement(BlockPlaceContext context) {
 		return super.getStateForPlacement(context).setValue(BlockStateProperties.HORIZONTAL_FACING, context.getHorizontalDirection().getOpposite());
+	}
+
+	@NotNull
+	@Override
+	public BlockState mirror(@NotNull BlockState state, Mirror mirror) {
+		return state.setValue(BlockStateProperties.HORIZONTAL_FACING, mirror.mirror(state.getValue(BlockStateProperties.HORIZONTAL_FACING)));
+	}
+
+	@NotNull
+	@Override
+	public BlockState rotate(@NotNull BlockState state, Rotation rot) {
+		return state.setValue(BlockStateProperties.HORIZONTAL_FACING, rot.rotate(state.getValue(BlockStateProperties.HORIZONTAL_FACING)));
 	}
 
 	@Override

--- a/Xplat/src/main/java/vazkii/botania/common/block/decor/TinyPotatoBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/decor/TinyPotatoBlock.java
@@ -22,9 +22,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.EntityBlock;
-import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -113,6 +111,18 @@ public class TinyPotatoBlock extends BotaniaWaterloggedBlock implements EntityBl
 	@Override
 	public BlockState getStateForPlacement(BlockPlaceContext ctx) {
 		return super.getStateForPlacement(ctx).setValue(BlockStateProperties.HORIZONTAL_FACING, ctx.getHorizontalDirection().getOpposite());
+	}
+
+	@NotNull
+	@Override
+	public BlockState mirror(@NotNull BlockState state, Mirror mirror) {
+		return state.setValue(BlockStateProperties.HORIZONTAL_FACING, mirror.mirror(state.getValue(BlockStateProperties.HORIZONTAL_FACING)));
+	}
+
+	@NotNull
+	@Override
+	public BlockState rotate(@NotNull BlockState state, Rotation rot) {
+		return state.setValue(BlockStateProperties.HORIZONTAL_FACING, rot.rotate(state.getValue(BlockStateProperties.HORIZONTAL_FACING)));
 	}
 
 	@Override

--- a/Xplat/src/main/java/vazkii/botania/common/block/mana/BellowsBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/mana/BellowsBlock.java
@@ -16,9 +16,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.EntityBlock;
-import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -62,6 +60,18 @@ public class BellowsBlock extends BotaniaBlock implements EntityBlock {
 	@Override
 	public BlockState getStateForPlacement(BlockPlaceContext context) {
 		return super.getStateForPlacement(context).setValue(BlockStateProperties.HORIZONTAL_FACING, context.getHorizontalDirection());
+	}
+
+	@NotNull
+	@Override
+	public BlockState mirror(@NotNull BlockState state, Mirror mirror) {
+		return state.setValue(BlockStateProperties.HORIZONTAL_FACING, mirror.mirror(state.getValue(BlockStateProperties.HORIZONTAL_FACING)));
+	}
+
+	@NotNull
+	@Override
+	public BlockState rotate(@NotNull BlockState state, Rotation rot) {
+		return state.setValue(BlockStateProperties.HORIZONTAL_FACING, rot.rotate(state.getValue(BlockStateProperties.HORIZONTAL_FACING)));
 	}
 
 	@Override

--- a/Xplat/src/main/java/vazkii/botania/common/block/mana/ManaPumpBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/mana/ManaPumpBlock.java
@@ -16,6 +16,8 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -52,6 +54,18 @@ public class ManaPumpBlock extends BotaniaWaterloggedBlock implements EntityBloc
 	@Override
 	public BlockState getStateForPlacement(BlockPlaceContext context) {
 		return super.getStateForPlacement(context).setValue(BlockStateProperties.HORIZONTAL_FACING, context.getHorizontalDirection().getOpposite());
+	}
+
+	@NotNull
+	@Override
+	public BlockState mirror(@NotNull BlockState state, Mirror mirror) {
+		return state.setValue(BlockStateProperties.HORIZONTAL_FACING, mirror.mirror(state.getValue(BlockStateProperties.HORIZONTAL_FACING)));
+	}
+
+	@NotNull
+	@Override
+	public BlockState rotate(@NotNull BlockState state, Rotation rot) {
+		return state.setValue(BlockStateProperties.HORIZONTAL_FACING, rot.rotate(state.getValue(BlockStateProperties.HORIZONTAL_FACING)));
 	}
 
 	@NotNull


### PR DESCRIPTION
Adds support for structure block rotation and mirroring to Manatide Bellows, Fel Pumpkin, Incense Plate, Mana Pump, and Tiny Potato blocks. This also fixes #4201 by allowing the Wand of the Forest to rotate these blocks when clicking their sides.