### PR TITLE
Specify supported dyes to allow co-existing with dye addon mods

### DIFF
--- a/Fabric/src/main/java/vazkii/botania/fabric/FabricCommonInitializer.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/FabricCommonInitializer.java
@@ -86,6 +86,7 @@ import vazkii.botania.common.crafting.BotaniaRecipeTypes;
 import vazkii.botania.common.entity.BotaniaEntities;
 import vazkii.botania.common.entity.GaiaGuardianEntity;
 import vazkii.botania.common.handler.*;
+import vazkii.botania.common.helper.ColorHelper;
 import vazkii.botania.common.helper.PlayerHelper;
 import vazkii.botania.common.impl.BotaniaAPIImpl;
 import vazkii.botania.common.impl.DefaultHornHarvestable;
@@ -317,9 +318,9 @@ public class FabricCommonInitializer implements ModInitializer {
 				Blocks.VINE, Blocks.CAVE_VINES, Blocks.CAVE_VINES_PLANT, Blocks.TWISTING_VINES,
 				Blocks.TWISTING_VINES_PLANT, Blocks.WEEPING_VINES, Blocks.WEEPING_VINES_PLANT);
 		BotaniaFabricCapabilities.HORN_HARVEST.registerForBlocks((w, p, s, be, c) -> DefaultHornHarvestable.INSTANCE,
-				Arrays.stream(DyeColor.values()).map(BotaniaBlocks::getMushroom).toArray(Block[]::new));
+				ColorHelper.supportedColors().map(BotaniaBlocks::getMushroom).toArray(Block[]::new));
 		BotaniaFabricCapabilities.HORN_HARVEST.registerForBlocks((w, p, s, be, c) -> DefaultHornHarvestable.INSTANCE,
-				Arrays.stream(DyeColor.values()).map(BotaniaBlocks::getShinyFlower).toArray(Block[]::new));
+				ColorHelper.supportedColors().map(BotaniaBlocks::getShinyFlower).toArray(Block[]::new));
 		BotaniaFabricCapabilities.HOURGLASS_TRIGGER.registerForBlockEntities((be, c) -> {
 			var torch = (AnimatedTorchBlockEntity) be;
 			return hourglass -> torch.toggle();

--- a/Fabric/src/main/java/vazkii/botania/fabric/data/FabricBlockTagProvider.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/data/FabricBlockTagProvider.java
@@ -6,7 +6,6 @@ import net.minecraft.data.PackOutput;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.TagKey;
-import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 

--- a/Fabric/src/main/java/vazkii/botania/fabric/data/FabricBlockTagProvider.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/data/FabricBlockTagProvider.java
@@ -11,6 +11,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 
 import vazkii.botania.common.block.BotaniaBlocks;
+import vazkii.botania.common.helper.ColorHelper;
 import vazkii.botania.data.BlockTagProvider;
 import vazkii.botania.xplat.XplatAbstractions;
 
@@ -44,9 +45,9 @@ public class FabricBlockTagProvider extends BlockTagProvider {
 		List.of(GLASS, GLASS_ALT).forEach(t -> tag(t).add(BotaniaBlocks.manaGlass, BotaniaBlocks.elfGlass, BotaniaBlocks.bifrostPerm));
 		List.of(GLASS_PANE, GLASS_PANE_ALT).forEach(t -> tag(t).add(BotaniaBlocks.managlassPane, BotaniaBlocks.alfglassPane, BotaniaBlocks.bifrostPane));
 
-		for (DyeColor color : DyeColor.values()) {
+		ColorHelper.supportedColors().forEach(color -> {
 			this.tag(MUSHROOMS).add(BotaniaBlocks.getMushroom(color));
-		}
+		});
 
 		var vanillaTags = List.of(
 				BlockTags.COAL_ORES,

--- a/Fabric/src/main/java/vazkii/botania/fabric/data/FabricItemTagProvider.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/data/FabricItemTagProvider.java
@@ -7,13 +7,13 @@ import net.minecraft.data.PackOutput;
 import net.minecraft.data.tags.TagsProvider;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
-import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
 
 import vazkii.botania.common.block.BotaniaBlocks;
+import vazkii.botania.common.helper.ColorHelper;
 import vazkii.botania.common.item.relic.DiceOfFateItem;
 import vazkii.botania.data.ItemTagProvider;
 
@@ -40,9 +40,9 @@ public class FabricItemTagProvider extends ItemTagProvider {
 
 	@Override
 	protected void addTags(HolderLookup.Provider provider) {
-		for (var color : DyeColor.values()) {
+		ColorHelper.supportedColors().forEach(color -> {
 			this.tag(MUSHROOMS).add(BotaniaBlocks.getMushroom(color).asItem());
-		}
+		});
 		this.copy(FabricBlockTagProvider.MUSHROOMS, MUSHROOMS);
 		this.copy(FabricBlockTagProvider.QUARTZ_BLOCKS, QUARTZ_BLOCKS);
 		this.copy(FabricBlockTagProvider.GLASS, GLASS);

--- a/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
+++ b/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
@@ -99,6 +99,7 @@ import vazkii.botania.common.crafting.BotaniaRecipeTypes;
 import vazkii.botania.common.entity.BotaniaEntities;
 import vazkii.botania.common.entity.GaiaGuardianEntity;
 import vazkii.botania.common.handler.*;
+import vazkii.botania.common.helper.ColorHelper;
 import vazkii.botania.common.helper.PlayerHelper;
 import vazkii.botania.common.impl.BotaniaAPIImpl;
 import vazkii.botania.common.impl.DefaultHornHarvestable;
@@ -558,9 +559,9 @@ public class ForgeCommonInitializer {
 				Blocks.VINE, Blocks.CAVE_VINES, Blocks.CAVE_VINES_PLANT, Blocks.TWISTING_VINES,
 				Blocks.TWISTING_VINES_PLANT, Blocks.WEEPING_VINES, Blocks.WEEPING_VINES_PLANT);
 		CapabilityUtil.registerBlockLookaside(BotaniaForgeCapabilities.HORN_HARVEST, (w, p, s) -> DefaultHornHarvestable.INSTANCE,
-				Arrays.stream(DyeColor.values()).map(BotaniaBlocks::getMushroom).toArray(Block[]::new));
+				ColorHelper.supportedColors().map(BotaniaBlocks::getMushroom).toArray(Block[]::new));
 		CapabilityUtil.registerBlockLookaside(BotaniaForgeCapabilities.HORN_HARVEST, (w, p, s) -> DefaultHornHarvestable.INSTANCE,
-				Arrays.stream(DyeColor.values()).map(BotaniaBlocks::getShinyFlower).toArray(Block[]::new));
+				ColorHelper.supportedColors().map(BotaniaBlocks::getShinyFlower).toArray(Block[]::new));
 		CapabilityUtil.registerBlockLookaside(BotaniaForgeCapabilities.MANA_GHOST, (w, p, s) -> ((ManaCollisionGhost) s.getBlock()),
 				BotaniaBlocks.manaDetector,
 				BotaniaBlocks.abstrusePlatform, BotaniaBlocks.infrangiblePlatform, BotaniaBlocks.spectralPlatform,

--- a/Forge/src/main/java/vazkii/botania/forge/data/ForgeBlockTagProvider.java
+++ b/Forge/src/main/java/vazkii/botania/forge/data/ForgeBlockTagProvider.java
@@ -6,12 +6,12 @@ import net.minecraft.data.PackOutput;
 import net.minecraft.data.tags.IntrinsicHolderTagsProvider;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
-import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.common.Tags;
 import net.minecraftforge.common.data.ExistingFileHelper;
 
 import vazkii.botania.common.block.BotaniaBlocks;
+import vazkii.botania.common.helper.ColorHelper;
 import vazkii.botania.common.lib.BotaniaTags;
 import vazkii.botania.common.lib.LibMisc;
 
@@ -40,9 +40,9 @@ public class ForgeBlockTagProvider extends IntrinsicHolderTagsProvider<Block> {
 				BotaniaBlocks.lavenderQuartz, BotaniaBlocks.redQuartz, BotaniaBlocks.elfQuartz, BotaniaBlocks.sunnyQuartz
 		);
 
-		for (DyeColor color : DyeColor.values()) {
+		ColorHelper.supportedColors().forEach(color -> {
 			this.tag(MUSHROOMS).add(BotaniaBlocks.getMushroom(color));
-		}
+		});
 
 		tag(TagKey.create(Registries.BLOCK, new ResourceLocation("buzzier_bees", "flower_blacklist")))
 				.addTag(BotaniaTags.Blocks.MYSTICAL_FLOWERS)

--- a/Xplat/src/main/java/vazkii/botania/client/core/handler/MiscellaneousModels.java
+++ b/Xplat/src/main/java/vazkii/botania/client/core/handler/MiscellaneousModels.java
@@ -21,6 +21,7 @@ import vazkii.botania.client.lib.ResourcesLib;
 import vazkii.botania.client.model.TinyPotatoModel;
 import vazkii.botania.client.render.block_entity.CorporeaCrystalCubeBlockEntityRenderer;
 import vazkii.botania.client.render.block_entity.ManaPumpBlockEntityRenderer;
+import vazkii.botania.common.helper.ColorHelper;
 import vazkii.botania.common.item.equipment.bauble.FlugelTiaraItem;
 import vazkii.botania.common.item.equipment.bauble.ThirdEyeItem;
 import vazkii.botania.common.item.relic.KeyOfTheKingsLawItem;
@@ -33,7 +34,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static vazkii.botania.common.lib.ResourceLocationHelper.modelResourceLocation;
 import static vazkii.botania.common.lib.ResourceLocationHelper.prefix;
@@ -66,7 +66,7 @@ public class MiscellaneousModels {
 	private static final ResourceLocation manaSpreaderScaffoldingId = prefix("block/mana_spreader_scaffolding");
 	private static final ResourceLocation elvenSpreaderScaffoldingId = prefix("block/elven_spreader_scaffolding");
 	private static final ResourceLocation gaiaSpreaderScaffoldingId = prefix("block/gaia_spreader_scaffolding");
-	private static final Map<DyeColor, ResourceLocation> spreaderPaddingIds = new EnumMap<>(Stream.of(DyeColor.values()).collect(Collectors.toMap(Function.identity(), color -> prefix("block/" + color.getSerializedName() + "_spreader_padding"))));
+	private static final Map<DyeColor, ResourceLocation> spreaderPaddingIds = new EnumMap<>(ColorHelper.supportedColors().collect(Collectors.toMap(Function.identity(), color -> prefix("block/" + color.getSerializedName() + "_spreader_padding"))));
 
 	public static final MiscellaneousModels INSTANCE = new MiscellaneousModels();
 

--- a/Xplat/src/main/java/vazkii/botania/common/block/BotaniaBlocks.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/BotaniaBlocks.java
@@ -50,6 +50,7 @@ import vazkii.botania.common.block.mana.*;
 import vazkii.botania.common.block.red_string.*;
 import vazkii.botania.common.entity.EnderAirBottleEntity;
 import vazkii.botania.common.entity.VineBallEntity;
+import vazkii.botania.common.helper.ColorHelper;
 import vazkii.botania.common.item.BotaniaItems;
 import vazkii.botania.common.item.block.BlockItemWithSpecialRenderer;
 import vazkii.botania.common.item.block.TinyPotatoBlockItem;
@@ -683,10 +684,10 @@ public final class BotaniaBlocks {
 				Triple.of(BotaniaBlocks::getPottedShinyFlower, LibBlockNames.POTTED_PREFIX, LibBlockNames.SHINY_FLOWER_SUFFIX),
 				Triple.of(BotaniaBlocks::getPottedMushroom, LibBlockNames.POTTED_PREFIX, LibBlockNames.MUSHROOM_SUFFIX)
 		).forEach(coloredBlockRegistration -> {
-			for (DyeColor dyeColor : DyeColor.values()) {
+			ColorHelper.supportedColors().forEach(dyeColor -> {
 				r.accept(coloredBlockRegistration.getLeft().apply(dyeColor),
 						prefix(coloredBlockRegistration.getMiddle() + dyeColor.getName() + coloredBlockRegistration.getRight()));
-			}
+			});
 		});
 
 		r.accept(defaultAltar, prefix(LibBlockNames.APOTHECARY_PREFIX + PetalApothecaryBlock.Variant.DEFAULT.name().toLowerCase(Locale.ROOT)));
@@ -1850,7 +1851,7 @@ public final class BotaniaBlocks {
 	}
 
 	public static void registerFlowerPotPlants(BiConsumer<ResourceLocation, Supplier<? extends Block>> consumer) {
-		Stream.of(DyeColor.values()).forEach(dyeColor -> {
+		ColorHelper.supportedColors().forEach(dyeColor -> {
 			consumer.accept(prefix(dyeColor.getName() + MYSTICAL_FLOWER_SUFFIX), () -> getPottedFlower(dyeColor));
 			consumer.accept(prefix(dyeColor.getName() + SHINY_FLOWER_SUFFIX), () -> getPottedShinyFlower(dyeColor));
 			consumer.accept(prefix(dyeColor.getName() + MUSHROOM_SUFFIX), () -> getPottedMushroom(dyeColor));

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/BotaniaBlockEntities.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/BotaniaBlockEntities.java
@@ -10,7 +10,6 @@ package vazkii.botania.common.block.block_entity;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -21,10 +20,10 @@ import vazkii.botania.common.block.BotaniaBlocks;
 import vazkii.botania.common.block.block_entity.corporea.*;
 import vazkii.botania.common.block.block_entity.mana.*;
 import vazkii.botania.common.block.block_entity.red_string.*;
+import vazkii.botania.common.helper.ColorHelper;
 import vazkii.botania.common.lib.LibBlockNames;
 import vazkii.botania.xplat.XplatAbstractions;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -55,7 +54,7 @@ public class BotaniaBlockEntities {
 	public static final BlockEntityType<PlatformBlockEntity> PLATFORM = type(prefix(LibBlockNames.PLATFORM), PlatformBlockEntity::new, abstrusePlatform, spectralPlatform, infrangiblePlatform);
 	public static final BlockEntityType<AlfheimPortalBlockEntity> ALF_PORTAL = type(prefix(LibBlockNames.ALF_PORTAL), AlfheimPortalBlockEntity::new, alfPortal);
 	public static final BlockEntityType<BifrostBlockEntity> BIFROST = type(prefix(LibBlockNames.BIFROST), BifrostBlockEntity::new, bifrost);
-	public static final BlockEntityType<FloatingFlowerBlockEntity> MINI_ISLAND = type(prefix(LibBlockNames.MINI_ISLAND), FloatingFlowerBlockEntity::new, Arrays.stream(DyeColor.values()).map(BotaniaBlocks::getFloatingFlower).toArray(Block[]::new));
+	public static final BlockEntityType<FloatingFlowerBlockEntity> MINI_ISLAND = type(prefix(LibBlockNames.MINI_ISLAND), FloatingFlowerBlockEntity::new, ColorHelper.supportedColors().map(BotaniaBlocks::getFloatingFlower).toArray(Block[]::new));
 	public static final BlockEntityType<TinyPotatoBlockEntity> TINY_POTATO = type(prefix(LibBlockNames.TINY_POTATO), TinyPotatoBlockEntity::new, tinyPotato);
 	public static final BlockEntityType<LifeImbuerBlockEntity> SPAWNER_CLAW = type(prefix(LibBlockNames.SPAWNER_CLAW), LifeImbuerBlockEntity::new, spawnerClaw);
 	public static final BlockEntityType<EnderOverseerBlockEntity> ENDER_EYE = type(prefix(LibBlockNames.ENDER_EYE_BLOCK), EnderOverseerBlockEntity::new, enderEye);

--- a/Xplat/src/main/java/vazkii/botania/common/handler/CompostingData.java
+++ b/Xplat/src/main/java/vazkii/botania/common/handler/CompostingData.java
@@ -1,9 +1,9 @@
 package vazkii.botania.common.handler;
 
-import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.ItemLike;
 
 import vazkii.botania.common.block.BotaniaBlocks;
+import vazkii.botania.common.helper.ColorHelper;
 import vazkii.botania.common.item.BotaniaItems;
 
 import java.util.function.BiConsumer;
@@ -18,13 +18,13 @@ public class CompostingData {
 		// unused here: final float chanceHighest = 1.0f;
 
 		// see https://github.com/VazkiiMods/Botania/issues/4263#issuecomment-1529130978
-		for (final var dyeColor : DyeColor.values()) {
+		ColorHelper.supportedColors().forEach(dyeColor -> {
 			registrationMethod.accept(BotaniaItems.getPetal(dyeColor), chanceLowest);
 			registrationMethod.accept(BotaniaBlocks.getPetalBlock(dyeColor), chanceLow);
 			registrationMethod.accept(BotaniaBlocks.getFlower(dyeColor), chanceMid);
 			registrationMethod.accept(BotaniaBlocks.getDoubleFlower(dyeColor), chanceMid);
 			registrationMethod.accept(BotaniaBlocks.getMushroom(dyeColor), chanceMid);
-		}
+		});
 
 		registrationMethod.accept(BotaniaBlocks.cellBlock, chanceHigh);
 	}

--- a/Xplat/src/main/java/vazkii/botania/common/handler/PaintableData.java
+++ b/Xplat/src/main/java/vazkii/botania/common/handler/PaintableData.java
@@ -8,7 +8,6 @@
  */
 package vazkii.botania.common.handler;
 
-import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.block.Blocks;
 
 import vazkii.botania.api.BotaniaAPI;
@@ -17,48 +16,23 @@ import vazkii.botania.common.helper.ColorHelper;
 public class PaintableData {
 	public static void init() {
 		BotaniaAPI.instance().registerPaintableBlock(Blocks.GLASS, ColorHelper.STAINED_GLASS_MAP);
-		for (DyeColor color : DyeColor.values()) {
-			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.STAINED_GLASS_MAP.apply(color), ColorHelper.STAINED_GLASS_MAP);
-		}
 
 		BotaniaAPI.instance().registerPaintableBlock(Blocks.GLASS_PANE, ColorHelper.STAINED_GLASS_PANE_MAP);
-		for (DyeColor color : DyeColor.values()) {
-			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.STAINED_GLASS_PANE_MAP.apply(color), ColorHelper.STAINED_GLASS_PANE_MAP);
-		}
-
 		BotaniaAPI.instance().registerPaintableBlock(Blocks.TERRACOTTA, ColorHelper.TERRACOTTA_MAP);
-		for (DyeColor color : DyeColor.values()) {
-			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.TERRACOTTA_MAP.apply(color), ColorHelper.TERRACOTTA_MAP);
-		}
-
-		for (DyeColor color : DyeColor.values()) {
-			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.GLAZED_TERRACOTTA_MAP.apply(color), ColorHelper.GLAZED_TERRACOTTA_MAP);
-		}
-
-		for (DyeColor color : DyeColor.values()) {
-			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.WOOL_MAP.apply(color), ColorHelper.WOOL_MAP);
-		}
-
-		for (DyeColor color : DyeColor.values()) {
-			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.CARPET_MAP.apply(color), ColorHelper.CARPET_MAP);
-		}
-
-		for (DyeColor color : DyeColor.values()) {
-			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.CONCRETE_MAP.apply(color), ColorHelper.CONCRETE_MAP);
-		}
-
-		for (DyeColor color : DyeColor.values()) {
-			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.CONCRETE_POWDER_MAP.apply(color), ColorHelper.CONCRETE_POWDER_MAP);
-		}
-
 		BotaniaAPI.instance().registerPaintableBlock(Blocks.CANDLE, ColorHelper.CANDLE_MAP);
-		for (DyeColor color : DyeColor.values()) {
-			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.CANDLE_MAP.apply(color), ColorHelper.CANDLE_MAP);
-		}
-
 		BotaniaAPI.instance().registerPaintableBlock(Blocks.CANDLE_CAKE, ColorHelper.CANDLE_CAKE_MAP);
-		for (DyeColor color : DyeColor.values()) {
+
+		ColorHelper.supportedColors().forEach(color -> {
+			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.STAINED_GLASS_MAP.apply(color), ColorHelper.STAINED_GLASS_MAP);
+			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.STAINED_GLASS_PANE_MAP.apply(color), ColorHelper.STAINED_GLASS_PANE_MAP);
+			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.TERRACOTTA_MAP.apply(color), ColorHelper.TERRACOTTA_MAP);
+			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.GLAZED_TERRACOTTA_MAP.apply(color), ColorHelper.GLAZED_TERRACOTTA_MAP);
+			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.WOOL_MAP.apply(color), ColorHelper.WOOL_MAP);
+			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.CARPET_MAP.apply(color), ColorHelper.CARPET_MAP);
+			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.CONCRETE_MAP.apply(color), ColorHelper.CONCRETE_MAP);
+			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.CONCRETE_POWDER_MAP.apply(color), ColorHelper.CONCRETE_POWDER_MAP);
+			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.CANDLE_MAP.apply(color), ColorHelper.CANDLE_MAP);
 			BotaniaAPI.instance().registerPaintableBlock(ColorHelper.CANDLE_CAKE_MAP.apply(color), ColorHelper.CANDLE_CAKE_MAP);
-		}
+		});
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/helper/ColorHelper.java
+++ b/Xplat/src/main/java/vazkii/botania/common/helper/ColorHelper.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 public final class ColorHelper {
 	public static final Function<DyeColor, Block> STAINED_GLASS_MAP = color -> BuiltInRegistries.BLOCK.get(new ResourceLocation(color.getSerializedName() + "_stained_glass"));
@@ -60,6 +61,27 @@ public final class ColorHelper {
 			case BROWN -> 0x8B6543;
 			default -> color.getTextColor();
 		};
+	}
+
+	public static Stream<DyeColor> supportedColors() {
+		return Stream.of(
+				DyeColor.WHITE,
+				DyeColor.ORANGE,
+				DyeColor.MAGENTA,
+				DyeColor.LIGHT_BLUE,
+				DyeColor.YELLOW,
+				DyeColor.LIME,
+				DyeColor.PINK,
+				DyeColor.GRAY,
+				DyeColor.LIGHT_GRAY,
+				DyeColor.CYAN,
+				DyeColor.PURPLE,
+				DyeColor.BLUE,
+				DyeColor.BROWN,
+				DyeColor.GREEN,
+				DyeColor.RED,
+				DyeColor.BLACK
+		);
 	}
 
 	private ColorHelper() {}

--- a/Xplat/src/main/java/vazkii/botania/common/item/FlowerPouchItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/FlowerPouchItem.java
@@ -40,6 +40,7 @@ import vazkii.botania.client.gui.bag.FlowerPouchContainer;
 import vazkii.botania.common.block.BotaniaBlocks;
 import vazkii.botania.common.block.BotaniaDoubleFlowerBlock;
 import vazkii.botania.common.block.BotaniaFlowerBlock;
+import vazkii.botania.common.helper.ColorHelper;
 import vazkii.botania.common.helper.EntityHelper;
 import vazkii.botania.common.helper.InventoryHelper;
 import vazkii.botania.xplat.XplatAbstractions;
@@ -47,18 +48,19 @@ import vazkii.botania.xplat.XplatAbstractions;
 import java.util.stream.IntStream;
 
 public class FlowerPouchItem extends Item {
-	public static final int SIZE = 2 * DyeColor.values().length;
+	public static final int DYE_COUNT = 16;
+	public static final int SIZE = 2 * DYE_COUNT;
 
 	public FlowerPouchItem(Properties props) {
 		super(props);
 	}
 
 	public static Item getFlowerForSlot(int slot) {
-		if (slot < 16) {
+		if (slot < DYE_COUNT) {
 			DyeColor color = DyeColor.byId(slot);
 			return BotaniaBlocks.getFlower(color).asItem();
 		} else {
-			DyeColor color = DyeColor.byId(slot - 16);
+			DyeColor color = DyeColor.byId(slot - DYE_COUNT);
 			return BotaniaBlocks.getDoubleFlower(color).asItem();
 		}
 	}

--- a/Xplat/src/main/java/vazkii/botania/common/item/FlowerPouchItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/FlowerPouchItem.java
@@ -40,7 +40,6 @@ import vazkii.botania.client.gui.bag.FlowerPouchContainer;
 import vazkii.botania.common.block.BotaniaBlocks;
 import vazkii.botania.common.block.BotaniaDoubleFlowerBlock;
 import vazkii.botania.common.block.BotaniaFlowerBlock;
-import vazkii.botania.common.helper.ColorHelper;
 import vazkii.botania.common.helper.EntityHelper;
 import vazkii.botania.common.helper.InventoryHelper;
 import vazkii.botania.xplat.XplatAbstractions;

--- a/Xplat/src/main/java/vazkii/botania/data/BlockTagProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/data/BlockTagProvider.java
@@ -14,7 +14,6 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.tags.IntrinsicHolderTagsProvider;
 import net.minecraft.tags.BlockTags;
-import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.FenceBlock;
@@ -31,12 +30,12 @@ import vazkii.botania.common.block.mana.DrumBlock;
 import vazkii.botania.common.block.mana.ManaPoolBlock;
 import vazkii.botania.common.block.mana.ManaSpreaderBlock;
 import vazkii.botania.common.block.red_string.RedStringBlock;
+import vazkii.botania.common.helper.ColorHelper;
 import vazkii.botania.common.lib.BotaniaTags;
 import vazkii.botania.common.lib.LibBlockNames;
 import vazkii.botania.common.lib.LibMisc;
 import vazkii.botania.xplat.XplatAbstractions;
 
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -73,7 +72,7 @@ public class BlockTagProvider extends IntrinsicHolderTagsProvider<Block> {
 		tag(BlockTags.WITHER_IMMUNE).add(BotaniaBlocks.infrangiblePlatform);
 
 		tag(BotaniaTags.Blocks.MUNDANE_FLOATING_FLOWERS).add(
-				Arrays.stream(DyeColor.values())
+				ColorHelper.supportedColors()
 						.map(BotaniaBlocks::getFloatingFlower)
 						.sorted(Comparator.comparing(BuiltInRegistries.BLOCK::getKey))
 						.toArray(Block[]::new)
@@ -89,21 +88,21 @@ public class BlockTagProvider extends IntrinsicHolderTagsProvider<Block> {
 				.addTag(BotaniaTags.Blocks.SPECIAL_FLOATING_FLOWERS);
 
 		tag(BotaniaTags.Blocks.MYSTICAL_FLOWERS).add(
-				Arrays.stream(DyeColor.values())
+				ColorHelper.supportedColors()
 						.map(BotaniaBlocks::getFlower)
 						.sorted(Comparator.comparing(BuiltInRegistries.BLOCK::getKey))
 						.toArray(Block[]::new)
 		);
 
 		tag(BotaniaTags.Blocks.SHINY_FLOWERS).add(
-				Arrays.stream(DyeColor.values())
+				ColorHelper.supportedColors()
 						.map(BotaniaBlocks::getShinyFlower)
 						.sorted(Comparator.comparing(BuiltInRegistries.BLOCK::getKey))
 						.toArray(Block[]::new)
 		);
 
 		tag(BotaniaTags.Blocks.DOUBLE_MYSTICAL_FLOWERS).add(
-				Arrays.stream(DyeColor.values())
+				ColorHelper.supportedColors()
 						.map(BotaniaBlocks::getDoubleFlower)
 						.sorted(Comparator.comparing(BuiltInRegistries.BLOCK::getKey))
 						.toArray(Block[]::new)
@@ -215,15 +214,15 @@ public class BlockTagProvider extends IntrinsicHolderTagsProvider<Block> {
 		tag(BotaniaTags.Blocks.PASTURE_SEED_REPLACEABLE).add(Blocks.DIRT, Blocks.GRASS_BLOCK, Blocks.MYCELIUM);
 
 		tag(BlockTags.FLOWER_POTS)
-				.add(Arrays.stream(DyeColor.values())
+				.add(ColorHelper.supportedColors()
 						.map(BotaniaBlocks::getPottedFlower)
 						.sorted(Comparator.comparing(BuiltInRegistries.BLOCK::getKey))
 						.toArray(Block[]::new))
-				.add(Arrays.stream(DyeColor.values())
+				.add(ColorHelper.supportedColors()
 						.map(BotaniaBlocks::getPottedShinyFlower)
 						.sorted(Comparator.comparing(BuiltInRegistries.BLOCK::getKey))
 						.toArray(Block[]::new))
-				.add(Arrays.stream(DyeColor.values())
+				.add(ColorHelper.supportedColors()
 						.map(BotaniaBlocks::getPottedMushroom)
 						.sorted(Comparator.comparing(BuiltInRegistries.BLOCK::getKey))
 						.toArray(Block[]::new))

--- a/Xplat/src/main/java/vazkii/botania/data/BlockstateProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/data/BlockstateProvider.java
@@ -446,7 +446,7 @@ public class BlockstateProvider implements DataProvider {
 						.put(TextureSlot.BOTTOM, getBlockTexture(b, "_scaffolding_bottom")), this.modelOutput);
 			}
 		});
-		for (DyeColor color : DyeColor.values()) {
+		ColorHelper.supportedColors().forEach(color -> {
 			Block wool = ColorHelper.WOOL_MAP.apply(color);
 			spreaderPaddingTemplate.create(prefix("block/" + color.getName() + "_spreader_padding"),
 					new TextureMapping()
@@ -454,7 +454,7 @@ public class BlockstateProvider implements DataProvider {
 							.put(TextureSlot.BACK, getBlockTexture(wool))
 							.put(TextureSlot.SIDE, getBlockTexture(wool)),
 					this.modelOutput);
-		}
+		});
 
 		var manaSlot = TextureSlotAccessor.make("mana");
 		TextureSlot[] manaPoolSlots = new TextureSlot[] { TextureSlot.SIDE, TextureSlot.TOP, TextureSlot.BOTTOM, TextureSlot.INSIDE };

--- a/Xplat/src/main/java/vazkii/botania/data/ItemTagProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/data/ItemTagProvider.java
@@ -24,6 +24,7 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
 
 import vazkii.botania.common.block.BotaniaBlocks;
+import vazkii.botania.common.helper.ColorHelper;
 import vazkii.botania.common.item.lens.LensItem;
 import vazkii.botania.common.lib.BotaniaTags;
 import vazkii.botania.common.lib.LibMisc;
@@ -135,11 +136,11 @@ public class ItemTagProvider extends ItemTagsProvider {
 		);
 
 		TagAppender<Item> allPetals = this.tag(BotaniaTags.Items.PETALS);
-		for (DyeColor color : DyeColor.values()) {
+		ColorHelper.supportedColors().forEach(color -> {
 			var petalTag = BotaniaTags.Items.getPetalTag(color);
 			this.tag(petalTag).add(getPetal(color), BotaniaBlocks.getMushroom(color).asItem());
 			allPetals.addTag(petalTag);
-		}
+		});
 
 		this.tag(BotaniaTags.Items.LOONIUM_BLACKLIST)
 				.add(lexicon, overgrowthSeed, blackLotus, blackerLotus)

--- a/Xplat/src/main/java/vazkii/botania/data/ItemTagProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/data/ItemTagProvider.java
@@ -18,7 +18,6 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.tags.ItemTags;
-import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;

--- a/Xplat/src/main/java/vazkii/botania/data/recipes/CraftingRecipeProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/data/recipes/CraftingRecipeProvider.java
@@ -35,6 +35,7 @@ import vazkii.botania.api.state.enums.CraftyCratePattern;
 import vazkii.botania.common.block.BotaniaBlocks;
 import vazkii.botania.common.block.BotaniaFlowerBlocks;
 import vazkii.botania.common.crafting.recipe.*;
+import vazkii.botania.common.helper.ColorHelper;
 import vazkii.botania.common.item.BotaniaItems;
 import vazkii.botania.common.lib.BotaniaTags;
 import vazkii.botania.common.lib.LibBlockNames;
@@ -42,7 +43,6 @@ import vazkii.botania.common.lib.LibItemNames;
 import vazkii.botania.common.lib.ResourceLocationHelper;
 import vazkii.botania.mixin.RecipeProviderAccessor;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -107,7 +107,7 @@ public class CraftingRecipeProvider extends BotaniaRecipeProvider {
 
 	private void registerMain(Consumer<FinishedRecipe> consumer) {
 		InventoryChangeTrigger.TriggerInstance hasAnyDye = conditionsFromItems(
-				Arrays.stream(DyeColor.values()).map(DyeItem::byColor).toArray(ItemLike[]::new)
+				ColorHelper.supportedColors().map(DyeItem::byColor).toArray(ItemLike[]::new)
 		);
 		MutableObject<FinishedRecipe> base = new MutableObject<>();
 		MutableObject<FinishedRecipe> gog = new MutableObject<>();
@@ -827,7 +827,7 @@ public class CraftingRecipeProvider extends BotaniaRecipeProvider {
 		ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC, BotaniaItems.phantomInk, 4)
 				.requires(BotaniaItems.manaPearl)
 				.requires(Ingredient.of(
-						Arrays.stream(DyeColor.values()).map(DyeItem::byColor).toArray(ItemLike[]::new)
+						ColorHelper.supportedColors().map(DyeItem::byColor).toArray(ItemLike[]::new)
 				))
 				.requires(Ingredient.of(Items.GLASS, Items.WHITE_STAINED_GLASS, Items.ORANGE_STAINED_GLASS,
 						Items.MAGENTA_STAINED_GLASS, Items.LIGHT_BLUE_STAINED_GLASS, Items.YELLOW_STAINED_GLASS,
@@ -890,7 +890,7 @@ public class CraftingRecipeProvider extends BotaniaRecipeProvider {
 					.unlockedBy("has_flower_item", conditionsFromItem(BotaniaFlowerBlocks.marimorphosis))
 					.save(consumer);
 		}
-		for (DyeColor color : DyeColor.values()) {
+		ColorHelper.supportedColors().forEach(color -> {
 			ShapelessRecipeBuilder.shapeless(RecipeCategory.DECORATIONS, BotaniaBlocks.getShinyFlower(color))
 					.requires(Items.GLOWSTONE_DUST)
 					.requires(Items.GLOWSTONE_DUST)
@@ -940,7 +940,7 @@ public class CraftingRecipeProvider extends BotaniaRecipeProvider {
 					.group("botania:dye")
 					.unlockedBy("has_item", conditionsFromItem(BotaniaItems.getPetal(color)))
 					.save(consumer, "botania:dye_" + color.getName());
-		}
+		});
 	}
 
 	private void registerTools(Consumer<FinishedRecipe> consumer) {

--- a/Xplat/src/main/java/vazkii/botania/data/recipes/ManaInfusionProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/data/recipes/ManaInfusionProvider.java
@@ -14,7 +14,6 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.data.PackOutput;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.ItemTags;
-import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.DyeItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -31,10 +30,10 @@ import vazkii.botania.common.block.BotaniaBlocks;
 import vazkii.botania.common.block.BotaniaFlowerBlocks;
 import vazkii.botania.common.crafting.BotaniaRecipeTypes;
 import vazkii.botania.common.crafting.StateIngredientHelper;
+import vazkii.botania.common.helper.ColorHelper;
 import vazkii.botania.common.helper.ItemNBTHelper;
 import vazkii.botania.common.item.BotaniaItems;
 
-import java.util.Arrays;
 import java.util.function.Consumer;
 
 import static vazkii.botania.common.lib.ResourceLocationHelper.prefix;
@@ -61,7 +60,7 @@ public class ManaInfusionProvider extends BotaniaRecipeProvider {
 
 		Ingredient dust = Ingredient.of(Items.GUNPOWDER, Items.REDSTONE, Items.GLOWSTONE_DUST, Items.SUGAR);
 		consumer.accept(new FinishedRecipe(id("mana_powder_dust"), new ItemStack(BotaniaItems.manaPowder), dust, 500));
-		Ingredient dyeIngredient = Ingredient.of(Arrays.stream(DyeColor.values()).map(DyeItem::byColor).toArray(Item[]::new));
+		Ingredient dyeIngredient = Ingredient.of(ColorHelper.supportedColors().map(DyeItem::byColor).toArray(Item[]::new));
 		consumer.accept(new FinishedRecipe(id("mana_powder_dye"), new ItemStack(BotaniaItems.manaPowder), dyeIngredient, 400));
 
 		consumer.accept(new FinishedRecipe(id("piston_relay"), new ItemStack(BotaniaBlocks.pistonRelay), ingr(Blocks.PISTON), 15000));


### PR DESCRIPTION
This is a proposed fix for #4589

I extracted all required places which use `DyeColor.values()` and replaced it with a reference to a centralized location which manually specifies the vanilla dyes.
This way, dye colors injected by mods like dye  depot are simply ignored.