### PR TITLE
Allow avatar to use rod of the depths

### DIFF
--- a/Fabric/src/main/java/vazkii/botania/fabric/FabricCommonInitializer.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/FabricCommonInitializer.java
@@ -278,6 +278,7 @@ public class FabricCommonInitializer implements ModInitializer {
 				BotaniaItems.waterBowl);
 
 		BotaniaFabricCapabilities.AVATAR_WIELDABLE.registerForItems((stack, c) -> new LandsRodItem.AvatarBehavior(), BotaniaItems.dirtRod);
+		BotaniaFabricCapabilities.AVATAR_WIELDABLE.registerForItems((stack, c) -> new DepthsRodItem.AvatarBehavior(), BotaniaItems.cobbleRod);
 		BotaniaFabricCapabilities.AVATAR_WIELDABLE.registerForItems((stack, c) -> new PlentifulMantleRodItem.AvatarBehavior(), BotaniaItems.diviningRod);
 		BotaniaFabricCapabilities.AVATAR_WIELDABLE.registerForItems((stack, c) -> new HellsRodItem.AvatarBehavior(), BotaniaItems.fireRod);
 		BotaniaFabricCapabilities.AVATAR_WIELDABLE.registerForItems((stack, c) -> new UnstableReservoirRodItem.AvatarBehavior(), BotaniaItems.missileRod);

--- a/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
+++ b/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
@@ -465,6 +465,7 @@ public class ForgeCommonInitializer {
 	// Needs to be lazy since items aren't initialized yet
 	private static final Supplier<Map<Item, Function<ItemStack, AvatarWieldable>>> AVATAR_WIELDABLES = Suppliers.memoize(() -> Map.of(
 			BotaniaItems.dirtRod, s -> new LandsRodItem.AvatarBehavior(),
+			BotaniaItems.cobbleRod, s -> new DepthsRodItem.AvatarBehavior(),
 			BotaniaItems.diviningRod, s -> new PlentifulMantleRodItem.AvatarBehavior(),
 			BotaniaItems.fireRod, s -> new HellsRodItem.AvatarBehavior(),
 			BotaniaItems.missileRod, s -> new UnstableReservoirRodItem.AvatarBehavior(),

--- a/Xplat/src/main/java/vazkii/botania/common/item/rod/DepthsRodItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/rod/DepthsRodItem.java
@@ -8,20 +8,32 @@
  */
 package vazkii.botania.common.item.rod;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 
+import net.minecraft.world.level.block.LevelEvent;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
 
+import vazkii.botania.api.block.Avatar;
+import vazkii.botania.api.item.AvatarWieldable;
 import vazkii.botania.api.item.BlockProvider;
 import vazkii.botania.api.mana.ManaItemHandler;
+import vazkii.botania.api.mana.ManaReceiver;
+import vazkii.botania.client.lib.ResourcesLib;
+import vazkii.botania.xplat.XplatAbstractions;
 
 public class DepthsRodItem extends Item {
+	private static final ResourceLocation avatarOverlay = new ResourceLocation(ResourcesLib.MODEL_AVATAR_DIRT);
 
 	public static final int COST = 150;
 
@@ -51,6 +63,29 @@ public class DepthsRodItem extends Item {
 				return ManaItemHandler.instance().getInvocationCountForTool(requestor, player, COST);
 			}
 			return 0;
+		}
+	}
+
+	public static class AvatarBehavior implements AvatarWieldable {
+		@Override
+		public void onAvatarUpdate(Avatar tile) {
+			BlockEntity te = (BlockEntity) tile;
+			Level world = te.getLevel();
+			ManaReceiver receiver = XplatAbstractions.INSTANCE.findManaReceiver(world, te.getBlockPos(), te.getBlockState(), te, null);
+			if (!world.isClientSide && receiver.getCurrentMana() >= COST && tile.getElapsedFunctionalTicks() % 4 == 0 && world.random.nextInt(8) == 0 && tile.isEnabled()) {
+				BlockPos pos = te.getBlockPos().relative(tile.getAvatarFacing());
+				BlockState state = world.getBlockState(pos);
+				if (state.isAir()) {
+					world.setBlockAndUpdate(pos, Blocks.COBBLESTONE.defaultBlockState());
+					world.levelEvent(LevelEvent.PARTICLES_DESTROY_BLOCK, pos, Block.getId(Blocks.COBBLESTONE.defaultBlockState()));
+					receiver.receiveMana(-COST);
+				}
+			}
+		}
+
+		@Override
+		public ResourceLocation getOverlayResource(Avatar tile) {
+			return avatarOverlay;
 		}
 	}
 


### PR DESCRIPTION
Allow for living wood avatars to use the rod of the depths. Currently uses the MODEL_AVATAR_DIRT, because I lack the skills to make a cobble version