### PR TITLE
Custom TNT ethical fix

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/helper/EthicalTntHelper.java
+++ b/Xplat/src/main/java/vazkii/botania/common/helper/EthicalTntHelper.java
@@ -118,7 +118,7 @@ public class EthicalTntHelper {
 				final var blockEntity = entity.level().getBlockEntity(blockPos);
 				if (blockEntity instanceof PistonMovingBlockEntity movingBlockEntity
 						&& movingBlockEntity.getMovementDirection() == dir
-						&& movingBlockEntity.getMovedState().getBlock() instanceof TntBlock) {
+						&& ((movingBlockEntity.getMovedState().getBlock() instanceof TntBlock) || movingBlockEntity.getMovedState().getBlock().getName().toString().contains("tnt"))) {
 					// found a moving block that marks the destination of a TNT block moving away from the TNT entity
 					XplatAbstractions.INSTANCE.ethicalComponent(entity).markUnethical();
 					break;


### PR DESCRIPTION
This bug will not happen on vanilla server, it will happened with some mod like AE2, their custom tnt can provide the ethical logic misjudgment. I have modified the logic for determining whether TNT is ethical to recognize other entities with TNT fields. I have checked the situation where the vanilla item does not have TNT, and those that have been judged as ethical have already been judged as TNT, so there should be no misjudgment