### PR TITLE
xplat: Switch from VanillaGradle to minivan

### DIFF
--- a/Xplat/build.gradle
+++ b/Xplat/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('org.spongepowered.gradle.vanilla') version '0.2.1-SNAPSHOT'
+    id('agency.highlysuspect.minivan') version '0.5-SNAPSHOT'
 }
 
 archivesBaseName = "${mod_name}-xplat"
@@ -9,7 +9,7 @@ if (System.getenv().RELEASE_MODE == null) {
     version += '-SNAPSHOT'
 }
 
-minecraft {
+minivan {
     version(minecraft_version)
     accessWideners 'src/main/resources/botania_xplat.accesswidener'
 }
@@ -45,6 +45,8 @@ dependencies {
 
     compileOnly "mezz.jei:jei-1.20.1-common-api:15.2.0.27"
     compileOnly "dev.emi:emi-xplat-mojmap:1.0.12+${minecraft_version}:api"
+
+    compileOnly "org.jetbrains:annotations:24.0.1"
 
     // annotationProcessor 'com.blamejared.crafttweaker:Crafttweaker_Annotation_Processors-1.18.2:2.0.0.123'
     // annotationProcessor 'com.blamejared.crafttweaker:CraftTweaker-common-1.18.2:9.1.123'

--- a/Xplat/build.gradle
+++ b/Xplat/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id('java')
-    id('agency.highlysuspect.minivan') version '0.5-SNAPSHOT'
+    id('agency.highlysuspect.minivan') version '0.5'
 }
 
 archivesBaseName = "${mod_name}-xplat"

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,10 +11,23 @@ pluginManagement {
         maven {
             name = 'Sponge Snapshots'
             url = 'https://repo.spongepowered.org/repository/maven-public/'
+        }
+        maven {
+            name = 'Sleeping Town'
+            url = 'https://repo.sleeping.town/'
+            content {
+                includeGroup 'agency.highlysuspect'
+                includeGroup 'agency.highlysuspect.minivan'
+            }
+        }
         
         gradlePluginPortal()
-        }
     }
 }
+
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
 rootProject.name = 'Botania'
 include("Xplat", "Fabric", "Forge")


### PR DESCRIPTION
[`minivan`](https://github.com/CrackedPolishedBlackstoneBricksMC/minivan) is my Gradle plugin that acts like VanillaGradle. It is written with pretty boring straightforward code, makes no attempt to download a copy of the Minecraft assets or anything else necessary to support a `runClient`, and doesn't use any IntelliJ "task activations", so it's a good bit lighter weight.

Interesting: When switching, I had to manually add a dependency on jetbrains annotations. Maybe vanillagradle did that?

Also adds the foojay-resolver-convention plugin, b/c apparently I don't have Java 17 installed in a place where Gradle can find it. This is a well-known Gradle 8 upgrade woe wrt. the toolchains feature.