### PR TITLE
Made plant check of Agricarnation more flexible

### DIFF
--- a/Xplat/src/generated/resources/.cache/bfa01a6ca2555c100103725bf5c9e6da285f29c3
+++ b/Xplat/src/generated/resources/.cache/bfa01a6ca2555c100103725bf5c9e6da285f29c3
@@ -1,4 +1,7 @@
 // 1.20.1	Botania/Tags for minecraft:block
+8865bb2eca4192a496bda05497a584aee6a3a409 data/botania/tags/blocks/agricarnation/apply_bonemeal.json
+1f1a3978ea72d2be2545d91126d194b1b6639c49 data/botania/tags/blocks/agricarnation/growth_candidate.json
+caa65214e42ad067ce1935d9b7d48e0a9feb9e73 data/botania/tags/blocks/agricarnation/growth_excluded.json
 7c8a171ae6d6133a08aa4d939254a4290e6b44b6 data/botania/tags/blocks/corporea_spark_override.json
 e8a61a147b6a258b9c37788ac1bd4edf592c9dc9 data/botania/tags/blocks/double_mystical_flowers.json
 070322f325bf48a093e7a873066fd5992202fd74 data/botania/tags/blocks/dreamwood_logs.json

--- a/Xplat/src/generated/resources/data/botania/tags/blocks/agricarnation/apply_bonemeal.json
+++ b/Xplat/src/generated/resources/data/botania/tags/blocks/agricarnation/apply_bonemeal.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:azalea",
+    "minecraft:flowering_azalea"
+  ]
+}

--- a/Xplat/src/generated/resources/data/botania/tags/blocks/agricarnation/growth_candidate.json
+++ b/Xplat/src/generated/resources/data/botania/tags/blocks/agricarnation/growth_candidate.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#botania:agricarnation/apply_bonemeal"
+  ]
+}

--- a/Xplat/src/generated/resources/data/botania/tags/blocks/agricarnation/growth_excluded.json
+++ b/Xplat/src/generated/resources/data/botania/tags/blocks/agricarnation/growth_excluded.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:red_mushroom",
+    "minecraft:brown_mushroom"
+  ]
+}

--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/AgricarnationBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/AgricarnationBlockEntity.java
@@ -11,6 +11,7 @@ package vazkii.botania.common.block.flower.functional;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -19,11 +20,14 @@ import vazkii.botania.api.block_entity.FunctionalFlowerBlockEntity;
 import vazkii.botania.api.block_entity.RadiusDescriptor;
 import vazkii.botania.common.block.BotaniaFlowerBlocks;
 import vazkii.botania.common.handler.BotaniaSounds;
+import vazkii.botania.common.lib.BotaniaTags;
+import vazkii.botania.mixin.GrowingPlantBodyBlockMixin;
 import vazkii.botania.xplat.BotaniaConfig;
 
 public class AgricarnationBlockEntity extends FunctionalFlowerBlockEntity {
 	private static final int RANGE = 5;
 	private static final int RANGE_MINI = 2;
+	private static final float BONEMEAL_SUCCESS_CHANCE = 0.5f;
 
 	protected AgricarnationBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
 		super(type, pos, state);
@@ -37,7 +41,7 @@ public class AgricarnationBlockEntity extends FunctionalFlowerBlockEntity {
 	public void tickFlower() {
 		super.tickFlower();
 
-		if (getLevel().isClientSide) {
+		if (!(getLevel() instanceof ServerLevel serverLevel)) {
 			return;
 		}
 
@@ -47,24 +51,41 @@ public class AgricarnationBlockEntity extends FunctionalFlowerBlockEntity {
 
 		if (ticksExisted % 6 == 0 && redstoneSignal == 0) {
 			int range = getRange();
-			int x = getEffectivePos().getX() + getLevel().random.nextInt(range * 2 + 1) - range;
-			int z = getEffectivePos().getZ() + getLevel().random.nextInt(range * 2 + 1) - range;
+			int x = getEffectivePos().getX() + serverLevel.random.nextInt(range * 2 + 1) - range;
+			int z = getEffectivePos().getZ() + serverLevel.random.nextInt(range * 2 + 1) - range;
 
 			for (int i = 4; i > -2; i--) {
 				int y = getEffectivePos().getY() + i;
 				BlockPos pos = new BlockPos(x, y, z);
-				if (getLevel().isEmptyBlock(pos)) {
+				BlockState state = serverLevel.getBlockState(pos);
+				if (state.isAir()) {
 					continue;
 				}
 
-				if (isPlant(pos) && getMana() > 5) {
-					BlockState state = getLevel().getBlockState(pos);
-					addMana(-5);
-					state.randomTick((ServerLevel) level, pos, level.random);
-					if (BotaniaConfig.common().blockBreakParticles()) {
-						getLevel().levelEvent(LevelEvent.PARTICLES_PLANT_GROWTH, pos, 6 + getLevel().random.nextInt(4));
+				Block block = state.getBlock();
+				if (block instanceof GrowingPlantBodyBlock) {
+					var headPos = ((GrowingPlantBodyBlockMixin) block).botania_getHeadPos(serverLevel, pos, block);
+					if (headPos.isPresent()) {
+						pos = headPos.get();
 					}
-					getLevel().playSound(null, x, y, z, BotaniaSounds.agricarnation, SoundSource.BLOCKS, 1F, 0.5F + (float) Math.random() * 0.5F);
+				}
+
+				if (isPlant(serverLevel, pos, state, block) && getMana() > 5) {
+					addMana(-5);
+					if (state.is(BotaniaTags.Blocks.AGRICARNATION_APPLY_BONEMEAL)
+							&& block instanceof BonemealableBlock bonemealableBlock
+							&& bonemealableBlock.isValidBonemealTarget(serverLevel, pos, state, false)) {
+						if (serverLevel.random.nextFloat() < BONEMEAL_SUCCESS_CHANCE
+								&& bonemealableBlock.isBonemealSuccess(serverLevel, serverLevel.random, pos, state)) {
+							bonemealableBlock.performBonemeal(serverLevel, serverLevel.random, pos, state);
+						}
+					} else {
+						state.randomTick(serverLevel, pos, serverLevel.random);
+					}
+					if (BotaniaConfig.common().blockBreakParticles()) {
+						serverLevel.levelEvent(LevelEvent.PARTICLES_PLANT_GROWTH, pos, 6 + serverLevel.random.nextInt(4));
+					}
+					serverLevel.playSound(null, x, y, z, BotaniaSounds.agricarnation, SoundSource.BLOCKS, 1F, 0.5F + (float) Math.random() * 0.5F);
 
 					break;
 				}
@@ -80,26 +101,27 @@ public class AgricarnationBlockEntity extends FunctionalFlowerBlockEntity {
 	/**
 	 * @return Whether the block at {@code pos} grows "naturally". That is, whether its IGrowable action is simply
 	 *         growing itself, instead of something like spreading around or creating flowers around, etc, and whether
-	 *         this
-	 *         action would have happened normally over time without bonemeal.
+	 *         this action would have happened normally over time without bonemeal.
 	 */
-	private boolean isPlant(BlockPos pos) {
-		BlockState state = getLevel().getBlockState(pos);
-		Block block = state.getBlock();
-
-		// Spreads when ticked
-		if (block instanceof SpreadingSnowyDirtBlock) {
+	private boolean isPlant(Level level, BlockPos pos, BlockState state, Block block) {
+		if (state.is(BotaniaTags.Blocks.AGRICARNATION_GROWTH_EXCLUDED)
+				// grass/mycelium/nylium-like spreading blocks are excluded unless tagged otherwise
+				|| (block instanceof SpreadingSnowyDirtBlock || block instanceof NyliumBlock)
+						&& !state.is(BotaniaTags.Blocks.AGRICARNATION_GROWTH_CANDIDATE)) {
 			return false;
 		}
 
-		// Exclude all BushBlock except known vanilla subclasses
-		if (block instanceof BushBlock && !(block instanceof CropBlock) && !(block instanceof StemBlock)
-				&& !(block instanceof SaplingBlock) && !(block instanceof SweetBerryBushBlock)) {
-			return false;
-		}
+		boolean couldApplyBonemeal = block instanceof BonemealableBlock bonemealableBlock
+				&& bonemealableBlock.isValidBonemealTarget(level, pos, state, level.isClientSide);
 
-		return block instanceof BonemealableBlock mealable
-				&& mealable.isValidBonemealTarget(getLevel(), pos, state, getLevel().isClientSide);
+		boolean isTargetCandidate = couldApplyBonemeal
+				|| block instanceof BushBlock
+				|| state.is(BotaniaTags.Blocks.AGRICARNATION_GROWTH_CANDIDATE);
+		boolean acceptsGrowthBoost = state.isRandomlyTicking()
+				|| couldApplyBonemeal && state.is(BotaniaTags.Blocks.AGRICARNATION_APPLY_BONEMEAL);
+
+		return isTargetCandidate && acceptsGrowthBoost;
+
 	}
 
 	@Override

--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/AgricarnationBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/AgricarnationBlockEntity.java
@@ -99,9 +99,12 @@ public class AgricarnationBlockEntity extends FunctionalFlowerBlockEntity {
 	}
 
 	/**
-	 * @return Whether the block at {@code pos} grows "naturally". That is, whether its IGrowable action is simply
-	 *         growing itself, instead of something like spreading around or creating flowers around, etc, and whether
-	 *         this action would have happened normally over time without bonemeal.
+	 * @return Whether the agricarnation considers the given block a plant it can grow. By default,
+	 *         grass/mycelium/nylium-like spreading blocks are excluded. They can be excplicitly included by being added
+	 *         to the AGRICARNATION_GROWTH_CANDIDATE tag. Blocks in AGRICARNATION_GROWTH_EXCLUDED are always excluded.
+	 *         Potential included blocks are those that are bonemealable, instance of BushBlock, or in the
+	 *         AGRICARNATION_GROWTH_CANDIDATE tag. They are included only if they accept random ticks, or are
+	 *         bonemealable and have the AGRICARNATION_APPLY_BONEMEAL tag.
 	 */
 	private boolean isPlant(Level level, BlockPos pos, BlockState state, Block block) {
 		if (state.is(BotaniaTags.Blocks.AGRICARNATION_GROWTH_EXCLUDED)

--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/AgricarnationBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/AgricarnationBlockEntity.java
@@ -27,6 +27,7 @@ import vazkii.botania.xplat.BotaniaConfig;
 public class AgricarnationBlockEntity extends FunctionalFlowerBlockEntity {
 	private static final int RANGE = 5;
 	private static final int RANGE_MINI = 2;
+	private static final int MANA_COST = 5;
 	private static final float BONEMEAL_SUCCESS_CHANCE = 0.5f;
 
 	protected AgricarnationBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
@@ -70,8 +71,8 @@ public class AgricarnationBlockEntity extends FunctionalFlowerBlockEntity {
 					}
 				}
 
-				if (isPlant(serverLevel, pos, state, block) && getMana() > 5) {
-					addMana(-5);
+				if (isPlant(serverLevel, pos, state, block) && getMana() > MANA_COST) {
+					addMana(-MANA_COST);
 					if (state.is(BotaniaTags.Blocks.AGRICARNATION_APPLY_BONEMEAL)
 							&& block instanceof BonemealableBlock bonemealableBlock
 							&& bonemealableBlock.isValidBonemealTarget(serverLevel, pos, state, false)) {

--- a/Xplat/src/main/java/vazkii/botania/common/lib/BotaniaTags.java
+++ b/Xplat/src/main/java/vazkii/botania/common/lib/BotaniaTags.java
@@ -239,6 +239,21 @@ public class BotaniaTags {
 		public static final TagKey<Block> HORN_OF_THE_COVERING_BREAKABLE = tag("horn_of_the_covering_breakable");
 
 		/**
+		 * Blocks in this tag are candidates for the Agricarnation's growth boost, assuming they accept random ticks.
+		 */
+		public static final TagKey<Block> AGRICARNATION_GROWTH_CANDIDATE = tag("agricarnation/growth_candidate");
+		/**
+		 * Blocks in this tag are ignored by the Agricarnation, even if they look like they are growable plants.
+		 */
+		public static final TagKey<Block> AGRICARNATION_GROWTH_EXCLUDED = tag("agricarnation/growth_excluded");
+		/**
+		 * Blocks in this tag will have their growth boosted as if bonemeal was applied, instead of via random ticks.
+		 * These plants need to pass the bonemeal success check twice to get a boost, but mana will be consumed even if
+		 * that fails.
+		 */
+		public static final TagKey<Block> AGRICARNATION_APPLY_BONEMEAL = tag("agricarnation/apply_bonemeal");
+
+		/**
 		 * Blocks in this tag can not have their state manipulated by a wand of the forest
 		 */
 		public static final TagKey<Block> UNWANDABLE = tag("unwandable");

--- a/Xplat/src/main/java/vazkii/botania/data/BlockTagProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/data/BlockTagProvider.java
@@ -244,6 +244,10 @@ public class BlockTagProvider extends IntrinsicHolderTagsProvider<Block> {
 						tigerseyePotted, vinculotusPotted
 				);
 
+		tag(BotaniaTags.Blocks.AGRICARNATION_APPLY_BONEMEAL).add(Blocks.AZALEA, Blocks.FLOWERING_AZALEA);
+		tag(BotaniaTags.Blocks.AGRICARNATION_GROWTH_CANDIDATE).addTag(BotaniaTags.Blocks.AGRICARNATION_APPLY_BONEMEAL);
+		tag(BotaniaTags.Blocks.AGRICARNATION_GROWTH_EXCLUDED).add(Blocks.RED_MUSHROOM, Blocks.BROWN_MUSHROOM);
+
 		registerMiningTags();
 	}
 

--- a/Xplat/src/main/java/vazkii/botania/mixin/GrowingPlantBodyBlockMixin.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/GrowingPlantBodyBlockMixin.java
@@ -1,0 +1,16 @@
+package vazkii.botania.mixin;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.util.Optional;
+
+@Mixin(net.minecraft.world.level.block.GrowingPlantBodyBlock.class)
+public interface GrowingPlantBodyBlockMixin {
+	@Invoker("getHeadPos")
+	Optional<BlockPos> botania_getHeadPos(BlockGetter level, BlockPos pos, Block block);
+}

--- a/Xplat/src/main/resources/botania_xplat.mixins.json
+++ b/Xplat/src/main/resources/botania_xplat.mixins.json
@@ -24,6 +24,7 @@
     "ExperienceOrbAccessor",
     "FarmBlockMixin",
     "FireBlockAccessor",
+    "GrowingPlantBodyBlockMixin",
     "HopperBlockEntityAccessor",
     "HurtByTargetGoalAccessor",
     "InventoryAccessor",


### PR DESCRIPTION
Resolves #4644 (and also closes #4446, which is superseded by this PR) by implementing the rule set laid out in that issue:

- when the location of a `GrowingPlantBodyBlock` is encountered, the corresponding head block location is used instead
- new block tags:
  - `#botania:agricarnation/growth_candidate` specifies blocks that should be considered candidates, in addition to any blocks that extend `BushBlock` or accept bonemeal
  - `#botania:agricarnation/apply_bonemeal` defines blocks that should be boosted by applying bonemeal instead of random ticks (only relevant if the block actually accepts bonemeal)
  - `#botania:agricarnation/growth_excluded` excludes blocks from any growth boost considerations
- azalea bushes are bonemealing candidates via the corresponding tag by default, to make them work similar to other saplings
- the bonemealing tag is included in the growth candidates tag by default
- vanilla mushrooms are growth-excluded via the corrsponding tag by default
- blocks extending `SpreadingSnowyDirtBlock` (i.e. grass or mycelium) or `NyliumBlock` are excluded via code, unless explicitly tagged as growth candidate
- the flower will boost growth for candidate blocks that can be random-ticked, or that are tagged for bonemeal application and also accept bonemeal
- bonemeal application needs to pass a built-in chance check and the block's own success check before applying the bonemeal effect; mana will still be consumed if either of those checks fail