### PR TITLE
Dandelifeon exploit fix

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/CellularBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/CellularBlockEntity.java
@@ -46,12 +46,16 @@ public class CellularBlockEntity extends BotaniaBlockEntity {
 		nextGeneration = gen;
 		getLevel().scheduleTick(getBlockPos(), BotaniaBlocks.cellBlock, 1);
 		if (!ticked) {
-			flowerCoords = flower.getEffectivePos();
-			validCoords = getBlockPos();
+			claim(flower);
 			ticked = true;
 		} else if (!validCoords.equals(getBlockPos()) || !flowerCoords.equals(flower.getEffectivePos())) {
 			level.removeBlock(worldPosition, false);
 		}
+	}
+
+	public void claim(DandelifeonBlockEntity flower) {
+		flowerCoords = flower.getEffectivePos();
+		validCoords = getBlockPos();
 	}
 
 	public void update(Level level) {
@@ -63,6 +67,10 @@ public class CellularBlockEntity extends BotaniaBlockEntity {
 
 	public boolean isSameFlower(DandelifeonBlockEntity flower) {
 		return !ticked || validCoords.equals(getBlockPos()) && flowerCoords.equals(flower.getEffectivePos());
+	}
+
+	public boolean hasPoweredParent(Level level) {
+		return flowerCoords != null && level.getBlockEntity(flowerCoords) instanceof DandelifeonBlockEntity && level.hasNeighborSignal(flowerCoords);
 	}
 
 	public int getGeneration() {

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/CellularBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/CellularBlockEntity.java
@@ -54,8 +54,10 @@ public class CellularBlockEntity extends BotaniaBlockEntity {
 	}
 
 	public void claim(DandelifeonBlockEntity flower) {
-		flowerCoords = flower.getEffectivePos();
-		validCoords = getBlockPos();
+		if (!ticked) {
+			flowerCoords = flower.getEffectivePos();
+			validCoords = getBlockPos();
+		}
 	}
 
 	public void update(Level level) {
@@ -63,10 +65,6 @@ public class CellularBlockEntity extends BotaniaBlockEntity {
 			level.removeBlock(getBlockPos(), false);
 		}
 		generation = nextGeneration;
-	}
-
-	public boolean isSameFlower(DandelifeonBlockEntity flower) {
-		return validCoords.equals(getBlockPos()) && flowerCoords.equals(flower.getEffectivePos());
 	}
 
 	public boolean hasPoweredParent(Level level) {

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/CellularBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/CellularBlockEntity.java
@@ -66,7 +66,7 @@ public class CellularBlockEntity extends BotaniaBlockEntity {
 	}
 
 	public boolean isSameFlower(DandelifeonBlockEntity flower) {
-		return !ticked || validCoords.equals(getBlockPos()) && flowerCoords.equals(flower.getEffectivePos());
+		return validCoords.equals(getBlockPos()) && flowerCoords.equals(flower.getEffectivePos());
 	}
 
 	public boolean hasPoweredParent(Level level) {

--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/generating/DandelifeonBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/generating/DandelifeonBlockEntity.java
@@ -60,15 +60,15 @@ public class DandelifeonBlockEntity extends GeneratingFlowerBlockEntity {
 		if (!getLevel().isClientSide) {
 			if (getLevel().getGameTime() % SPEED == 0 && getLevel().hasNeighborSignal(getBlockPos())) {
 				runSimulation();
-			} else if (getLevel().getGameTime()+1 % SPEED == 0) {
-				diameter = radius * 2 + 1;
+			} else if ((getLevel().getGameTime()+1) % SPEED == 0) {
+				int diameter = radius * 2;
 
-				for (int i = -1; i <= diameter; i++) {
-					for (int j = -1; j <= diameter; j++) {
-						BlockPos pos = getEffectivePosition().offset(-range + i, 0, -range + j);
-						BlockEntity tile = dandie.getLevel().getBlockEntity(pos);
+				for (int i = 0; i <= diameter; i++) {
+					for (int j = 0; j <= diameter; j++) {
+						BlockPos pos = getEffectivePos().offset(-radius + i, 0, -radius + j);
+						BlockEntity tile = getLevel().getBlockEntity(pos);
 						if (tile instanceof CellularBlockEntity) {
-							tile.claim();
+							((CellularBlockEntity)(tile)).claim(this);
 						}
 					}
 				}

--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/generating/DandelifeonBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/generating/DandelifeonBlockEntity.java
@@ -60,7 +60,7 @@ public class DandelifeonBlockEntity extends GeneratingFlowerBlockEntity {
 		if (!getLevel().isClientSide) {
 			if (getLevel().getGameTime() % SPEED == 0 && getLevel().hasNeighborSignal(getBlockPos())) {
 				runSimulation();
-			} else if ((getLevel().getGameTime()+1) % SPEED == 0) {
+			} else if ((getLevel().getGameTime() + 1) % SPEED == 0) {
 				int diameter = radius * 2;
 
 				for (int i = 0; i <= diameter; i++) {
@@ -68,7 +68,7 @@ public class DandelifeonBlockEntity extends GeneratingFlowerBlockEntity {
 						BlockPos pos = getEffectivePos().offset(-radius + i, 0, -radius + j);
 						BlockEntity tile = getLevel().getBlockEntity(pos);
 						if (tile instanceof CellularBlockEntity) {
-							((CellularBlockEntity)(tile)).claim(this);
+							((CellularBlockEntity) (tile)).claim(this);
 						}
 					}
 				}
@@ -178,15 +178,15 @@ public class DandelifeonBlockEntity extends GeneratingFlowerBlockEntity {
 			for (int i = -1; i <= diameter; i++) {
 				for (int j = -1; j <= diameter; j++) {
 					BlockPos pos = center.offset(-range + i, 0, -range + j);
-					cells[i + 1][j + 1] = getCellGeneration(pos, dandie);
+					cells[i + 1][j + 1] = getCellGeneration(pos, dandie, onBoundary(i, j));
 				}
 			}
 		}
 
-		private static int getCellGeneration(BlockPos pos, DandelifeonBlockEntity dandie) {
+		private static int getCellGeneration(BlockPos pos, DandelifeonBlockEntity dandie, boolean onBoundary) {
 			BlockEntity tile = dandie.getLevel().getBlockEntity(pos);
 			if (tile instanceof CellularBlockEntity cell) {
-				return cell.isSameFlower(dandie) ? cell.getGeneration() : (cell.hasPoweredParent(dandie.getLevel()) ? Cell.boundaryPunish(cell.getGeneration()) : Cell.DEAD);
+				return onBoundary ? (cell.hasPoweredParent(dandie.getLevel()) ? Cell.boundaryPunish(cell.getGeneration()) : Cell.DEAD) : cell.getGeneration();
 			}
 
 			return Cell.DEAD;
@@ -194,6 +194,10 @@ public class DandelifeonBlockEntity extends GeneratingFlowerBlockEntity {
 
 		public boolean inBounds(int x, int z) {
 			return x >= 0 && z >= 0 && x < diameter && z < diameter;
+		}
+
+		private boolean onBoundary(int x, int z) {
+			return x == -1 || z == -1 || x == diameter || z == diameter;
 		}
 
 		public int getAdjCells(int x, int z) {

--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/generating/DandelifeonBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/generating/DandelifeonBlockEntity.java
@@ -60,6 +60,18 @@ public class DandelifeonBlockEntity extends GeneratingFlowerBlockEntity {
 		if (!getLevel().isClientSide) {
 			if (getLevel().getGameTime() % SPEED == 0 && getLevel().hasNeighborSignal(getBlockPos())) {
 				runSimulation();
+			} else if (getLevel().getGameTime()+1 % SPEED == 0) {
+				diameter = radius * 2 + 1;
+
+				for (int i = -1; i <= diameter; i++) {
+					for (int j = -1; j <= diameter; j++) {
+						BlockPos pos = getEffectivePosition().offset(-range + i, 0, -range + j);
+						BlockEntity tile = dandie.getLevel().getBlockEntity(pos);
+						if (tile instanceof CellularBlockEntity) {
+							tile.claim();
+						}
+					}
+				}
 			}
 		}
 	}
@@ -174,7 +186,7 @@ public class DandelifeonBlockEntity extends GeneratingFlowerBlockEntity {
 		private static int getCellGeneration(BlockPos pos, DandelifeonBlockEntity dandie) {
 			BlockEntity tile = dandie.getLevel().getBlockEntity(pos);
 			if (tile instanceof CellularBlockEntity cell) {
-				return cell.isSameFlower(dandie) ? cell.getGeneration() : Cell.boundaryPunish(cell.getGeneration());
+				return cell.isSameFlower(dandie) ? cell.getGeneration() : (cell.hasPoweredParent(dandie.getLevel()) ? Cell.boundaryPunish(cell.getGeneration()) : Cell.DEAD);
 			}
 
 			return Cell.DEAD;


### PR DESCRIPTION
Fixing the Dendelifeon "exploit" by requiring cells to have a powered parent in order to qualify as a boundary cell. Fixes #4353 