### PR TITLE
Treat Elementium Axe as weapon for durability damage

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ElementiumAxeItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ElementiumAxeItem.java
@@ -11,6 +11,7 @@ package vazkii.botania.common.item.equipment.tool.elementium;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -19,6 +20,8 @@ import net.minecraft.world.item.enchantment.Enchantments;
 import net.minecraft.world.level.storage.loot.LootParams;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+
+import org.jetbrains.annotations.NotNull;
 
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.common.annotations.SoftImplement;
@@ -61,6 +64,14 @@ public class ElementiumAxeItem extends ManasteelAxeItem {
 			return enchantment.category.canEnchant(this);
 		}
 
+	}
+
+	// [VanillaCopy] modified from DiggerItem::hurtEnemy, actually same as SwordItem::hurtEnemy
+	@Override
+	public boolean hurtEnemy(ItemStack stack, @NotNull LivingEntity target, @NotNull LivingEntity attacker) {
+		// only do 1 durability damage, since this is primarily a weapon
+		stack.hurtAndBreak(1, attacker, living -> living.broadcastBreakEvent(EquipmentSlot.MAINHAND));
+		return true;
 	}
 
 }


### PR DESCRIPTION
Fixes #4492 by reducing the durability damage from attacking with an elementium axe from 2 to 1, since it's primarily intended as a weapon.