### PR TITLE
Nerf placing down cellular blocks via Create means

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/CellularBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/CellularBlockEntity.java
@@ -101,4 +101,9 @@ public class CellularBlockEntity extends BotaniaBlockEntity {
 		}
 	}
 
+	@Override
+	public boolean onlyOpCanSetNbt() {
+		// targeting Create here, sorry about any instances of https://xkcd.com/1172/
+		return true;
+	}
 }


### PR DESCRIPTION
Block entity NBT is ignored when a cellular block is placed by a non-OP player or by the various automated ways the Create mod has to offer. That means cellular blocks placed in those ways always start at age zero.