### PR TITLE
Fire "summon entity" trigger for mobs spawned via Botania means

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/FelPumpkinBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/FelPumpkinBlock.java
@@ -8,9 +8,11 @@
  */
 package vazkii.botania.common.block;
 
+import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobSpawnType;
 import net.minecraft.world.entity.monster.Blaze;
@@ -58,6 +60,10 @@ public class FelPumpkinBlock extends BotaniaBlock {
 			((MobAccessor) blaze).setLootTable(LOOT_TABLE);
 			blaze.finalizeSpawn((ServerLevelAccessor) world, world.getCurrentDifficultyAt(pos), MobSpawnType.EVENT, null, null);
 			world.addFreshEntity(blaze);
+
+			for (ServerPlayer player : world.getEntitiesOfClass(ServerPlayer.class, blaze.getBoundingBox().inflate(5.0))) {
+				CriteriaTriggers.SUMMONED_ENTITY.trigger(player, blaze);
+			}
 		}
 	}
 

--- a/Xplat/src/main/java/vazkii/botania/common/entity/GaiaGuardianEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/entity/GaiaGuardianEntity.java
@@ -252,7 +252,8 @@ public class GaiaGuardianEntity extends Mob {
 			e.mobSpawnTicks = MOB_SPAWN_TICKS;
 			e.hardMode = hard;
 
-			int playerCount = e.getPlayersAround().size();
+			List<Player> playersAround = e.getPlayersAround();
+			int playerCount = playersAround.size();
 			e.playerCount = playerCount;
 
 			float healthMultiplier = 1;
@@ -268,6 +269,12 @@ public class GaiaGuardianEntity extends Mob {
 			e.playSound(BotaniaSounds.gaiaSummon, 1F, 1F);
 			e.finalizeSpawn((ServerLevelAccessor) world, world.getCurrentDifficultyAt(e.blockPosition()), MobSpawnType.EVENT, null, null);
 			world.addFreshEntity(e);
+
+			for (Player nearbyPlayer : playersAround) {
+				if (nearbyPlayer instanceof ServerPlayer serverPlayer) {
+					CriteriaTriggers.SUMMONED_ENTITY.trigger(serverPlayer, e);
+				}
+			}
 		}
 
 		return true;


### PR DESCRIPTION
- constructing a fel blaze (for all players within 5 blocks, like for vanilla iron/snow golems)
- starting the gaia fight (for all players considered to be in the fight)

(fixes #4554)