### PR TITLE
Fix Cirrus/Nimbus Amulet miscounting jumps

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/bauble/CirrusAmuletItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/bauble/CirrusAmuletItem.java
@@ -56,6 +56,11 @@ public class CirrusAmuletItem extends BaubleItem {
 				if (playerSp.onGround()) {
 					timesJumped = 0;
 				} else {
+					if (timesJumped == 0) {
+						// regardless how ground contact was lost, count that as first jump
+						timesJumped = 1;
+						jumpDown = true;
+					}
 					if (playerSp.input.jumping) {
 						if (!jumpDown && timesJumped < ((CirrusAmuletItem) stack.getItem()).getMaxAllowedJumps()) {
 							playerSp.jumpFromGround();


### PR DESCRIPTION
This fix prevents the multi-jump amulets from occasionally not counting the player's initial jump from the ground by always assuming that no longer being on the ground means the player must have jumped. (fixes #3939)