### PR TITLE
Allow motif flowers for suspicious stew making

### DIFF
--- a/Xplat/src/generated/resources/.cache/5e449fe289648869bd1f4d4d99715c8b4e0c057d
+++ b/Xplat/src/generated/resources/.cache/5e449fe289648869bd1f4d4d99715c8b4e0c057d
@@ -69,7 +69,7 @@ d5f2792b94968c712824b9ab93ba589c15bd1886 data/minecraft/tags/items/rails.json
 8a23702b05296c8af5014d6aa6e9265ded85c7d9 data/minecraft/tags/items/sand.json
 ac11e7f7d9355f0316ce880df9aaea6ee53b3734 data/minecraft/tags/items/shovels.json
 a01e6f58bac0c802977ef45bff0374c7030b2dac data/minecraft/tags/items/slabs.json
-ef6aa45a135e98ddd532aa5d076288280653df82 data/minecraft/tags/items/small_flowers.json
+339480513a866abc2481f318c1deacb1b86e326c data/minecraft/tags/items/small_flowers.json
 201298e855b770d34316738abb0e37a31ebd77b0 data/minecraft/tags/items/stairs.json
 cbf87989430a41a11a5f7c28bcf331b4159887c7 data/minecraft/tags/items/swords.json
 589fa9d68f43847133a9115af36e85e50cf29be7 data/minecraft/tags/items/tall_flowers.json

--- a/Xplat/src/generated/resources/data/minecraft/tags/items/small_flowers.json
+++ b/Xplat/src/generated/resources/data/minecraft/tags/items/small_flowers.json
@@ -2,6 +2,9 @@
   "replace": false,
   "values": [
     "#botania:mystical_flowers",
-    "#botania:special_flowers"
+    "#botania:special_flowers",
+    "botania:daybloom_motif",
+    "botania:nightshade_motif",
+    "botania:hydroangeas_motif"
   ]
 }

--- a/Xplat/src/main/java/vazkii/botania/data/ItemTagProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/data/ItemTagProvider.java
@@ -71,7 +71,8 @@ public class ItemTagProvider extends ItemTagsProvider {
 				.add(BotaniaBlocks.motifDaybloom.asItem(), BotaniaBlocks.motifNightshade.asItem());
 
 		this.tag(ItemTags.TALL_FLOWERS).addTag(BotaniaTags.Items.DOUBLE_MYSTICAL_FLOWERS);
-		this.tag(ItemTags.SMALL_FLOWERS).addTag(BotaniaTags.Items.MYSTICAL_FLOWERS).addTag(BotaniaTags.Items.SPECIAL_FLOWERS);
+		this.tag(ItemTags.SMALL_FLOWERS).addTag(BotaniaTags.Items.MYSTICAL_FLOWERS).addTag(BotaniaTags.Items.SPECIAL_FLOWERS)
+				.add(BotaniaBlocks.motifDaybloom.asItem(), BotaniaBlocks.motifNightshade.asItem(), BotaniaBlocks.motifHydroangeas.asItem());
 
 		this.tag(BotaniaTags.Items.BURST_VIEWERS).add(monocle);
 		this.tag(BotaniaTags.Items.TERRA_PICK_BLACKLIST).add(auraRing, auraRingGreater, terrasteelHelm, spark);


### PR DESCRIPTION
Adds the Daybloom, Nightshade, and Hydroangeas motif flowers to the `#minecraft:small_flowers` tag so they are picked up by the suspicious stew recipe and corresponding brown mooshroom logic.