### PR TITLE
Separation of AncientWillContainer and TerrasteelHelmItem

### DIFF
--- a/Fabric/src/main/java/vazkii/botania/fabric/integration/rei/BotaniaREIPlugin.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/integration/rei/BotaniaREIPlugin.java
@@ -151,14 +151,13 @@ public class BotaniaREIPlugin implements REIClientPlugin {
 		ImmutableList.Builder<EntryIngredient> input = ImmutableList.builder();
 		ImmutableList.Builder<EntryStack<ItemStack>> output = ImmutableList.builder();
 		Set<ItemStack> wills = ImmutableSet.of(new ItemStack(BotaniaItems.ancientWillAhrim), new ItemStack(BotaniaItems.ancientWillDharok), new ItemStack(BotaniaItems.ancientWillGuthan), new ItemStack(BotaniaItems.ancientWillKaril), new ItemStack(BotaniaItems.ancientWillTorag), new ItemStack(BotaniaItems.ancientWillVerac));
-		AncientWillContainer container = (AncientWillContainer) BotaniaItems.terrasteelHelm;
 
 		ItemStack helmet = new ItemStack(BotaniaItems.terrasteelHelm);
 		input.add(EntryIngredients.of(helmet));
 		input.add(EntryIngredients.ofItemStacks(wills));
 		for (ItemStack will : wills) {
 			ItemStack copy = helmet.copy();
-			container.addAncientWill(copy, ((AncientWillItem) will.getItem()).type);
+			AncientWillContainer.addAncientWill(copy, ((AncientWillItem) will.getItem()).type);
 			output.add(EntryStacks.of(copy));
 		}
 		helper.add(new DefaultCustomDisplay(null, input.build(), Collections.singletonList(EntryIngredient.of(output.build()))));

--- a/Fabric/src/main/java/vazkii/botania/fabric/mixin/PlayerFabricMixin.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/mixin/PlayerFabricMixin.java
@@ -33,6 +33,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
+import vazkii.botania.api.item.AncientWillContainer;
 import vazkii.botania.common.PlayerAccess;
 import vazkii.botania.common.handler.EquipmentHandler;
 import vazkii.botania.common.handler.PixieHandler;
@@ -123,7 +124,7 @@ public abstract class PlayerFabricMixin extends LivingEntity {
 	private float onCritMul(float f, Entity target) {
 		if (target instanceof LivingEntity living) {
 			((PlayerAccess) this).botania$setCritTarget(living);
-			return f * TerrasteelHelmItem.getCritDamageMult((Player) (Object) this);
+			return f * AncientWillContainer.getCritDamageMult((Player) (Object) this);
 		}
 		return f;
 	}

--- a/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
+++ b/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
@@ -20,6 +20,7 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.EnderMan;
@@ -65,10 +66,7 @@ import vazkii.botania.api.BotaniaForgeCapabilities;
 import vazkii.botania.api.BotaniaRegistries;
 import vazkii.botania.api.block.HornHarvestable;
 import vazkii.botania.api.block.Wandable;
-import vazkii.botania.api.item.AvatarWieldable;
-import vazkii.botania.api.item.BlockProvider;
-import vazkii.botania.api.item.CoordBoundItem;
-import vazkii.botania.api.item.Relic;
+import vazkii.botania.api.item.*;
 import vazkii.botania.api.mana.*;
 import vazkii.botania.api.mana.spark.SparkAttachable;
 import vazkii.botania.client.fx.BotaniaParticles;
@@ -446,11 +444,11 @@ public class ForgeCommonInitializer {
 				if (e.getEntity().level().isClientSide
 						|| result == Event.Result.DENY
 						|| result == Event.Result.DEFAULT && !e.isVanillaCritical()
-						|| !TerrasteelHelmItem.hasTerraArmorSet(e.getEntity())
+						|| !(e.getEntity().getItemBySlot(EquipmentSlot.HEAD).getItem() instanceof AncientWillContainer awc && awc.hasFullArmorSet(e.getEntity()))
 						|| !(e.getTarget() instanceof LivingEntity target)) {
 					return;
 				}
-				e.setDamageModifier(e.getDamageModifier() * TerrasteelHelmItem.getCritDamageMult(e.getEntity()));
+				e.setDamageModifier(e.getDamageModifier() * AncientWillContainer.getCritDamageMult(e.getEntity()));
 				((PlayerAccess) e.getEntity()).botania$setCritTarget(target);
 			});
 

--- a/Xplat/src/main/java/vazkii/botania/api/item/AncientWillContainer.java
+++ b/Xplat/src/main/java/vazkii/botania/api/item/AncientWillContainer.java
@@ -8,13 +8,32 @@
  */
 package vazkii.botania.api.item;
 
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import vazkii.botania.api.mana.ManaItemHandler;
+import vazkii.botania.common.BotaniaDamageTypes;
+import vazkii.botania.common.helper.ItemNBTHelper;
+import vazkii.botania.common.item.equipment.armor.terrasteel.TerrasteelHelmItem;
+
+import java.util.List;
+import java.util.Locale;
 
 /**
  * An item that implements this can have Ancient Wills
  * crafted onto it.
  */
 public interface AncientWillContainer {
+
+	String TAG_ANCIENT_WILL = "AncientWill";
 	enum AncientWillType {
 		AHRIM,
 		DHAROK,
@@ -24,8 +43,81 @@ public interface AncientWillContainer {
 		KARIL
 	}
 
-	void addAncientWill(ItemStack stack, AncientWillType will);
+	static void addAncientWill(ItemStack stack, AncientWillType will) {
+		ItemNBTHelper.setBoolean(stack, TAG_ANCIENT_WILL + "_" + will.name().toLowerCase(Locale.ROOT), true);
+	}
 
-	boolean hasAncientWill(ItemStack stack, AncientWillType will);
+	static boolean hasAncientWill(ItemStack stack, AncientWillType will) {
+		return ItemNBTHelper.getBoolean(stack, TAG_ANCIENT_WILL + "_" + will.name().toLowerCase(Locale.ROOT), false);
+	}
 
+	static float getCritDamageMult(Player player) {
+		ItemStack stack = player.getItemBySlot(EquipmentSlot.HEAD);
+		if (stack.getItem() instanceof AncientWillContainer awc && awc.hasFullArmorSet(player)) {
+			if (!stack.isEmpty() && AncientWillContainer.hasAncientWill(stack, AncientWillType.DHAROK)) {
+				return 1.0F + (1.0F - player.getHealth() / player.getMaxHealth()) * 0.5F;
+			}
+		}
+
+		return 1.0F;
+	}
+
+	static boolean hasAnyWill(ItemStack stack) {
+		for (AncientWillType type : AncientWillType.values()) {
+			if (AncientWillContainer.hasAncientWill(stack, type)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	static DamageSource onEntityAttacked(DamageSource source, float amount, Player player, LivingEntity entity) {
+		ItemStack stack = player.getItemBySlot(EquipmentSlot.HEAD);
+		if (stack.getItem() instanceof AncientWillContainer awc && awc.hasFullArmorSet(player)) {
+			if (AncientWillContainer.hasAncientWill(stack, AncientWillType.AHRIM)) {
+				entity.addEffect(new MobEffectInstance(MobEffects.WEAKNESS, 20, 1));
+			}
+
+			if (AncientWillContainer.hasAncientWill(stack, AncientWillType.GUTHAN)) {
+				player.heal(amount * 0.25F);
+			}
+
+			if (AncientWillContainer.hasAncientWill(stack, AncientWillType.TORAG)) {
+				entity.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SLOWDOWN, 60, 1));
+			}
+
+			if (AncientWillContainer.hasAncientWill(stack, AncientWillType.VERAC)) {
+				source = BotaniaDamageTypes.Sources.playerAttackArmorPiercing(player.level().registryAccess(), player);
+			}
+
+			if (AncientWillContainer.hasAncientWill(stack, AncientWillType.KARIL)) {
+				entity.addEffect(new MobEffectInstance(MobEffects.WITHER, 60, 1));
+			}
+		}
+
+		return source;
+	}
+
+	static void addAncientWillDescription(ItemStack stack, List<Component> list){
+		for (AncientWillType type : AncientWillType.values()) {
+			if (hasAncientWill(stack, type)) {
+				list.add(Component.translatable("botania.armorset.will_" + type.name().toLowerCase(Locale.ROOT) + ".desc").withStyle(ChatFormatting.GRAY));
+			}
+		}
+	}
+
+	static void ancientWillInventoryTick(ItemStack stack, Level world, Entity entity){
+		if (!world.isClientSide && entity instanceof Player player && player.getInventory().armor.contains(stack) && stack.getItem() instanceof AncientWillContainer awc && awc.hasFullArmorSet(player)) {
+			int food = player.getFoodData().getFoodLevel();
+			if (food > 0 && food < 18 && player.isHurt() && player.tickCount % 80 == 0) {
+				player.heal(1F);
+			}
+			if (player.tickCount % 10 == 0) {
+				ManaItemHandler.instance().dispatchManaExact(stack, player, 10, true);
+			}
+		}
+	}
+
+	boolean hasFullArmorSet(Player player);
 }

--- a/Xplat/src/main/java/vazkii/botania/client/integration/emi/AncientWillEmiRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/emi/AncientWillEmiRecipe.java
@@ -39,7 +39,7 @@ public class AncientWillEmiRecipe extends EmiPatternCraftingRecipe {
 		return new GeneratedSlotWidget(r -> {
 			ItemStack stack = container.getItemStack().copy();
 			ItemStack will = wills.get(r.nextInt(wills.size())).getItemStack().copy();
-			((AncientWillContainer) stack.getItem()).addAncientWill(stack, ((AncientWillItem) will.getItem()).type);
+			AncientWillContainer.addAncientWill(stack, ((AncientWillItem) will.getItem()).type);
 			return EmiStack.of(stack);
 		}, unique, x, y);
 	}

--- a/Xplat/src/main/java/vazkii/botania/client/integration/jei/crafting/AncientWillRecipeWrapper.java
+++ b/Xplat/src/main/java/vazkii/botania/client/integration/jei/crafting/AncientWillRecipeWrapper.java
@@ -62,7 +62,7 @@ public class AncientWillRecipeWrapper implements ICraftingCategoryExtension {
 		var outputStacks = new ArrayList<ItemStack>();
 		for (var will : !foci.isEmpty() ? foci : willStacks) {
 			var stack = new ItemStack(BotaniaItems.terrasteelHelm);
-			((AncientWillContainer) stack.getItem()).addAncientWill(stack, ((AncientWillItem) will.getItem()).type);
+			AncientWillContainer.addAncientWill(stack, ((AncientWillItem) will.getItem()).type);
 			outputStacks.add(stack);
 		}
 

--- a/Xplat/src/main/java/vazkii/botania/client/render/entity/TerrasteelHelmetLayer.java
+++ b/Xplat/src/main/java/vazkii/botania/client/render/entity/TerrasteelHelmetLayer.java
@@ -25,6 +25,7 @@ import net.minecraft.world.item.ItemStack;
 
 import org.jetbrains.annotations.NotNull;
 
+import vazkii.botania.api.item.AncientWillContainer;
 import vazkii.botania.client.core.handler.MiscellaneousModels;
 import vazkii.botania.common.item.equipment.armor.terrasteel.TerrasteelHelmItem;
 
@@ -37,7 +38,7 @@ public class TerrasteelHelmetLayer extends RenderLayer<AbstractClientPlayer, Pla
 	public void render(@NotNull PoseStack ms, @NotNull MultiBufferSource buffers, int light, AbstractClientPlayer player, float limbSwing, float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw, float headPitch) {
 		ItemStack helm = player.getItemBySlot(EquipmentSlot.HEAD);
 		if (!helm.isEmpty() && helm.getItem() instanceof TerrasteelHelmItem terraHelm) {
-			if (TerrasteelHelmItem.hasAnyWill(helm) && !terraHelm.hasPhantomInk(helm)) {
+			if (AncientWillContainer.hasAnyWill(helm) && !terraHelm.hasPhantomInk(helm)) {
 				ms.pushPose();
 				getParentModel().head.translateAndRotate(ms);
 				ms.translate(-0.2, -0.15, -0.3);

--- a/Xplat/src/main/java/vazkii/botania/common/crafting/recipe/AncientWillRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/common/crafting/recipe/AncientWillRecipe.java
@@ -69,13 +69,12 @@ public class AncientWillRecipe extends CustomRecipe {
 			}
 		}
 
-		AncientWillContainer container = (AncientWillContainer) item.getItem();
-		if (container.hasAncientWill(item, will)) {
+		if (AncientWillContainer.hasAncientWill(item, will)) {
 			return ItemStack.EMPTY;
 		}
 
 		ItemStack copy = item.copy();
-		container.addAncientWill(copy, will);
+		AncientWillContainer.addAncientWill(copy, will);
 		return copy;
 	}
 

--- a/Xplat/src/main/java/vazkii/botania/mixin/PlayerMixin.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/PlayerMixin.java
@@ -18,6 +18,7 @@ import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
+import vazkii.botania.api.item.AncientWillContainer;
 import vazkii.botania.common.BotaniaStats;
 import vazkii.botania.common.PlayerAccess;
 import vazkii.botania.common.entity.BotaniaEntities;
@@ -61,7 +62,7 @@ public abstract class PlayerMixin extends LivingEntity implements PlayerAccess {
 	)
 	private DamageSource onDamageTarget(DamageSource source, float amount) {
 		if (this.terraWillCritTarget != null) {
-			DamageSource newSource = TerrasteelHelmItem.onEntityAttacked(source, amount, (Player) (Object) this, terraWillCritTarget);
+			DamageSource newSource = AncientWillContainer.onEntityAttacked(source, amount, (Player) (Object) this, terraWillCritTarget);
 			this.terraWillCritTarget = null;
 			return newSource;
 		}


### PR DESCRIPTION
These changes should allow for a better implementation by other mods of the AncientWillContainer interface to new armor pieces. Works for both fabric and forge.

Edits aren't exactly what was written in the issue and more methods were affected by that change than anticipated.

I know this change is set for 1.21+, but if I'm not wrong, there is still going to be an other version of 1.20.+ released. If so, this change is pretty important while having almost no impact on the rest of the mod's code. It could easily be added to 1.20.+. This shouldn't require any mods to change their code as this interface is currently practically unusable by third parties.

Fixes #4746