### PR TITLE
Workaround for floating flowers in multiblock visualization

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/client/patchouli/PatchouliUtils.java
+++ b/Xplat/src/main/java/vazkii/botania/client/patchouli/PatchouliUtils.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 public class PatchouliUtils {
 	private static boolean crafttweakerInfoNote = false;
+	private static boolean inVisualizer;
 
 	/**
 	 * Gets a recipe of a specified type and ID, and replaces the namespace
@@ -119,5 +120,17 @@ public class PatchouliUtils {
 	 */
 	public static IVariable interweaveIngredients(List<Ingredient> ingredients) {
 		return interweaveIngredients(ingredients, ingredients.stream().mapToInt(ingr -> ingr.getItems().length).max().orElse(1));
+	}
+
+	/**
+	 * Workaround for Patchouli limitation - Allow block entity-rendered blocks to detect being rendered in
+	 * a multiblock visualization and switch to block model rendering to actually be visible.
+	 */
+	public static boolean isInVisualizer() {
+		return inVisualizer;
+	}
+
+	public static void setInVisualizer(boolean inVisualization) {
+		PatchouliUtils.inVisualizer = inVisualization;
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/block/decor/FloatingFlowerBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/decor/FloatingFlowerBlock.java
@@ -33,6 +33,7 @@ import vazkii.botania.api.block.FloatingFlower.IslandType;
 import vazkii.botania.api.block.FloatingFlowerProvider;
 import vazkii.botania.api.internal.VanillaPacketDispatcher;
 import vazkii.botania.client.fx.SparkleParticleData;
+import vazkii.botania.client.patchouli.PatchouliUtils;
 import vazkii.botania.common.block.BotaniaWaterloggedBlock;
 import vazkii.botania.common.block.block_entity.FloatingFlowerBlockEntity;
 import vazkii.botania.common.item.FloatingFlowerVariant;
@@ -62,7 +63,7 @@ public class FloatingFlowerBlock extends BotaniaWaterloggedBlock implements Enti
 		if (!XplatAbstractions.INSTANCE.isPhysicalClient()) {
 			return RenderShape.ENTITYBLOCK_ANIMATED;
 		}
-		return BotaniaConfig.client().staticFloaters() ? RenderShape.MODEL : RenderShape.ENTITYBLOCK_ANIMATED;
+		return BotaniaConfig.client().staticFloaters() || PatchouliUtils.isInVisualizer() ? RenderShape.MODEL : RenderShape.ENTITYBLOCK_ANIMATED;
 	}
 
 	@Override

--- a/Xplat/src/main/java/vazkii/botania/mixin/client/BlockRenderDispatcherMixin.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/client/BlockRenderDispatcherMixin.java
@@ -1,0 +1,31 @@
+package vazkii.botania.mixin.client;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.block.BlockRenderDispatcher;
+import net.minecraft.world.level.block.state.BlockState;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import vazkii.botania.client.patchouli.PatchouliUtils;
+
+/**
+ * Hack for Patchouli visualizer rendering of floating flowers.
+ * TODO: Check if new Patchouli versions can handle rendering non-vanilla block entities in multiblock visualizations.
+ */
+@Mixin(BlockRenderDispatcher.class)
+public class BlockRenderDispatcherMixin {
+	@Inject(method = "renderSingleBlock", at = @At("HEAD"))
+	void enterRenderSingleBlock(BlockState state, PoseStack poseStack, MultiBufferSource buffer, int packedLight, int packedOverlay, CallbackInfo ci) {
+		PatchouliUtils.setInVisualizer(true);
+	}
+
+	@Inject(method = "renderSingleBlock", at = @At("RETURN"))
+	void exitRenderSingleBlock(BlockState state, PoseStack poseStack, MultiBufferSource buffer, int packedLight, int packedOverlay, CallbackInfo ci) {
+		PatchouliUtils.setInVisualizer(false);
+	}
+}

--- a/Xplat/src/main/resources/botania_xplat.mixins.json
+++ b/Xplat/src/main/resources/botania_xplat.mixins.json
@@ -59,6 +59,7 @@
   ],
   "client": [
     "client.AbstractContainerScreenAccessor",
+    "client.BlockRenderDispatcherMixin",
     "client.ClientLevelDataMixin",
     "client.ItemInHandRendererMixin",
     "client.ItemRendererAccessor",


### PR DESCRIPTION
"Fix" for #4181, by switching floating flowers to block model render shape when displaying them as part of a multiblock visualization. (As if setting the simpleFloaters client option, but only for individual "virtual" blocks.) Potentially also fixes other uses of that particular way to render blocks, such as the block held by an enderman.