### PR TITLE
Botania Shader Compatibility for Particles

### DIFF
--- a/Forge/src/main/java/vazkii/botania/forge/ForgeBotaniaConfig.java
+++ b/Forge/src/main/java/vazkii/botania/forge/ForgeBotaniaConfig.java
@@ -15,7 +15,9 @@ import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.config.ModConfigEvent;
+
 import org.apache.commons.lang3.tuple.Pair;
+
 import vazkii.botania.common.lib.LibMisc;
 import vazkii.botania.xplat.BotaniaConfig;
 import vazkii.botania.xplat.XplatAbstractions;

--- a/Forge/src/main/java/vazkii/botania/forge/ForgeBotaniaConfig.java
+++ b/Forge/src/main/java/vazkii/botania/forge/ForgeBotaniaConfig.java
@@ -15,9 +15,7 @@ import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.config.ModConfigEvent;
-
 import org.apache.commons.lang3.tuple.Pair;
-
 import vazkii.botania.common.lib.LibMisc;
 import vazkii.botania.xplat.BotaniaConfig;
 import vazkii.botania.xplat.XplatAbstractions;
@@ -52,7 +50,7 @@ public final class ForgeBotaniaConfig {
 		public Client(ForgeConfigSpec.Builder builder) {
 			builder.push("rendering");
 			useShaders = builder
-					.comment("Set this to false to disable the use of shaders for some of the mod's renders. (Requires game restart)")
+					.comment("Set this to false to disable the use of shaders for some of the mod's renders and render translucent particles as opaque, for shader compatibility with some shaders which implement a deferred lighting pass. (Requires game restart, and enabling without shaders may impact aesthetics)")
 					.define("shaders", true);
 			boundBlockWireframe = builder
 					.comment("Set this to false to disable the wireframe when looking a block bound to something (spreaders, flowers, etc).")

--- a/Xplat/src/main/java/vazkii/botania/client/fx/FXSparkle.java
+++ b/Xplat/src/main/java/vazkii/botania/client/fx/FXSparkle.java
@@ -13,23 +13,22 @@ import com.mojang.blaze3d.vertex.BufferBuilder;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.Tesselator;
 import com.mojang.blaze3d.vertex.VertexFormat;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.client.particle.SpriteSet;
 import net.minecraft.client.particle.TextureSheetParticle;
+import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.phys.Vec3;
-
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.opengl.GL11;
-
 import vazkii.botania.client.core.helper.CoreShaders;
+import vazkii.botania.xplat.BotaniaConfig;
 import vazkii.botania.xplat.ClientXplatAbstractions;
 
 public class FXSparkle extends TextureSheetParticle {
@@ -156,13 +155,26 @@ public class FXSparkle extends TextureSheetParticle {
 	private static void beginRenderCommon(BufferBuilder buffer, TextureManager textureManager) {
 		Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
 		RenderSystem.enableDepthTest();
-		RenderSystem.depthMask(false);
-		RenderSystem.enableBlend();
-		RenderSystem.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
+
+		if(!BotaniaConfig.client().useShaders()) { //Shader compatibility mode enabled
+			RenderSystem.disableBlend();
+			RenderSystem.depthMask(true);
+			RenderSystem.setShader(GameRenderer::getParticleShader);
+		}
+		else { //Shader compatibility mode disabled
+			RenderSystem.depthMask(false);
+			RenderSystem.enableBlend();
+			RenderSystem.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
+			RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 0.7f);
+		}
+
 		RenderSystem.setShaderTexture(0, TextureAtlas.LOCATION_PARTICLES);
 		AbstractTexture tex = textureManager.getTexture(TextureAtlas.LOCATION_PARTICLES);
 		ClientXplatAbstractions.INSTANCE.setFilterSave(tex, true, false);
 		buffer.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.PARTICLE);
+
+
+
 	}
 
 	private static void endRenderCommon() {

--- a/Xplat/src/main/java/vazkii/botania/client/fx/FXSparkle.java
+++ b/Xplat/src/main/java/vazkii/botania/client/fx/FXSparkle.java
@@ -13,6 +13,7 @@ import com.mojang.blaze3d.vertex.BufferBuilder;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.Tesselator;
 import com.mojang.blaze3d.vertex.VertexFormat;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.ParticleRenderType;
@@ -25,8 +26,10 @@ import net.minecraft.client.renderer.texture.TextureManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.phys.Vec3;
+
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.opengl.GL11;
+
 import vazkii.botania.client.core.helper.CoreShaders;
 import vazkii.botania.xplat.BotaniaConfig;
 import vazkii.botania.xplat.ClientXplatAbstractions;
@@ -156,12 +159,11 @@ public class FXSparkle extends TextureSheetParticle {
 		Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
 		RenderSystem.enableDepthTest();
 
-		if(!BotaniaConfig.client().useShaders()) { //Shader compatibility mode enabled
+		if (!BotaniaConfig.client().useShaders()) { //Shader compatibility mode enabled
 			RenderSystem.disableBlend();
 			RenderSystem.depthMask(true);
 			RenderSystem.setShader(GameRenderer::getParticleShader);
-		}
-		else { //Shader compatibility mode disabled
+		} else { //Shader compatibility mode disabled
 			RenderSystem.depthMask(false);
 			RenderSystem.enableBlend();
 			RenderSystem.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
@@ -172,8 +174,6 @@ public class FXSparkle extends TextureSheetParticle {
 		AbstractTexture tex = textureManager.getTexture(TextureAtlas.LOCATION_PARTICLES);
 		ClientXplatAbstractions.INSTANCE.setFilterSave(tex, true, false);
 		buffer.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.PARTICLE);
-
-
 
 	}
 

--- a/Xplat/src/main/java/vazkii/botania/client/fx/FXWisp.java
+++ b/Xplat/src/main/java/vazkii/botania/client/fx/FXWisp.java
@@ -13,6 +13,7 @@ import com.mojang.blaze3d.vertex.BufferBuilder;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.Tesselator;
 import com.mojang.blaze3d.vertex.VertexFormat;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.ParticleRenderType;
@@ -21,8 +22,10 @@ import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureManager;
+
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.opengl.GL11;
+
 import vazkii.botania.xplat.BotaniaConfig;
 import vazkii.botania.xplat.ClientXplatAbstractions;
 
@@ -103,12 +106,11 @@ public class FXWisp extends TextureSheetParticle {
 
 	private static void beginRenderCommon(BufferBuilder bufferBuilder, TextureManager textureManager) {
 		Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
-		if(!BotaniaConfig.client().useShaders()) { //Shader compatibility mode enabled
+		if (!BotaniaConfig.client().useShaders()) { //Shader compatibility mode enabled
 			RenderSystem.disableBlend();
 			RenderSystem.depthMask(true);
 			RenderSystem.setShader(GameRenderer::getParticleShader);
-		}
-		else { //Shader compatibility mode disabled
+		} else { //Shader compatibility mode disabled
 			RenderSystem.depthMask(false);
 			RenderSystem.enableBlend();
 			RenderSystem.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);

--- a/Xplat/src/main/java/vazkii/botania/client/fx/FXWisp.java
+++ b/Xplat/src/main/java/vazkii/botania/client/fx/FXWisp.java
@@ -13,18 +13,17 @@ import com.mojang.blaze3d.vertex.BufferBuilder;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.Tesselator;
 import com.mojang.blaze3d.vertex.VertexFormat;
-
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.client.particle.TextureSheetParticle;
+import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.renderer.texture.TextureManager;
-
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.opengl.GL11;
-
+import vazkii.botania.xplat.BotaniaConfig;
 import vazkii.botania.xplat.ClientXplatAbstractions;
 
 public class FXWisp extends TextureSheetParticle {
@@ -104,14 +103,29 @@ public class FXWisp extends TextureSheetParticle {
 
 	private static void beginRenderCommon(BufferBuilder bufferBuilder, TextureManager textureManager) {
 		Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
-		RenderSystem.depthMask(false);
-		RenderSystem.enableBlend();
-		RenderSystem.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
+		if(!BotaniaConfig.client().useShaders()) { //Shader compatibility mode enabled
+			RenderSystem.disableBlend();
+			RenderSystem.depthMask(true);
+			RenderSystem.setShader(GameRenderer::getParticleShader);
+		}
+		else { //Shader compatibility mode disabled
+			RenderSystem.depthMask(false);
+			RenderSystem.enableBlend();
+			RenderSystem.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
+			RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 0.7f);
+		}
 
 		RenderSystem.setShaderTexture(0, TextureAtlas.LOCATION_PARTICLES);
 		AbstractTexture tex = textureManager.getTexture(TextureAtlas.LOCATION_PARTICLES);
 		ClientXplatAbstractions.INSTANCE.setFilterSave(tex, true, false);
 		bufferBuilder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.PARTICLE);
+
+		//---
+//		RenderSystem.disableBlend();
+//		RenderSystem.depthMask(true);
+//		RenderSystem.setShader(GameRenderer::getParticleShader);
+//		RenderSystem.setShaderTexture(0, TextureAtlas.LOCATION_PARTICLES);
+//		$$0.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.PARTICLE);
 	}
 
 	private static void endRenderCommon() {


### PR DESCRIPTION
When a shader pack uses GLSL deferred rendering, particles with transparency are not rendered correctly. This change (reflected in comments on the config file) will change the rendering method when shaders are set to false in the config, so particles render opaquely (albeit not quite as pretty as they render as is, with shaders they would not have rendered at all, so I feel this change is beneficial but not perfect)