### PR TITLE
Restrict Ring of Correction to block breaking

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/bauble/RingOfCorrectionItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/bauble/RingOfCorrectionItem.java
@@ -8,9 +8,9 @@
  */
 package vazkii.botania.common.item.equipment.bauble;
 
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
@@ -18,6 +18,7 @@ import net.minecraft.world.phys.HitResult;
 
 import vazkii.botania.api.item.SortableTool;
 import vazkii.botania.common.item.equipment.tool.ToolCommons;
+import vazkii.botania.mixin.ServerPlayerGameModeAccessor;
 
 public class RingOfCorrectionItem extends BaubleItem {
 
@@ -27,13 +28,13 @@ public class RingOfCorrectionItem extends BaubleItem {
 
 	@Override
 	public void onWornTick(ItemStack stack, LivingEntity entity) {
-		if (entity.level().isClientSide || !(entity instanceof Player player)) {
+		if (entity.level().isClientSide || !(entity instanceof ServerPlayer player)) {
 			return;
 		}
 
 		ItemStack currentStack = player.getMainHandItem();
 		if (currentStack.isEmpty() || !(currentStack.getItem() instanceof SortableTool tool)
-				|| !player.swinging) {
+				|| !((ServerPlayerGameModeAccessor) player.gameMode).botania_isDestroyingBlock()) {
 			return;
 		}
 

--- a/Xplat/src/main/java/vazkii/botania/mixin/ServerPlayerGameModeAccessor.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/ServerPlayerGameModeAccessor.java
@@ -1,0 +1,12 @@
+package vazkii.botania.mixin;
+
+import net.minecraft.server.level.ServerPlayerGameMode;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ServerPlayerGameMode.class)
+public interface ServerPlayerGameModeAccessor {
+	@Accessor("isDestroyingBlock")
+	boolean botania_isDestroyingBlock();
+}

--- a/Xplat/src/main/resources/botania_xplat.mixins.json
+++ b/Xplat/src/main/resources/botania_xplat.mixins.json
@@ -47,6 +47,7 @@
     "RecipeManagerAccessor",
     "RecipeProviderAccessor",
     "ServerLevelMixin",
+    "ServerPlayerGameModeAccessor",
     "ServerPlayerMixin",
     "SpawnPlacementsMixin",
     "StatsAccessor",


### PR DESCRIPTION
Fixes #4317, and also makes things less weird e.g. with scraping copper blocks or tilling soil.