### PR TITLE
Smelty rod improvements

### DIFF
--- a/Fabric/src/main/java/vazkii/botania/fabric/FabricCommonInitializer.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/FabricCommonInitializer.java
@@ -287,6 +287,7 @@ public class FabricCommonInitializer implements ModInitializer {
 		BotaniaFabricCapabilities.BLOCK_PROVIDER.registerForItems((stack, c) -> new LandsRodItem.BlockProviderImpl(stack), BotaniaItems.dirtRod, BotaniaItems.skyDirtRod);
 		BotaniaFabricCapabilities.BLOCK_PROVIDER.registerForItems((stack, c) -> new BlackHoleTalismanItem.BlockProviderImpl(stack), BotaniaItems.blackHoleTalisman);
 		BotaniaFabricCapabilities.BLOCK_PROVIDER.registerForItems((stack, c) -> new DepthsRodItem.BlockProviderImpl(), BotaniaItems.cobbleRod);
+		BotaniaFabricCapabilities.BLOCK_PROVIDER.registerForItems((stack, c) -> new MoltenCoreRodItem.BlockProviderImpl(), BotaniaItems.smeltRod);
 		BotaniaFabricCapabilities.BLOCK_PROVIDER.registerForItems((stack, c) -> new EnderHandItem.BlockProviderImpl(stack), BotaniaItems.enderHand);
 		BotaniaFabricCapabilities.BLOCK_PROVIDER.registerForItems((stack, c) -> new TerraFirmaRodItem.BlockProviderImpl(), BotaniaItems.terraformRod);
 		BotaniaFabricCapabilities.COORD_BOUND_ITEM.registerForItems((st, c) -> new EyeOfTheFlugelItem.CoordBoundItemImpl(st), BotaniaItems.flugelEye);

--- a/Fabric/src/main/java/vazkii/botania/fabric/FabricCommonInitializer.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/FabricCommonInitializer.java
@@ -241,6 +241,7 @@ public class FabricCommonInitializer implements ModInitializer {
 			UseBlockCallback.EVENT.register(SkyblockWorldEvents::onPlayerInteract);
 		}
 		AttackBlockCallback.EVENT.register((player, world, hand, pos, direction) -> ((ShiftingCrustRodItem) BotaniaItems.exchangeRod).onLeftClick(player, world, hand, pos, direction));
+		AttackBlockCallback.EVENT.register((player, world, hand, pos, direction) -> ((MoltenCoreRodItem) BotaniaItems.smeltRod).onLeftClick(player, world, hand, pos, direction));
 		AttackEntityCallback.EVENT.register(ShadedMesaRodItem::onAttack);
 		AttackEntityCallback.EVENT.register(TerraBladeItem::attackEntity);
 		CommandRegistrationCallback.EVENT.register(this::registerCommands);

--- a/Fabric/src/main/java/vazkii/botania/fabric/FabricCommonInitializer.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/FabricCommonInitializer.java
@@ -241,7 +241,6 @@ public class FabricCommonInitializer implements ModInitializer {
 			UseBlockCallback.EVENT.register(SkyblockWorldEvents::onPlayerInteract);
 		}
 		AttackBlockCallback.EVENT.register((player, world, hand, pos, direction) -> ((ShiftingCrustRodItem) BotaniaItems.exchangeRod).onLeftClick(player, world, hand, pos, direction));
-		AttackBlockCallback.EVENT.register((player, world, hand, pos, direction) -> ((MoltenCoreRodItem) BotaniaItems.smeltRod).onLeftClick(player, world, hand, pos, direction));
 		AttackEntityCallback.EVENT.register(ShadedMesaRodItem::onAttack);
 		AttackEntityCallback.EVENT.register(TerraBladeItem::attackEntity);
 		CommandRegistrationCallback.EVENT.register(this::registerCommands);

--- a/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
+++ b/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
@@ -299,8 +299,6 @@ public class ForgeCommonInitializer {
 		}
 		bus.addListener((PlayerInteractEvent.LeftClickBlock e) -> ((ShiftingCrustRodItem) BotaniaItems.exchangeRod).onLeftClick(
 				e.getEntity(), e.getLevel(), e.getHand(), e.getPos(), e.getFace()));
-		bus.addListener((PlayerInteractEvent.LeftClickBlock e) -> ((MoltenCoreRodItem) BotaniaItems.smeltRod).onLeftClick(
-				e.getEntity(), e.getLevel(), e.getHand(), e.getPos(), e.getFace()));
 		bus.addListener((PlayerInteractEvent.LeftClickEmpty e) -> TerraBladeItem.leftClick(e.getItemStack()));
 		bus.addListener((AttackEntityEvent e) -> TerraBladeItem.attackEntity(
 				e.getEntity(), e.getEntity().level(), InteractionHand.MAIN_HAND, e.getTarget(), null));

--- a/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
+++ b/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
@@ -480,7 +480,8 @@ public class ForgeCommonInitializer {
 			BotaniaItems.blackHoleTalisman, BlackHoleTalismanItem.BlockProviderImpl::new,
 			BotaniaItems.cobbleRod, s -> new DepthsRodItem.BlockProviderImpl(),
 			BotaniaItems.enderHand, EnderHandItem.BlockProviderImpl::new,
-			BotaniaItems.terraformRod, s -> new TerraFirmaRodItem.BlockProviderImpl()
+			BotaniaItems.terraformRod, s -> new TerraFirmaRodItem.BlockProviderImpl(),
+			BotaniaItems.smeltRod, s -> new MoltenCoreRodItem.BlockProviderImpl()
 	));
 
 	private static final Supplier<Map<Item, Function<ItemStack, CoordBoundItem>>> COORD_BOUND_ITEM = Suppliers.memoize(() -> Map.of(

--- a/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
+++ b/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
@@ -299,6 +299,8 @@ public class ForgeCommonInitializer {
 		}
 		bus.addListener((PlayerInteractEvent.LeftClickBlock e) -> ((ShiftingCrustRodItem) BotaniaItems.exchangeRod).onLeftClick(
 				e.getEntity(), e.getLevel(), e.getHand(), e.getPos(), e.getFace()));
+		bus.addListener((PlayerInteractEvent.LeftClickBlock e) -> ((MoltenCoreRodItem) BotaniaItems.smeltRod).onLeftClick(
+				e.getEntity(), e.getLevel(), e.getHand(), e.getPos(), e.getFace()));
 		bus.addListener((PlayerInteractEvent.LeftClickEmpty e) -> TerraBladeItem.leftClick(e.getItemStack()));
 		bus.addListener((AttackEntityEvent e) -> TerraBladeItem.attackEntity(
 				e.getEntity(), e.getEntity().level(), InteractionHand.MAIN_HAND, e.getTarget(), null));

--- a/Xplat/src/main/java/vazkii/botania/common/item/rod/MoltenCoreRodItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/rod/MoltenCoreRodItem.java
@@ -8,144 +8,73 @@
  */
 package vazkii.botania.common.item.rod;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.sounds.SoundSource;
-import net.minecraft.world.Container;
-import net.minecraft.world.InteractionHand;
-import net.minecraft.world.InteractionResultHolder;
-import net.minecraft.world.SimpleContainer;
-import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.*;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.ItemUtils;
-import net.minecraft.world.item.UseAnim;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.BlockHitResult;
-import net.minecraft.world.phys.HitResult;
-
-import org.jetbrains.annotations.NotNull;
 
 import vazkii.botania.api.mana.ManaItemHandler;
 import vazkii.botania.client.fx.WispParticleData;
 import vazkii.botania.common.handler.BotaniaSounds;
-import vazkii.botania.common.item.equipment.tool.ToolCommons;
-
-import java.util.Map;
-import java.util.WeakHashMap;
 
 public class MoltenCoreRodItem extends Item {
 
-	private static final int TIME = 10;
 	private static final int COST = 300;
-	private static final int COST_PER_TICK = COST / TIME;
-
-	public static final Map<Player, SmeltData> playerData = new WeakHashMap<>();
 
 	public MoltenCoreRodItem(Properties props) {
 		super(props);
 	}
 
-	@NotNull
-	@Override
-	public UseAnim getUseAnimation(ItemStack stack) {
-		return UseAnim.BOW;
-	}
-
-	@Override
-	public int getUseDuration(ItemStack stack) {
-		return 72000;
-	}
-
-	@NotNull
-	@Override
-	public InteractionResultHolder<ItemStack> use(Level world, Player player, @NotNull InteractionHand hand) {
-		return ItemUtils.startUsingInstantly(world, player, hand);
-	}
-
-	@Override
-	public void onUseTick(Level world, LivingEntity living, ItemStack stack, int time) {
-		if (!(living instanceof Player p)) {
-			return;
+	public InteractionResult onLeftClick(Player p, Level world, InteractionHand hand, BlockPos pos, Direction side) {
+		if (p.isSpectator()) {
+			return InteractionResult.PASS;
+		}
+		ItemStack stack = p.getItemInHand(hand);
+		if (stack.isEmpty() || !stack.is(this)) {
+			return InteractionResult.PASS;
 		}
 		Container dummyInv = new SimpleContainer(1);
 
-		if (!ManaItemHandler.instance().requestManaExactForTool(stack, p, COST_PER_TICK, false)) {
-			return;
+		if (!ManaItemHandler.instance().requestManaExactForTool(stack, p, COST, false)) {
+			return InteractionResult.PASS;
 		}
 
-		BlockHitResult pos = ToolCommons.raytraceFromEntity(p, 32, false);
+		BlockState state = world.getBlockState(pos);
 
-		if (pos.getType() == HitResult.Type.BLOCK) {
-			BlockState state = world.getBlockState(pos.getBlockPos());
+		dummyInv.setItem(0, new ItemStack(state.getBlock()));
+		world.getRecipeManager().getRecipeFor(RecipeType.SMELTING, dummyInv, p.level())
+				.map(r -> r.assemble(dummyInv, world.registryAccess()))
+				.filter(r -> !r.isEmpty() && r.getItem() instanceof BlockItem)
+				.ifPresent(result -> {
+					if (!world.isClientSide) {
+						world.setBlockAndUpdate(pos, Block.byItem(result.getItem()).defaultBlockState());
+						world.playSound(null, p.getX(), p.getY(), p.getZ(), BotaniaSounds.smeltRod, SoundSource.PLAYERS, 1F, 1F);
+						world.playSound(null, p.getX(), p.getY(), p.getZ(), BotaniaSounds.smeltRod2, SoundSource.PLAYERS, 1F, 1F);
 
-			dummyInv.setItem(0, new ItemStack(state.getBlock()));
-			world.getRecipeManager().getRecipeFor(RecipeType.SMELTING, dummyInv, p.level())
-					.map(r -> r.assemble(dummyInv, world.registryAccess()))
-					.filter(r -> !r.isEmpty() && r.getItem() instanceof BlockItem)
-					.ifPresent(result -> {
-						boolean decremented = false;
+						ManaItemHandler.instance().requestManaExactForTool(stack, p, COST, true);
+					}
 
-						if (playerData.containsKey(p)) {
-							SmeltData data = playerData.get(p);
-
-							if (data.equalPos(pos)) {
-								data.progress--;
-								decremented = true;
-								if (data.progress <= 0) {
-									if (!world.isClientSide) {
-										world.setBlockAndUpdate(pos.getBlockPos(), Block.byItem(result.getItem()).defaultBlockState());
-										world.playSound(null, p.getX(), p.getY(), p.getZ(), BotaniaSounds.smeltRod, SoundSource.PLAYERS, 1F, 1F);
-										world.playSound(null, p.getX(), p.getY(), p.getZ(), BotaniaSounds.smeltRod2, SoundSource.PLAYERS, 1F, 1F);
-
-										ManaItemHandler.instance().requestManaExactForTool(stack, p, COST_PER_TICK, true);
-										playerData.remove(p);
-										decremented = false;
-									}
-
-									WispParticleData data1 = WispParticleData.wisp(0.5F, 1F, 0.2F, 0.2F, 1);
-									for (int i = 0; i < 25; i++) {
-										double x = pos.getBlockPos().getX() + Math.random();
-										double y = pos.getBlockPos().getY() + Math.random();
-										double z = pos.getBlockPos().getZ() + Math.random();
-										world.addParticle(data1, x, y, z, 0, (float) -Math.random() / 10F, 0);
-									}
-								}
-							}
-						}
-
-						if (!decremented) {
-							playerData.put(p, new SmeltData(pos, ManaItemHandler.instance().hasProficiency(p, stack) ? (int) (TIME * 0.6) : TIME));
-						} else {
-							for (int i = 0; i < 2; i++) {
-								double x = pos.getBlockPos().getX() + Math.random();
-								double y = pos.getBlockPos().getY() + Math.random();
-								double z = pos.getBlockPos().getZ() + Math.random();
-								WispParticleData data = WispParticleData.wisp(0.5F, 1F, 0.2F, 0.2F, 1);
-								world.addParticle(data, x, y, z, 0, (float) Math.random() / 10F, 0);
-							}
-							if (time % 10 == 0) {
-								world.playSound(null, p.getX(), p.getY(), p.getZ(), BotaniaSounds.smeltRodSimmer, SoundSource.PLAYERS, (float) Math.random() / 2F + 0.5F, 1F);
-							}
-						}
-					});
-		}
+					WispParticleData data1 = WispParticleData.wisp(0.5F, 1F, 0.2F, 0.2F, 1);
+					for (int i = 0; i < 25; i++) {
+						double x = pos.getX() + Math.random();
+						double y = pos.getY() + Math.random();
+						double z = pos.getZ() + Math.random();
+						world.addParticle(data1, x, y, z, 0, (float) -Math.random() / 10F, 0);
+					}
+				});
+		return InteractionResult.SUCCESS;
 	}
 
-	static class SmeltData {
-		public final BlockHitResult pos;
-		public int progress;
-
-		public SmeltData(BlockHitResult pos, int progress) {
-			this.pos = pos;
-			this.progress = progress;
-		}
-
-		public boolean equalPos(BlockHitResult pos) {
-			return pos.getBlockPos().equals(this.pos.getBlockPos());
-		}
+	@Override
+	public boolean canAttackBlock(BlockState state, Level world, BlockPos pos, Player player) {
+		return !player.isCreative();
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/item/rod/MoltenCoreRodItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/rod/MoltenCoreRodItem.java
@@ -47,8 +47,14 @@ public class MoltenCoreRodItem extends Item {
 		super(props);
 	}
 
-	public InteractionResult onLeftClick(Player p, Level world, InteractionHand hand, BlockPos pos, Direction side) {
-		ItemStack stack = p.getItemInHand(hand);
+	@Override
+	public InteractionResult useOn(UseOnContext ctx) {
+		Player p = ctx.getPlayer();
+		ItemStack stack = ctx.getItemInHand();
+		Level world = ctx.getLevel();
+		Direction side = ctx.getClickedFace();
+		BlockPos pos = ctx.getClickedPos();
+		
 		if (p.isSpectator() || stack.isEmpty() || !stack.is(this)) {
 			return InteractionResult.PASS;
 		}
@@ -83,12 +89,7 @@ public class MoltenCoreRodItem extends Item {
 	}
 
 	@Override
-	public boolean canAttackBlock(BlockState state, Level world, BlockPos pos, Player player) {
-		return !player.isCreative();
-	}
-
-	@Override
-	public boolean overrideOtherStackedOnMe(
+	public boolean overrideStackedOnOther(
 			@NotNull ItemStack rod, @NotNull ItemStack toSmelt, @NotNull Slot slot,
 			@NotNull ClickAction clickAction, @NotNull Player player, @NotNull SlotAccess cursorAccess) {
 		if (clickAction == ClickAction.SECONDARY && ManaItemHandler.instance().requestManaExactForTool(rod, player, COST * toSmelt.getCount(), false)) {

--- a/Xplat/src/main/java/vazkii/botania/common/item/rod/MoltenCoreRodItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/rod/MoltenCoreRodItem.java
@@ -28,25 +28,22 @@ import vazkii.botania.common.handler.BotaniaSounds;
 public class MoltenCoreRodItem extends Item {
 
 	private static final int COST = 300;
+	private static final long COOLDOWN = 4;
+	private long lastUsedAt = -1;
 
 	public MoltenCoreRodItem(Properties props) {
 		super(props);
 	}
 
 	public InteractionResult onLeftClick(Player p, Level world, InteractionHand hand, BlockPos pos, Direction side) {
-		if (p.isSpectator()) {
+		ItemStack stack = p.getItemInHand(hand);
+		if (p.isSpectator() || stack.isEmpty() || !stack.is(this)) {
 			return InteractionResult.PASS;
 		}
-		ItemStack stack = p.getItemInHand(hand);
-		if (stack.isEmpty() || !stack.is(this)) {
-			return InteractionResult.PASS;
+		if (!ManaItemHandler.instance().requestManaExactForTool(stack, p, COST, false) || lastUsedAt + COOLDOWN > world.getGameTime()) {
+			return InteractionResult.SUCCESS;
 		}
 		Container dummyInv = new SimpleContainer(1);
-
-		if (!ManaItemHandler.instance().requestManaExactForTool(stack, p, COST, false)) {
-			return InteractionResult.PASS;
-		}
-
 		BlockState state = world.getBlockState(pos);
 
 		dummyInv.setItem(0, new ItemStack(state.getBlock()));
@@ -60,8 +57,8 @@ public class MoltenCoreRodItem extends Item {
 						world.playSound(null, p.getX(), p.getY(), p.getZ(), BotaniaSounds.smeltRod2, SoundSource.PLAYERS, 1F, 1F);
 
 						ManaItemHandler.instance().requestManaExactForTool(stack, p, COST, true);
+						lastUsedAt = world.getGameTime();
 					}
-
 					WispParticleData data1 = WispParticleData.wisp(0.5F, 1F, 0.2F, 0.2F, 1);
 					for (int i = 0; i < 25; i++) {
 						double x = pos.getX() + Math.random();

--- a/Xplat/src/main/resources/assets/botania/lang/en_us.json
+++ b/Xplat/src/main/resources/assets/botania/lang/en_us.json
@@ -2962,7 +2962,7 @@
 
   "botania.entry.smeltRod": "Rod of the Molten Core",
   "botania.tagline.smeltRod": "A rod for smelting blocks",
-  "botania.page.smeltRod0": "The $(item)Rod of the Molten Core$(0) has the ability to focus heat drawn from the world's core. Punching a block in the world that can be smelted into a different block will smelt it into that block.$(p)For example, $(item)Cobblestone$(0) will smelt into $(item)Stone$(0) and then into $(item)Smooth Stone$(0), $(item)Sand$(0) melts into $(item)Glass$(0), and so on.",
+  "botania.page.smeltRod0": "The $(item)Rod of the Molten Core$(0) has the ability to focus heat drawn from the world's core. Punching a block in the world that can be smelted into a different block will smelt it into that block.$(p)For example, $(item)Cobblestone$(0) will smelt into $(item)Stone$(0) and then into $(item)Smooth Stone$(0), $(item)Sand$(0) melts into $(item)Glass$(0), and so on. Furthermore, the rod can be used as a portable furnace by right clicking items onto it in inventory, for the same mana cost",
   "botania.page.smeltRod1": "No raid party required",
 
   "botania.entry.worldSeed": "World Seed",

--- a/Xplat/src/main/resources/assets/botania/lang/en_us.json
+++ b/Xplat/src/main/resources/assets/botania/lang/en_us.json
@@ -2962,7 +2962,7 @@
 
   "botania.entry.smeltRod": "Rod of the Molten Core",
   "botania.tagline.smeltRod": "A rod for smelting blocks",
-  "botania.page.smeltRod0": "The $(item)Rod of the Molten Core$(0) has the ability to focus heat drawn from the world's core. Focusing it (by holding right-click) at a block in the world that can be smelted into a different block will smelt it into that block.$(p)For example, $(item)Cobblestone$(0) will smelt into $(item)Stone$(0) and then into $(item)Smooth Stone$(0), $(item)Sand$(0) melts into $(item)Glass$(0), and so on.",
+  "botania.page.smeltRod0": "The $(item)Rod of the Molten Core$(0) has the ability to focus heat drawn from the world's core. Punching a block in the world that can be smelted into a different block will smelt it into that block.$(p)For example, $(item)Cobblestone$(0) will smelt into $(item)Stone$(0) and then into $(item)Smooth Stone$(0), $(item)Sand$(0) melts into $(item)Glass$(0), and so on.",
   "botania.page.smeltRod1": "No raid party required",
 
   "botania.entry.worldSeed": "World Seed",

--- a/web/changelog.md
+++ b/web/changelog.md
@@ -21,6 +21,7 @@ and start a new "Upcoming" section.
 * Add: Horn and Drum of the Wild can break moss carpet, with the option to add more blocks through a block tag
 * Change: Cellular blocks around the boundary of a Dandelifeon's simulation area are ignored, unless they belong to another active Dandelifeon (NEstoll)
 * Change: Charm of the Diva also supports charming or targeting neutral mobs that are angry at the player or attacking one of the player's tamed animals, and properly prevents the player's tamed animals from being affected or targeted by the charm
+* Change: Rod of the Molten Core now smelts blocks punched while holding it (similar to how the Rod of the Shifting Crust works)
 * Fix: Flight bar for Flügel Tiara no longer overlaps with the refilling air bubbles indicator or the mount health bar, if that uses more than one row
 * Fix: The Manaseer Monocle's flower radius indicator no longer jumps around if you are very far from the world origin, and should also not Z-fight with the binding radius indicator of luminizers anymore
 * Fix: The air bubble created by Bubbells no longer flickers with inflowing water

--- a/web/changelog.md
+++ b/web/changelog.md
@@ -19,6 +19,7 @@ and start a new "Upcoming" section.
 {% include changelog_header.html version="Upcoming" %}
 
 * Add: Horn and Drum of the Wild can break moss carpet, with the option to add more blocks through a block tag
+* Add: Rod of the Molten Core can now act as a portable furnace, providing in-inventory smelting
 * Change: Cellular blocks around the boundary of a Dandelifeon's simulation area are ignored, unless they belong to another active Dandelifeon (NEstoll)
 * Change: Charm of the Diva also supports charming or targeting neutral mobs that are angry at the player or attacking one of the player's tamed animals, and properly prevents the player's tamed animals from being affected or targeted by the charm
 * Change: Rod of the Molten Core now smelts blocks punched while holding it (similar to how the Rod of the Shifting Crust works)


### PR DESCRIPTION
Changes the Rod of the Molten Core to use punch rather than holding right click to smelt blocks. This both brings it in line with how the rod of the shifting crust works and improves its usability.