### PR TITLE
Bergamutes can occlude vibrations

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/mixin/VibrationSystemListenerMixin.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/VibrationSystemListenerMixin.java
@@ -1,0 +1,26 @@
+package vazkii.botania.mixin;
+
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.gameevent.vibrations.VibrationSystem;
+import net.minecraft.world.phys.Vec3;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import vazkii.botania.common.block.flower.functional.BergamuteBlockEntity;
+
+@Mixin(VibrationSystem.Listener.class)
+public class VibrationSystemListenerMixin {
+	/**
+	 * Check if any active Bergamutes are near the direct line of sight between a vibration source
+	 * and the vibration listener currently checking whether it can receive the vibration.
+	 */
+	@Inject(method = "isOccluded", at = @At("HEAD"), cancellable = true)
+	private static void checkBergamuteOcclusion(Level level, Vec3 sourcePos, Vec3 destPos, CallbackInfoReturnable<Boolean> cir) {
+		if (BergamuteBlockEntity.isBergamuteOccludingVibration(level, sourcePos, destPos)) {
+			cir.setReturnValue(true);
+		}
+	}
+}

--- a/Xplat/src/main/resources/assets/botania/lang/en_us.json
+++ b/Xplat/src/main/resources/assets/botania/lang/en_us.json
@@ -2414,7 +2414,7 @@
   "botania.entry.bergamute": "Bergamute",
   "botania.tagline.bergamute": "Absorbs sound",
   "botania.page.bergamute0": "Anyone who's ever attempted ranching knows of the cacophonous din emitted by herds of animals. Luckily, the $(item)Bergamute$(0) can deafen such dins.",
-  "botania.page.bergamute1": "The $(item)Bergamute$(0) absorbs sound energy emitted in a close radius around itself, converting it into trace amounts of mana and dispersing it harmlessly. It halves the volume of sounds within reach, the effect stacking with other nearby $(item)Bergamutes$(0).$(p)Additionally, $(l:tools/grass_horn)$(item)Horns$(0)$(/l) or $(l:devices/forest_drum)$(item)Drums$(0)$(/l) will not break blocks within its range.",
+  "botania.page.bergamute1": "The $(item)Bergamute$(0) absorbs sound energy emitted in a close radius around itself, converting it into trace amounts of mana and dispersing it harmlessly. It halves the volume of sounds within reach, the effect stacking with other nearby $(item)Bergamutes$(0).$(p)Additionally, $(l:tools/grass_horn)$(item)Horns$(0)$(/l) or $(l:devices/forest_drum)$(item)Drums$(0)$(/l) will not break blocks within its range, and vibrations passing through its area of effect are muffled.",
   "botania.page.bergamute2": "Deaf to All but the Song",
 
   "botania.entry.gIntro": "Generating Flora",

--- a/Xplat/src/main/resources/botania_xplat.mixins.json
+++ b/Xplat/src/main/resources/botania_xplat.mixins.json
@@ -53,6 +53,7 @@
     "StatsAccessor",
     "TextureSlotAccessor",
     "ThrowableProjectileMixin",
+    "VibrationSystemListenerMixin",
     "WitherEntityAccessor"
   ],
   "client": [

--- a/web/changelog.md
+++ b/web/changelog.md
@@ -19,6 +19,7 @@ and start a new "Upcoming" section.
 {% include changelog_header.html version="Upcoming" %}
 
 * Add: Horn and Drum of the Wild can break moss carpet, with the option to add more blocks through a block tag
+* Add: Bergamute occludes vibrations within its range 
 * Change: Cellular blocks around the boundary of a Dandelifeon's simulation area are ignored, unless they belong to another active Dandelifeon (NEstoll)
 * Change: Charm of the Diva also supports charming or targeting neutral mobs that are angry at the player or attacking one of the player's tamed animals, and properly prevents the player's tamed animals from being affected or targeted by the charm
 * Change: Dandelifeon recipe also requires a redstone root (zacharybarbanell)


### PR DESCRIPTION
Vibration source and destination positions are rounded to the center of the respective blocks (same as wool occlusion checks). If the line drawn between the two positions intersects the Bergamute's spherical area of effect, the vibration is occluded.