### PR TITLE
Fix incorrect platform render types on Forge

### DIFF
--- a/Forge/src/main/java/vazkii/botania/forge/client/ForgeClientInitializer.java
+++ b/Forge/src/main/java/vazkii/botania/forge/client/ForgeClientInitializer.java
@@ -85,6 +85,7 @@ public class ForgeClientInitializer {
 
 	@SubscribeEvent
 	public static void clientInit(FMLClientSetupEvent evt) {
+		BlockRenderLayers.skipPlatformBlocks = true; // platforms can use standard rendering on Forge
 		BlockRenderLayers.init(ItemBlockRenderTypes::setRenderLayer);
 		// GUIs
 		evt.enqueueWork(() -> {

--- a/Forge/src/main/java/vazkii/botania/forge/client/ForgePlatformModel.java
+++ b/Forge/src/main/java/vazkii/botania/forge/client/ForgePlatformModel.java
@@ -9,6 +9,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.client.ChunkRenderTypeSet;
 import net.minecraftforge.client.model.BakedModelWrapper;
 import net.minecraftforge.client.model.data.ModelData;
 import net.minecraftforge.client.model.data.ModelProperty;
@@ -58,6 +59,24 @@ public class ForgePlatformModel extends BakedModelWrapper<BakedModel> {
 			BakedModel model = Minecraft.getInstance().getBlockRenderer()
 					.getBlockModelShaper().getBlockModel(heldState);
 			return model.getQuads(heldState, side, rand, ModelData.EMPTY, renderType);
+		}
+	}
+
+	@NotNull
+	@Override
+	public ChunkRenderTypeSet getRenderTypes(@NotNull BlockState state, @NotNull RandomSource rand, @NotNull ModelData extraData) {
+		var data = extraData.get(PROPERTY);
+		if (!(state.getBlock() instanceof PlatformBlock) || data == null) {
+			return Minecraft.getInstance().getBlockRenderer().getBlockModelShaper()
+					.getModelManager().getMissingModel().getRenderTypes(state, rand, extraData);
+		}
+
+		BlockState heldState = data.state();
+		if (heldState == null) {
+			return super.getRenderTypes(state, rand, extraData);
+		} else {
+			BakedModel model = Minecraft.getInstance().getBlockRenderer().getBlockModelShaper().getBlockModel(heldState);
+			return model.getRenderTypes(heldState, rand, ModelData.EMPTY);
 		}
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/api/block_entity/SpecialFlowerBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/api/block_entity/SpecialFlowerBlockEntity.java
@@ -264,9 +264,9 @@ public abstract class SpecialFlowerBlockEntity extends BlockEntity implements Fl
 		return 0;
 	}
 
-	@SoftImplement("RenderAttachmentBlockEntity")
+	@SoftImplement("RenderDataBlockEntity")
 	@Nullable
-	public Object getRenderAttachmentData() {
+	public Object getRenderData() {
 		if (isFloating()) {
 			return floatingData.getIslandType();
 		}

--- a/Xplat/src/main/java/vazkii/botania/client/render/BlockRenderLayers.java
+++ b/Xplat/src/main/java/vazkii/botania/client/render/BlockRenderLayers.java
@@ -14,6 +14,8 @@ import vazkii.botania.common.lib.LibMisc;
 import java.util.function.BiConsumer;
 
 public final class BlockRenderLayers {
+	public static boolean skipPlatformBlocks;
+
 	public static void init(BiConsumer<Block, RenderType> consumer) {
 		consumer.accept(BotaniaBlocks.defaultAltar, RenderType.cutout());
 		consumer.accept(BotaniaBlocks.forestAltar, RenderType.cutout());
@@ -39,10 +41,15 @@ public final class BlockRenderLayers {
 		consumer.accept(BotaniaBlocks.prism, RenderType.translucent());
 
 		consumer.accept(BotaniaBlocks.starfield, RenderType.cutoutMipped());
-		consumer.accept(BotaniaBlocks.abstrusePlatform, RenderType.translucent());
-		consumer.accept(BotaniaBlocks.infrangiblePlatform, RenderType.translucent());
-		consumer.accept(BotaniaBlocks.spectralPlatform, RenderType.translucent());
-
+		if (!skipPlatformBlocks) {
+			// Render type is set dynamically on Forge and undisguised platforms should render as "solid",
+			// but "translucent" is the best compromise on Fabric.
+			// Translucent comes with a couple of downsides, like hidden block breaking animation and bad
+			// Z-ordering for non-cubic block models that should be rendered with the "cutout" render type.
+			consumer.accept(BotaniaBlocks.abstrusePlatform, RenderType.translucent());
+			consumer.accept(BotaniaBlocks.infrangiblePlatform, RenderType.translucent());
+			consumer.accept(BotaniaBlocks.spectralPlatform, RenderType.translucent());
+		}
 		BuiltInRegistries.BLOCK.stream().filter(b -> BuiltInRegistries.BLOCK.getKey(b).getNamespace().equals(LibMisc.MOD_ID))
 				.forEach(b -> {
 					if (b instanceof FloatingFlowerBlock || b instanceof FlowerBlock

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/FloatingFlowerBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/FloatingFlowerBlockEntity.java
@@ -58,8 +58,8 @@ public class FloatingFlowerBlockEntity extends BotaniaBlockEntity implements Flo
 		}
 	}
 
-	@SoftImplement("RenderAttachmentBlockEntity")
-	public Object getRenderAttachmentData() {
+	@SoftImplement("RenderDataBlockEntity")
+	public Object getRenderData() {
 		return floatingData.getIslandType();
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/PlatformBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/PlatformBlockEntity.java
@@ -121,8 +121,8 @@ public class PlatformBlockEntity extends BotaniaBlockEntity implements Wandable 
 		}
 	}
 
-	@SoftImplement("RenderAttachmentBlockEntity")
-	public Object getRenderAttachmentData() {
+	@SoftImplement("RenderDataBlockEntity")
+	public Object getRenderData() {
 		return new PlatformData(this);
 	}
 


### PR DESCRIPTION
Partial fix for https://github.com/VazkiiMods/Botania/issues/4557 (invisible block breaking animation on platforms) and https://github.com/VazkiiMods/Botania/issues/4404 (incorrect rendering when disguised as foliage):
- undisguised platforms are rendered solid by default
- the platform model determines the render type based on the disguise block state/model
- (also update soft implementation methods for deprecated Fabric rendering interface)