### PR TITLE
Don't output a comparator signal for flowers that don't actually have one

### DIFF
--- a/Fabric/src/main/java/vazkii/botania/fabric/block/FabricSpecialFlowerBlock.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/block/FabricSpecialFlowerBlock.java
@@ -42,10 +42,16 @@ import java.util.function.Supplier;
 public class FabricSpecialFlowerBlock extends FlowerBlock implements EntityBlock {
 	private static final VoxelShape SHAPE = box(4.8, 0, 4.8, 12.8, 16, 12.8);
 	private final Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> blockEntityType;
+	private final boolean hasComparatorOutput;
 
 	public FabricSpecialFlowerBlock(MobEffect stewEffect, int stewDuration, Properties props, Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> blockEntityType) {
+		this(stewEffect, stewDuration, props, blockEntityType, false);
+	}
+
+	public FabricSpecialFlowerBlock(MobEffect stewEffect, int stewDuration, Properties props, Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> blockEntityType, boolean hasComparatorOutput) {
 		super(stewEffect, stewDuration, props);
 		this.blockEntityType = blockEntityType;
+		this.hasComparatorOutput = hasComparatorOutput;
 	}
 
 	@NotNull
@@ -86,13 +92,21 @@ public class FabricSpecialFlowerBlock extends FlowerBlock implements EntityBlock
 	}
 
 	@Override
+	public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean movedByPiston) {
+		if (hasComparatorOutput && !newState.hasAnalogOutputSignal()) {
+			level.updateNeighbourForOutputSignal(pos, newState.getBlock());
+		}
+		super.onRemove(state, level, pos, newState, movedByPiston);
+	}
+
+	@Override
 	public void animateTick(BlockState state, Level world, BlockPos pos, RandomSource rand) {
 		redstoneParticlesIfPowered(state, world, pos, rand);
 	}
 
 	@Override
 	public boolean hasAnalogOutputSignal(BlockState bs) {
-		return true;
+		return hasComparatorOutput;
 	}
 
 	@Override

--- a/Fabric/src/main/java/vazkii/botania/fabric/xplat/FabricXplatImpl.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/xplat/FabricXplatImpl.java
@@ -454,8 +454,8 @@ public class FabricXplatImpl implements XplatAbstractions {
 	}
 
 	@Override
-	public FlowerBlock createSpecialFlowerBlock(MobEffect effect, int effectDuration, BlockBehaviour.Properties props, Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> beType) {
-		return new FabricSpecialFlowerBlock(effect, effectDuration, props, beType);
+	public FlowerBlock createSpecialFlowerBlock(MobEffect effect, int effectDuration, BlockBehaviour.Properties props, Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> beType, boolean hasComparatorOutput) {
+		return new FabricSpecialFlowerBlock(effect, effectDuration, props, beType, hasComparatorOutput);
 	}
 
 	@Override

--- a/Forge/src/main/java/vazkii/botania/forge/block/ForgeSpecialFlowerBlock.java
+++ b/Forge/src/main/java/vazkii/botania/forge/block/ForgeSpecialFlowerBlock.java
@@ -32,12 +32,18 @@ import java.util.function.Supplier;
 public class ForgeSpecialFlowerBlock extends FlowerBlock implements EntityBlock {
 	private static final VoxelShape SHAPE = box(4.8, 0, 4.8, 12.8, 16, 12.8);
 	private final Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> blockEntityType;
+	private final boolean hasComparatorOutput;
 
 	public ForgeSpecialFlowerBlock(MobEffect stewEffect, int stewDuration, Properties props, Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> blockEntityType) {
+		this(stewEffect, stewDuration, props, blockEntityType, false);
+	}
+
+	public ForgeSpecialFlowerBlock(MobEffect stewEffect, int stewDuration, Properties props, Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> blockEntityType, boolean hasComparatorOutput) {
 		super(/* the only godforsaken reason why this class needs to be duplicated for each loader
 				is so that we can add a "() ->" here. Amazing. */
 				() -> stewEffect, stewDuration, props);
 		this.blockEntityType = blockEntityType;
+		this.hasComparatorOutput = hasComparatorOutput;
 	}
 
 	@NotNull
@@ -78,13 +84,21 @@ public class ForgeSpecialFlowerBlock extends FlowerBlock implements EntityBlock 
 	}
 
 	@Override
+	public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean movedByPiston) {
+		if (hasComparatorOutput && !newState.hasAnalogOutputSignal()) {
+			level.updateNeighbourForOutputSignal(pos, newState.getBlock());
+		}
+		super.onRemove(state, level, pos, newState, movedByPiston);
+	}
+
+	@Override
 	public void animateTick(BlockState state, Level world, BlockPos pos, RandomSource rand) {
 		FloatingSpecialFlowerBlock.redstoneParticlesIfPowered(state, world, pos, rand);
 	}
 
 	@Override
 	public boolean hasAnalogOutputSignal(BlockState bs) {
-		return true;
+		return hasComparatorOutput;
 	}
 
 	@Override

--- a/Forge/src/main/java/vazkii/botania/forge/xplat/ForgeXplatImpl.java
+++ b/Forge/src/main/java/vazkii/botania/forge/xplat/ForgeXplatImpl.java
@@ -457,8 +457,9 @@ public class ForgeXplatImpl implements XplatAbstractions {
 	@Override
 	public FlowerBlock createSpecialFlowerBlock(MobEffect effect, int effectDuration,
 			BlockBehaviour.Properties props,
-			Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> beType) {
-		return new ForgeSpecialFlowerBlock(effect, effectDuration, props, beType);
+			Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> beType,
+			boolean hasComparatorOutput) {
+		return new ForgeSpecialFlowerBlock(effect, effectDuration, props, beType, hasComparatorOutput);
 	}
 
 	@Override

--- a/Xplat/src/main/java/vazkii/botania/common/block/BotaniaFlowerBlocks.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/BotaniaFlowerBlocks.java
@@ -59,8 +59,8 @@ public class BotaniaFlowerBlocks {
 	public static final Block endoflameFloating = new FloatingSpecialFlowerBlock(FLOATING_PROPS, () -> BotaniaFlowerBlocks.ENDOFLAME);
 	public static final Block endoflamePotted = BotaniaBlocks.flowerPot(endoflame, 0);
 
-	public static final Block thermalily = createSpecialFlowerBlock(MobEffects.FIRE_RESISTANCE, 120, FLOWER_PROPS, () -> BotaniaFlowerBlocks.THERMALILY);
-	public static final Block thermalilyFloating = new FloatingSpecialFlowerBlock(FLOATING_PROPS, () -> BotaniaFlowerBlocks.THERMALILY);
+	public static final Block thermalily = createSpecialFlowerBlock(MobEffects.FIRE_RESISTANCE, 120, FLOWER_PROPS, () -> BotaniaFlowerBlocks.THERMALILY, true);
+	public static final Block thermalilyFloating = new FloatingSpecialFlowerBlock(FLOATING_PROPS, () -> BotaniaFlowerBlocks.THERMALILY, true);
 	public static final Block thermalilyPotted = BotaniaBlocks.flowerPot(thermalily, 0);
 
 	public static final Block rosaArcana = createSpecialFlowerBlock(MobEffects.LUCK, 64, FLOWER_PROPS, () -> BotaniaFlowerBlocks.ROSA_ARCANA);
@@ -315,7 +315,16 @@ public class BotaniaFlowerBlocks {
 			BlockBehaviour.Properties props,
 			Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> beType) {
 		return XplatAbstractions.INSTANCE.createSpecialFlowerBlock(
-				effect, effectDuration, props, beType
+				effect, effectDuration, props, beType);
+	}
+
+	private static FlowerBlock createSpecialFlowerBlock(
+			MobEffect effect, int effectDuration,
+			BlockBehaviour.Properties props,
+			Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> beType,
+			boolean hasComparatorOutput) {
+		return XplatAbstractions.INSTANCE.createSpecialFlowerBlock(
+				effect, effectDuration, props, beType, hasComparatorOutput
 		);
 	}
 

--- a/Xplat/src/main/java/vazkii/botania/common/block/FloatingSpecialFlowerBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/FloatingSpecialFlowerBlock.java
@@ -33,10 +33,19 @@ import java.util.function.Supplier;
 
 public class FloatingSpecialFlowerBlock extends FloatingFlowerBlock {
 	private final Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> blockEntityType;
+	private final boolean hasComparatorOutput;
 
-	public FloatingSpecialFlowerBlock(Properties props, Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> blockEntityType) {
+	public FloatingSpecialFlowerBlock(Properties props,
+			Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> blockEntityType) {
+		this(props, blockEntityType, false);
+	}
+
+	public FloatingSpecialFlowerBlock(Properties props,
+			Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> blockEntityType,
+			boolean hasComparatorOutput) {
 		super(DyeColor.WHITE, props);
 		this.blockEntityType = blockEntityType;
+		this.hasComparatorOutput = hasComparatorOutput;
 	}
 
 	@Override
@@ -65,6 +74,14 @@ public class FloatingSpecialFlowerBlock extends FloatingFlowerBlock {
 		((SpecialFlowerBlockEntity) world.getBlockEntity(pos)).setPlacedBy(world, pos, state, entity, stack);
 	}
 
+	@Override
+	public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean movedByPiston) {
+		if (hasComparatorOutput && !newState.hasAnalogOutputSignal()) {
+			level.updateNeighbourForOutputSignal(pos, newState.getBlock());
+		}
+		super.onRemove(state, level, pos, newState, movedByPiston);
+	}
+
 	@NotNull
 	@Override
 	public BlockEntity newBlockEntity(@NotNull BlockPos pos, @NotNull BlockState state) {
@@ -81,7 +98,7 @@ public class FloatingSpecialFlowerBlock extends FloatingFlowerBlock {
 
 	@Override
 	public boolean hasAnalogOutputSignal(BlockState bs) {
-		return true;
+		return hasComparatorOutput;
 	}
 
 	@Override

--- a/Xplat/src/main/java/vazkii/botania/xplat/XplatAbstractions.java
+++ b/Xplat/src/main/java/vazkii/botania/xplat/XplatAbstractions.java
@@ -163,9 +163,17 @@ public interface XplatAbstractions {
 
 	// Registrations
 	boolean isSpecialFlowerBlock(Block b);
+
+	default FlowerBlock createSpecialFlowerBlock(MobEffect effect, int effectDuration,
+			BlockBehaviour.Properties props,
+			Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> beType) {
+		return createSpecialFlowerBlock(effect, effectDuration, props, beType, false);
+	}
+
 	FlowerBlock createSpecialFlowerBlock(MobEffect effect, int effectDuration,
 			BlockBehaviour.Properties props,
-			Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> beType);
+			Supplier<BlockEntityType<? extends SpecialFlowerBlockEntity>> beType,
+			boolean hasComparatorOutput);
 	<T extends BlockEntity> BlockEntityType<T> createBlockEntityType(BiFunction<BlockPos, BlockState, T> func, Block... blocks);
 	void registerReloadListener(PackType type, ResourceLocation id, PreparableReloadListener listener);
 	Item.Properties defaultItemBuilder();


### PR DESCRIPTION
- fixes #4741 (non-Thermalily special/floating flowers having comparator output zero)
- also fixes breaking a Thermalily not resetting a comparator output that was read through a solid block