### PR TITLE
Switched to unmapped field name in accesstransformer.cfg

### DIFF
--- a/Forge/src/main/resources/META-INF/accesstransformer.cfg
+++ b/Forge/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,4 +1,4 @@
 public net.minecraft.client.gui.screens.worldselection.WorldPreset <init>(Ljava/lang/String;)V
 public net.minecraft.client.renderer.RenderType$CompositeRenderType
 public net.minecraft.core.registries.BuiltInRegistries$RegistryBootstrap
-private-f net.minecraft.world.level.block.piston.PistonStructureResolver pistonPos
+private-f net.minecraft.world.level.block.piston.PistonStructureResolver f_60410_ # pistonPos

--- a/web/changelog.md
+++ b/web/changelog.md
@@ -18,6 +18,10 @@ and start a new "Upcoming" section.
 
 {% include changelog_header.html version="Upcoming" %}
 
+* Fix: Crash related to PistonStructureResolverMixin on Forge
+
+---
+
 {% include changelog_header.html version="1.20.1-442" %}
 
 * Relaxed forge version requirement to 47.1.3


### PR DESCRIPTION
Fixes #4527: PistonStructureResolverMixin crash on Forge whenever blocks are moved by a piston, force relay, or force lens.