### PR TITLE
Add native EMI support for Forge

### DIFF
--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -55,6 +55,7 @@ repositories {
         url = "https://maven.blamejared.com/" // for JEI and Patchouli
     }
     maven {
+        name = "TerraformersMC"
         url = "https://maven.terraformersmc.com/" // for trinkets and emi
     }
     maven {
@@ -111,7 +112,8 @@ dependencies {
 
     modCompileOnly "me.shedaniel:RoughlyEnoughItems-fabric:12.0.625"
 
-    modImplementation("dev.emi:emi-fabric:1.0.4+1.20.1") { transitive = false }
+    modCompileOnly "dev.emi:emi-fabric:1.0.12+${minecraft_version}:api"
+    modLocalRuntime "dev.emi:emi-fabric:1.1.4+${minecraft_version}"
 
     modImplementation "me.zeroeightsix:fiber:0.23.0-2"  
     include "me.zeroeightsix:fiber:0.23.0-2"

--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -62,7 +62,7 @@
       "vazkii.botania.fabric.internal_caps.CCAInternalEntityComponents"
     ],
     "emi": [
-      "vazkii.botania.fabric.integration.emi.BotaniaEmiPlugin"
+      "vazkii.botania.client.integration.emi.BotaniaEmiPlugin"
     ],
     "rei_client": [
       "vazkii.botania.fabric.integration.rei.BotaniaREIPlugin"

--- a/Forge/build.gradle
+++ b/Forge/build.gradle
@@ -39,6 +39,10 @@ repositories {
         url = "https://maven.theillusivec4.top/"
     }
     maven {
+        name = "TerraformersMC"
+        url = "https://maven.terraformersmc.com/" // for emi
+    }
+    maven {
         name = "Unascribed"
         url "https://repo.unascribed.com" // for ears
         content {
@@ -102,6 +106,9 @@ dependencies {
     implementation fg.deobf("vazkii.patchouli:Patchouli:${minecraft_version}-84-FORGE")
     compileOnly fg.deobf("mezz.jei:jei-1.20.1-common-api:15.2.0.27")
     runtimeOnly fg.deobf("mezz.jei:jei-1.20.1-forge:15.2.0.27")
+
+    compileOnly fg.deobf("dev.emi:emi-forge:1.0.12+${minecraft_version}:api")
+    //runtimeOnly fg.deobf("dev.emi:emi-forge:1.1.4+${minecraft_version}")
 
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:5.4.2+1.20.1:api")
     runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:5.4.2+1.20.1")

--- a/Xplat/build.gradle
+++ b/Xplat/build.gradle
@@ -20,6 +20,10 @@ repositories {
         url = "https://maven.blamejared.com/"
     }
     maven {
+        name = "TerraformersMC"
+        url = "https://maven.terraformersmc.com/" // for emi
+    }
+    maven {
         name = "Unascribed"
         url "https://repo.unascribed.com" // for ears
         content {
@@ -40,6 +44,7 @@ dependencies {
     compileOnly "com.unascribed:ears-api:1.4.5"
 
     compileOnly "mezz.jei:jei-1.20.1-common-api:15.2.0.27"
+    compileOnly "dev.emi:emi-xplat-mojmap:1.0.12+${minecraft_version}:api"
 
     // annotationProcessor 'com.blamejared.crafttweaker:Crafttweaker_Annotation_Processors-1.18.2:2.0.0.123'
     // annotationProcessor 'com.blamejared.crafttweaker:CraftTweaker-common-1.18.2:9.1.123'

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/AncientWillEmiRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/AncientWillEmiRecipe.java
@@ -1,4 +1,4 @@
-package vazkii.botania.fabric.integration.emi;
+package vazkii.botania.client.integration.emi;
 
 import dev.emi.emi.api.recipe.EmiPatternCraftingRecipe;
 import dev.emi.emi.api.stack.EmiIngredient;

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/BlendTextureWidget.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/BlendTextureWidget.java
@@ -1,4 +1,4 @@
-package vazkii.botania.fabric.integration.emi;
+package vazkii.botania.client.integration.emi;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/BotaniaEmiPlugin.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/BotaniaEmiPlugin.java
@@ -1,6 +1,7 @@
-package vazkii.botania.fabric.integration.emi;
+package vazkii.botania.client.integration.emi;
 
 import dev.emi.emi.api.EmiApi;
+import dev.emi.emi.api.EmiEntrypoint;
 import dev.emi.emi.api.EmiPlugin;
 import dev.emi.emi.api.EmiRegistry;
 import dev.emi.emi.api.recipe.EmiCraftingRecipe;
@@ -43,6 +44,7 @@ import java.util.stream.StreamSupport;
 
 import static vazkii.botania.common.lib.ResourceLocationHelper.prefix;
 
+@EmiEntrypoint
 public class BotaniaEmiPlugin implements EmiPlugin {
 	private static final Comparator<EmiRecipe> BY_ID = Comparator.comparing(EmiRecipe::getId);
 	private static final Comparator<EmiRecipe> BY_GROUP =

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/BotaniaEmiRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/BotaniaEmiRecipe.java
@@ -1,4 +1,4 @@
-package vazkii.botania.fabric.integration.emi;
+package vazkii.botania.client.integration.emi;
 
 import dev.emi.emi.api.recipe.EmiRecipe;
 import dev.emi.emi.api.recipe.EmiRecipeCategory;

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/BotanicalBreweryEmiRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/BotanicalBreweryEmiRecipe.java
@@ -1,4 +1,4 @@
-package vazkii.botania.fabric.integration.emi;
+package vazkii.botania.client.integration.emi;
 
 import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/CompositeLensEmiRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/CompositeLensEmiRecipe.java
@@ -1,4 +1,4 @@
-package vazkii.botania.fabric.integration.emi;
+package vazkii.botania.client.integration.emi;
 
 import dev.emi.emi.api.recipe.EmiPatternCraftingRecipe;
 import dev.emi.emi.api.stack.EmiIngredient;

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/ElvenTradeEmiRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/ElvenTradeEmiRecipe.java
@@ -1,4 +1,4 @@
-package vazkii.botania.fabric.integration.emi;
+package vazkii.botania.client.integration.emi;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/ManaInfusionEmiRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/ManaInfusionEmiRecipe.java
@@ -1,4 +1,4 @@
-package vazkii.botania.fabric.integration.emi;
+package vazkii.botania.client.integration.emi;
 
 import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/ManaWidget.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/ManaWidget.java
@@ -1,4 +1,4 @@
-package vazkii.botania.fabric.integration.emi;
+package vazkii.botania.client.integration.emi;
 
 import dev.emi.emi.api.widget.Bounds;
 import dev.emi.emi.api.widget.Widget;

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/MarimorphosisEmiRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/MarimorphosisEmiRecipe.java
@@ -1,4 +1,4 @@
-package vazkii.botania.fabric.integration.emi;
+package vazkii.botania.client.integration.emi;
 
 import dev.emi.emi.api.stack.EmiIngredient;
 

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/OrechidEmiRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/OrechidEmiRecipe.java
@@ -1,4 +1,4 @@
-package vazkii.botania.fabric.integration.emi;
+package vazkii.botania.client.integration.emi;
 
 import dev.emi.emi.api.recipe.EmiRecipeCategory;
 import dev.emi.emi.api.stack.EmiIngredient;

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/PetalApothecaryEmiRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/PetalApothecaryEmiRecipe.java
@@ -1,4 +1,4 @@
-package vazkii.botania.fabric.integration.emi;
+package vazkii.botania.client.integration.emi;
 
 import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/PureDaisyEmiRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/PureDaisyEmiRecipe.java
@@ -1,4 +1,4 @@
-package vazkii.botania.fabric.integration.emi;
+package vazkii.botania.client.integration.emi;
 
 import dev.emi.emi.api.recipe.EmiRecipe;
 import dev.emi.emi.api.stack.EmiIngredient;

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/RunicAltarEmiRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/RunicAltarEmiRecipe.java
@@ -1,4 +1,4 @@
-package vazkii.botania.fabric.integration.emi;
+package vazkii.botania.client.integration.emi;
 
 import dev.emi.emi.api.recipe.EmiRecipe;
 import dev.emi.emi.api.stack.EmiIngredient;

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/TerrestrialAgglomerationEmiRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/TerrestrialAgglomerationEmiRecipe.java
@@ -1,4 +1,4 @@
-package vazkii.botania.fabric.integration.emi;
+package vazkii.botania.client.integration.emi;
 
 import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;


### PR DESCRIPTION
- moved EMI plugin classes to XPlat
- bumped compile-only EMI dependencies to version 1.0.12 (that's when "experimental" annotations were removed from some stable APIs)
- bumped local test run EMI versions to 1.1.4 (latest release; only enabled for Fabric by default, JEI stays default for Forge)