### PR TITLE
Use phantom ink instead of managlass to make abstruse platforms invisible

### DIFF
--- a/Fabric/src/main/java/vazkii/botania/fabric/client/FabricPlatformModel.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/client/FabricPlatformModel.java
@@ -15,10 +15,8 @@ import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 
-import vazkii.botania.common.block.BotaniaBlocks;
 import vazkii.botania.common.block.PlatformBlock;
 import vazkii.botania.common.block.block_entity.PlatformBlockEntity;
 

--- a/Fabric/src/main/java/vazkii/botania/fabric/client/FabricPlatformModel.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/client/FabricPlatformModel.java
@@ -15,6 +15,7 @@ import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 
 import vazkii.botania.common.block.BotaniaBlocks;
@@ -50,11 +51,6 @@ public class FabricPlatformModel extends ForwardingBakedModel {
 				// No camo
 				super.emitBlockQuads(blockView, state, pos, randomSupplier, context);
 			} else {
-				// Some people used this to get an invisible block in the past, accommodate that.
-				if (heldState.is(BotaniaBlocks.manaGlass)) {
-					return;
-				}
-
 				BakedModel model = Minecraft.getInstance().getBlockRenderer()
 						.getBlockModelShaper().getBlockModel(heldState);
 				// Steal camo's model

--- a/Forge/src/main/java/vazkii/botania/forge/client/ForgePlatformModel.java
+++ b/Forge/src/main/java/vazkii/botania/forge/client/ForgePlatformModel.java
@@ -8,7 +8,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.client.model.BakedModelWrapper;
 import net.minecraftforge.client.model.data.ModelData;
@@ -17,11 +16,9 @@ import net.minecraftforge.client.model.data.ModelProperty;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import vazkii.botania.common.block.BotaniaBlocks;
 import vazkii.botania.common.block.PlatformBlock;
 import vazkii.botania.common.block.block_entity.PlatformBlockEntity;
 
-import java.util.Collections;
 import java.util.List;
 
 public class ForgePlatformModel extends BakedModelWrapper<BakedModel> {

--- a/Forge/src/main/java/vazkii/botania/forge/client/ForgePlatformModel.java
+++ b/Forge/src/main/java/vazkii/botania/forge/client/ForgePlatformModel.java
@@ -8,6 +8,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.client.model.BakedModelWrapper;
 import net.minecraftforge.client.model.data.ModelData;
@@ -57,11 +58,6 @@ public class ForgePlatformModel extends BakedModelWrapper<BakedModel> {
 			// No camo
 			return super.getQuads(state, side, rand, extraData, renderType);
 		} else {
-			// Some people used this to get an invisible block in the past, accommodate that.
-			if (heldState.is(BotaniaBlocks.manaGlass)) {
-				return Collections.emptyList();
-			}
-
 			BakedModel model = Minecraft.getInstance().getBlockRenderer()
 					.getBlockModelShaper().getBlockModel(heldState);
 			return model.getQuads(heldState, side, rand, ModelData.EMPTY, renderType);

--- a/Xplat/src/main/java/vazkii/botania/common/block/PlatformBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/PlatformBlock.java
@@ -11,7 +11,6 @@ package vazkii.botania.common.block;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
-import net.minecraft.stats.Stats;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
@@ -81,7 +80,7 @@ public class PlatformBlock extends BotaniaBlock implements ManaCollisionGhost, E
 	@Override
 	public VoxelShape getShape(@NotNull BlockState state, @NotNull BlockGetter world, @NotNull BlockPos pos, @NotNull CollisionContext context) {
 		BlockEntity te = world.getBlockEntity(pos);
-		if (te instanceof PlatformBlockEntity platform && platform.getCamoState() != null && !platform.getCamoState().isAir()) {
+		if (te instanceof PlatformBlockEntity platform && platform.getCamoState() != null) {
 			return platform.getCamoState().getShape(world, pos);
 		} else {
 			return super.getShape(state, world, pos, context);
@@ -158,12 +157,11 @@ public class PlatformBlock extends BotaniaBlock implements ManaCollisionGhost, E
 
 				return InteractionResult.sidedSuccess(world.isClientSide());
 			}
-		}
-		else if (!currentStack.isEmpty()
+		} else if (!currentStack.isEmpty()
 				&& currentStack.is(BotaniaItems.phantomInk)
-				&& tile instanceof PlatformBlockEntity camo ) {
+				&& tile instanceof PlatformBlockEntity camo) {
 			if (!world.isClientSide) {
-				camo.setCamoState(Blocks.AIR.defaultBlockState());  //Air is being used as a sentinel value here
+				camo.setCamoState(Blocks.BARRIER.defaultBlockState()); //Barrier block is being used as a sentinel value here
 			}
 
 			return InteractionResult.sidedSuccess(world.isClientSide());

--- a/Xplat/src/main/java/vazkii/botania/common/block/PlatformBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/PlatformBlock.java
@@ -11,6 +11,7 @@ package vazkii.botania.common.block;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
+import net.minecraft.stats.Stats;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
@@ -37,6 +38,7 @@ import org.jetbrains.annotations.Nullable;
 
 import vazkii.botania.api.mana.ManaCollisionGhost;
 import vazkii.botania.common.block.block_entity.PlatformBlockEntity;
+import vazkii.botania.common.item.BotaniaItems;
 
 import java.util.List;
 import java.util.function.BiPredicate;
@@ -79,7 +81,7 @@ public class PlatformBlock extends BotaniaBlock implements ManaCollisionGhost, E
 	@Override
 	public VoxelShape getShape(@NotNull BlockState state, @NotNull BlockGetter world, @NotNull BlockPos pos, @NotNull CollisionContext context) {
 		BlockEntity te = world.getBlockEntity(pos);
-		if (te instanceof PlatformBlockEntity platform && platform.getCamoState() != null) {
+		if (te instanceof PlatformBlockEntity platform && platform.getCamoState() != null && !platform.getCamoState().isAir()) {
 			return platform.getCamoState().getShape(world, pos);
 		} else {
 			return super.getShape(state, world, pos, context);
@@ -156,6 +158,20 @@ public class PlatformBlock extends BotaniaBlock implements ManaCollisionGhost, E
 
 				return InteractionResult.sidedSuccess(world.isClientSide());
 			}
+		}
+		else if (!currentStack.isEmpty()
+				&& currentStack.is(BotaniaItems.phantomInk)
+				&& tile instanceof PlatformBlockEntity camo ) {
+			if (!world.isClientSide) {
+				camo.setCamoState(Blocks.AIR.defaultBlockState());  //Air is being used as a sentinel value here
+
+				player.awardStat(Stats.ITEM_USED.get(BotaniaItems.phantomInk));
+            	if (!player.getAbilities().instabuild) {
+                	currentStack.shrink(1);
+            	}
+			}
+
+			return InteractionResult.sidedSuccess(world.isClientSide());
 		}
 
 		return InteractionResult.PASS;

--- a/Xplat/src/main/java/vazkii/botania/common/block/PlatformBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/PlatformBlock.java
@@ -164,11 +164,6 @@ public class PlatformBlock extends BotaniaBlock implements ManaCollisionGhost, E
 				&& tile instanceof PlatformBlockEntity camo ) {
 			if (!world.isClientSide) {
 				camo.setCamoState(Blocks.AIR.defaultBlockState());  //Air is being used as a sentinel value here
-
-				player.awardStat(Stats.ITEM_USED.get(BotaniaItems.phantomInk));
-            	if (!player.getAbilities().instabuild) {
-                	currentStack.shrink(1);
-            	}
 			}
 
 			return InteractionResult.sidedSuccess(world.isClientSide());

--- a/web/changelog.md
+++ b/web/changelog.md
@@ -39,7 +39,7 @@ and start a new "Upcoming" section.
   * Unlock conditions for slab recombination recipes now require the slab, not the full block
 * Change: Recipe displays for Petal Apothecary and Runic Altar show required reagents (e.g. seeds, livingrock)
 * Change: Recipe display for Terrestrial Agglomeration Plate in EMI looks more like it does on JEI or REI now
-* Change: Phantom ink is now used to hide abstruse and spectral platforms instead of managlass.
+* Change: Phantom ink is now used to hide abstruse and spectral platforms instead of managlass. (zacharybarbanell)
 * Fix: Corporea Crystal Cube and Abstruse/Spectral Platform no longer forget their internal state after unloading
 * Fix: Quick-moving (shift+click) Botania pattern items in the loom UI properly puts them in the pattern slot
 * Fix: Animated Torch powers blocks consistently, and properly updates necessary blocks when placed, rotated, or removed

--- a/web/changelog.md
+++ b/web/changelog.md
@@ -39,6 +39,7 @@ and start a new "Upcoming" section.
   * Unlock conditions for slab recombination recipes now require the slab, not the full block
 * Change: Recipe displays for Petal Apothecary and Runic Altar show required reagents (e.g. seeds, livingrock)
 * Change: Recipe display for Terrestrial Agglomeration Plate in EMI looks more like it does on JEI or REI now
+* Change: Phantom ink is now used to hide abstruse and spectral platforms instead of managlass.
 * Fix: Corporea Crystal Cube and Abstruse/Spectral Platform no longer forget their internal state after unloading
 * Fix: Quick-moving (shift+click) Botania pattern items in the loom UI properly puts them in the pattern slot
 * Fix: Animated Torch powers blocks consistently, and properly updates necessary blocks when placed, rotated, or removed


### PR DESCRIPTION
(implements #4279)