### PR TITLE
Remove mod priority configuration option for Orechid outputs

### DIFF
--- a/Forge/src/main/java/vazkii/botania/forge/ForgeBotaniaConfig.java
+++ b/Forge/src/main/java/vazkii/botania/forge/ForgeBotaniaConfig.java
@@ -227,8 +227,6 @@ public final class ForgeBotaniaConfig {
 		public final ForgeConfigSpec.BooleanValue gogSpawnWithLexicon;
 		public final ForgeConfigSpec.IntValue gogIslandScaleMultiplier;
 
-		public final ForgeConfigSpec.ConfigValue<List<? extends String>> orechidPriorityMods;
-
 		public final ForgeConfigSpec.ConfigValue<List<? extends String>> rannuncarpusItemBlacklist;
 		public final ForgeConfigSpec.ConfigValue<List<? extends String>> rannuncarpusModBlacklist;
 
@@ -288,13 +286,6 @@ public final class ForgeBotaniaConfig {
 						By default, the scale is 8, putting each island on points separated by 2048 blocks.
 						Values below 4 (1024 block spacing) are not recommended due to Nether portal collisions.""")
 					.defineInRange("gardenOfGlass.islandScaleMultiplier", 8, 1, 512);
-			orechidPriorityMods = builder
-					.comment("""
-						List of modids to prioritize when choosing a random ore from the tag.
-						By default, the chosen ore is randomly picked from all ores in the ore's tag.
-						Ores from mods present on this list will be picked over mods listed lower or not listed at all.
-						Applying changes at runtime requires /reload afterwards.""")
-					.defineList("orechidPriorityMods", Collections.emptyList(), o -> o instanceof String s && ResourceLocation.tryParse(s + ":test") != null);
 			rannuncarpusItemBlacklist = builder
 					.comment("List of item registry names that will be ignored by rannuncarpuses when placing blocks.")
 					.defineList("rannuncarpus.itemBlacklist", Collections.emptyList(), o -> o instanceof String s && ResourceLocation.tryParse(s) != null);

--- a/Xplat/src/main/java/vazkii/botania/common/crafting/TagExcludingStateIngredient.java
+++ b/Xplat/src/main/java/vazkii/botania/common/crafting/TagExcludingStateIngredient.java
@@ -12,7 +12,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
@@ -39,15 +38,6 @@ public class TagExcludingStateIngredient extends TagStateIngredient {
 			return false;
 		}
 		return isNotExcluded(state);
-	}
-
-	@Override
-	public BlockState pick(RandomSource random) {
-		List<Block> blocks = getBlocks();
-		if (blocks.isEmpty()) {
-			return null;
-		}
-		return blocks.get(random.nextInt(blocks.size())).defaultBlockState();
 	}
 
 	private boolean isNotExcluded(BlockState state) {

--- a/Xplat/src/main/java/vazkii/botania/common/crafting/TagStateIngredient.java
+++ b/Xplat/src/main/java/vazkii/botania/common/crafting/TagStateIngredient.java
@@ -49,11 +49,11 @@ public class TagStateIngredient extends BlocksStateIngredient {
 
 	@Override
 	public BlockState pick(RandomSource random) {
-		var values = resolve().toList();
-		if (values.isEmpty()) {
+		var blocks = getBlocks();
+		if (blocks.isEmpty()) {
 			return null;
 		}
-		return values.get(random.nextInt(values.size())).defaultBlockState();
+		return blocks.get(random.nextInt(blocks.size())).defaultBlockState();
 	}
 
 	@Override


### PR DESCRIPTION
~~If the configured list is non-empty, the first namespace ID on the list that is matched to blocks in the potential output tag is used to determine the output. If more than one such block is found, the output is randomized amon those blocks. If none of the namespace IDs matches any output block, the result is picked randomly as if no priority mods were configured.~~

Option is removed to prevent confusion, because pack authors should use data pack recipes to customize the Orechid.