### PR TITLE
Floral obedience stick can unbind flowers

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/api/block_entity/BindableSpecialFlowerBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/api/block_entity/BindableSpecialFlowerBlockEntity.java
@@ -15,8 +15,10 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
@@ -24,10 +26,12 @@ import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.Nullable;
 
 import vazkii.botania.api.BotaniaAPIClient;
+import vazkii.botania.api.block.Bound;
 import vazkii.botania.api.block.WandBindable;
 import vazkii.botania.api.block.WandHUD;
 import vazkii.botania.client.core.helper.RenderHelper;
 import vazkii.botania.common.helper.MathHelper;
+import vazkii.botania.common.item.BotaniaItems;
 
 import java.util.Objects;
 
@@ -63,7 +67,9 @@ public abstract class BindableSpecialFlowerBlockEntity<T> extends SpecialFlowerB
 
 		//First time the flower has been placed. This is the best time to check it; /setblock and friends don't call
 		//the typical setPlacedBy method that player-placements do.
-		if (ticksExisted == 1 && !level.isClientSide) {
+		if (Bound.UNBOUND_POS.equals(bindingPos)) {
+			setBindingPos(null);
+		} else if (ticksExisted == 1 && !level.isClientSide) {
 			//Situations to consider:
 			// the flower has been placed in the void, and there is nothing for it to bind to;
 			// the flower has been placed next to a bind target, and I want to automatically bind to it;
@@ -73,6 +79,14 @@ public abstract class BindableSpecialFlowerBlockEntity<T> extends SpecialFlowerB
 				setBindingPos(findClosestTarget());
 			}
 		}
+	}
+
+	@Override
+	public void setPlacedBy(Level level, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack stack) {
+		if (placer != null && placer.isHolding(BotaniaItems.obedienceStick)) {
+			setBindingPos(Bound.UNBOUND_POS);
+		}
+		super.setPlacedBy(level, pos, state, placer, stack);
 	}
 
 	public @Nullable BlockPos getBindingPos() {

--- a/Xplat/src/main/java/vazkii/botania/common/item/FloralObedienceStickItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/FloralObedienceStickItem.java
@@ -60,6 +60,11 @@ public class FloralObedienceStickItem extends Item {
 
 			return true;
 		}
+		BlockEntity tile = world.getBlockEntity(pos);
+		if (tile instanceof BindableSpecialFlowerBlockEntity<?>bindableFlower) {
+			bindableFlower.setBindingPos(null);
+			return true;
+		}
 
 		return false;
 	}

--- a/Xplat/src/main/resources/assets/botania/lang/en_us.json
+++ b/Xplat/src/main/resources/assets/botania/lang/en_us.json
@@ -3013,6 +3013,7 @@
   "botania.entry.obedienceStick": "Floral Obedience Stick",
   "botania.tagline.obedienceStick": "Binding flowers to a location en masse",
   "botania.page.obedienceStick0": "For some inexplicable reason, a piece of $(item)Manasteel$(0) attached to some $(item)Livingwood Twigs$(0) is a thing flowers $(o)pay attention to$().$(p)When used on a $(l:mana/spreader)$(item)Mana Spreader$(0)$(/l) or $(l:mana/pool)$(item)Mana Pool$(0)$(/l), this tool (dubbed the $(item)Floral Obedience Stick$(0)) binds all nearby $(thing)Generating$(0) or $(thing)Functional$(0) flowers, respectively, to that block.$(p)A $(item)Dispenser$(0) can also use a $(item)Floral Obedience Stick$(0).",
+  "botania.page.obedienceStick_unbind": "On rare occasions it might not be desirable to have a flower pull mana from a nearby pool or output its mana to any spreader.$(p)Holding a $(item)Floral Obedience Stick$(0) while placing a flower will prevent it from automatically binding to a nearby spreader or pool. If the flower is already placed it can be unbound by using a $(item)Floral Obedience Stick$(0) on it, either manually or via a $(item)Dispenser$(0).",
   "botania.page.obedienceStick1": "Generate, or else!",
 
   "botania.entry.slimeBottle": "Slime in a Bottle",

--- a/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/tools/obedience_stick.json
+++ b/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/tools/obedience_stick.json
@@ -10,6 +10,10 @@
       "text": "botania.page.obedienceStick0"
     },
     {
+      "type": "text",
+      "text": "botania.page.obedienceStick_unbind"
+    },
+    {
       "type": "crafting",
       "text": "botania.page.obedienceStick1",
       "recipe": "botania:obedience_stick"


### PR DESCRIPTION
- using the stick on a flower unbinds it (including use via dispenser)
- holding an obedience stick while placing a flower skips its auto-binding