### PR TITLE
Account for 1.20 changes in Inventory.contains(ItemStack)

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/decor/ManaFlameBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/decor/ManaFlameBlock.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
 import vazkii.botania.client.fx.WispParticleData;
 import vazkii.botania.common.block.BotaniaWaterloggedBlock;
 import vazkii.botania.common.block.block_entity.ManaFlameBlockEntity;
+import vazkii.botania.common.helper.InventoryHelper;
 import vazkii.botania.common.item.BotaniaItems;
 import vazkii.botania.xplat.XplatAbstractions;
 
@@ -57,7 +58,7 @@ public class ManaFlameBlock extends BotaniaWaterloggedBlock implements EntityBlo
 	public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
 		if (XplatAbstractions.INSTANCE.gogLoaded()) {
 			ItemStack stack = player.getItemInHand(hand);
-			if (!stack.isEmpty() && stack.is(ItemTags.SAPLINGS) && !player.getInventory().contains(new ItemStack(BotaniaItems.lexicon))) {
+			if (!stack.isEmpty() && stack.is(ItemTags.SAPLINGS) && !InventoryHelper.containsType(player.getInventory(), BotaniaItems.lexicon)) {
 				if (!world.isClientSide) {
 					stack.shrink(1);
 					player.getInventory().placeItemBackInInventory(new ItemStack(BotaniaItems.lexicon));

--- a/Xplat/src/main/java/vazkii/botania/common/helper/InventoryHelper.java
+++ b/Xplat/src/main/java/vazkii/botania/common/helper/InventoryHelper.java
@@ -15,9 +15,11 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.Container;
 import net.minecraft.world.WorldlyContainer;
 import net.minecraft.world.entity.SlotAccess;
+import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ClickAction;
 import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.HopperBlockEntity;
 
@@ -27,6 +29,7 @@ import org.jetbrains.annotations.Nullable;
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.common.block.block_entity.SimpleInventoryBlockEntity;
 import vazkii.botania.mixin.HopperBlockEntityAccessor;
+import vazkii.botania.mixin.InventoryAccessor;
 
 import java.util.List;
 import java.util.function.Function;
@@ -179,5 +182,24 @@ public class InventoryHelper {
 			mp.inventoryMenu.broadcastChanges();
 		}
 		return didAny;
+	}
+
+	/**
+	 * Replicates pre-1.20 behavior of {@link Inventory#contains(ItemStack)}, i.e. only matching item type.
+	 * 
+	 * @param inventory The Inventory.
+	 * @param item      The item to match.
+	 * @return {@code true} if the inventory contains an item of the specified type, otherwise {@code false}.
+	 */
+	public static boolean containsType(Inventory inventory, Item item) {
+		for (List<ItemStack> compartment : ((InventoryAccessor) inventory).getCompartments()) {
+			for (ItemStack stack : compartment) {
+				if (stack.is(item)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/bauble/FlugelTiaraItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/bauble/FlugelTiaraItem.java
@@ -43,6 +43,7 @@ import vazkii.botania.client.render.AccessoryRenderRegistry;
 import vazkii.botania.client.render.AccessoryRenderer;
 import vazkii.botania.common.handler.BotaniaSounds;
 import vazkii.botania.common.handler.EquipmentHandler;
+import vazkii.botania.common.helper.InventoryHelper;
 import vazkii.botania.common.helper.ItemNBTHelper;
 import vazkii.botania.common.helper.StringObfuscator;
 import vazkii.botania.common.helper.VecHelper;
@@ -196,7 +197,7 @@ public class FlugelTiaraItem extends BaubleItem implements CustomCreativeTabCont
 		if (!armor.isEmpty()) {
 			int left = ItemNBTHelper.getInt(armor, TAG_TIME_LEFT, MAX_FLY_TIME);
 			boolean flying = ItemNBTHelper.getBoolean(armor, TAG_FLYING, false);
-			return (left > (flying ? 0 : MAX_FLY_TIME / 10) || player.getInventory().contains(new ItemStack(BotaniaItems.flugelEye))) && ManaItemHandler.instance().requestManaExact(armor, player, getCost(armor, left), false);
+			return (left > (flying ? 0 : MAX_FLY_TIME / 10) || InventoryHelper.containsType(player.getInventory(), BotaniaItems.flugelEye)) && ManaItemHandler.instance().requestManaExact(armor, player, getCost(armor, left), false);
 		}
 
 		return false;

--- a/Xplat/src/main/java/vazkii/botania/mixin/InventoryAccessor.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/InventoryAccessor.java
@@ -1,0 +1,16 @@
+package vazkii.botania.mixin;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import java.util.List;
+
+@Mixin(Inventory.class)
+public interface InventoryAccessor {
+	@Accessor
+	List<NonNullList<ItemStack>> getCompartments();
+}

--- a/Xplat/src/main/resources/botania_xplat.mixins.json
+++ b/Xplat/src/main/resources/botania_xplat.mixins.json
@@ -25,6 +25,7 @@
     "FireBlockAccessor",
     "HopperBlockEntityAccessor",
     "HurtByTargetGoalAccessor",
+    "InventoryAccessor",
     "ItemEntityAccessor",
     "ItemEntityMixin",
     "ItemMixin",


### PR DESCRIPTION
Added new helper method to replicate the old behavior and used it where necessary. (i.e. Flügel Tiara check for Eye, and GoG mana flame block; fixes #4530, and partially #4491)