### PR TITLE
Prevent Animated Torch from emitting signal before its block entity is initialized

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/AnimatedTorchBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/AnimatedTorchBlock.java
@@ -10,6 +10,7 @@ package vazkii.botania.common.block;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.LivingEntity;
@@ -71,7 +72,7 @@ public class AnimatedTorchBlock extends BotaniaWaterloggedBlock implements Entit
 	public int getSignal(BlockState blockState, BlockGetter blockAccess, BlockPos pos, Direction side) {
 		AnimatedTorchBlockEntity tile = (AnimatedTorchBlockEntity) blockAccess.getBlockEntity(pos);
 
-		if (tile.rotating) {
+		if (tile.rotating || !tile.directionInitialized) {
 			return 0;
 		}
 
@@ -109,6 +110,11 @@ public class AnimatedTorchBlock extends BotaniaWaterloggedBlock implements Entit
 	public void destroy(LevelAccessor world, BlockPos pos, BlockState state) {
 		// Block entity is already gone so best we can do is just notify everyone
 		world.blockUpdated(pos, this);
+		if (world instanceof ServerLevel level) {
+			for (Direction e : AnimatedTorchBlockEntity.SIDES) {
+				level.updateNeighborsAtExceptFromFacing(pos.relative(e), state.getBlock(), e.getOpposite());
+			}
+		}
 		super.destroy(world, pos, state);
 	}
 


### PR DESCRIPTION
Fixes #4489, where (on Fabric) the torch initially provides power to the south if placed any other direction. The torch now initially does not output a signal until its block entity is initialized, at which point neighbors are updated accordingly.
This also fixes the torch updating too few block when removed (e.g. if it was powering something through a solid block), and unnecessary updates to unaffected blocks when it starts or finishes rotating.