### PR TITLE
Improve compatibility with other blocks that emulate dispenser behavior

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/dispenser/CorporeaSparkBehavior.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/dispenser/CorporeaSparkBehavior.java
@@ -26,7 +26,7 @@ public class CorporeaSparkBehavior extends OptionalDispenseItemBehavior {
 	@Override
 	protected ItemStack execute(BlockSource source, @NotNull ItemStack stack) {
 		Level world = source.getLevel();
-		Direction facing = world.getBlockState(source.getPos()).getValue(DispenserBlock.FACING);
+		Direction facing = source.getBlockState().getValue(DispenserBlock.FACING);
 		BlockPos pos = source.getPos().relative(facing);
 
 		setSuccess(CorporeaSparkItem.attachSpark(world, pos, stack));

--- a/Xplat/src/main/java/vazkii/botania/common/block/dispenser/ManaPoolMinecartBehavior.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/dispenser/ManaPoolMinecartBehavior.java
@@ -33,41 +33,46 @@ public class ManaPoolMinecartBehavior extends DefaultDispenseItemBehavior {
 	@NotNull
 	@Override
 	public ItemStack execute(BlockSource source, ItemStack stack) {
-		Direction enumfacing = source.getBlockState().getValue(DispenserBlock.FACING);
+		Direction direction = source.getBlockState().getValue(DispenserBlock.FACING);
 		Level world = source.getLevel();
-		double d0 = source.x() + (double) enumfacing.getStepX() * 1.125D;
-		double d1 = Math.floor(source.y()) + (double) enumfacing.getStepY();
-		double d2 = source.z() + (double) enumfacing.getStepZ() * 1.125D;
-		BlockPos blockpos = source.getPos().relative(enumfacing);
-		BlockState iblockstate = world.getBlockState(blockpos);
-		RailShape railshape = iblockstate.getBlock() instanceof BaseRailBlock ? iblockstate.getValue(((BaseRailBlock) iblockstate.getBlock()).getShapeProperty()) : RailShape.NORTH_SOUTH;
-		double d3;
-		if (iblockstate.is(BlockTags.RAILS)) {
-			if (railshape.isAscending()) {
-				d3 = 0.6D;
+		double x = source.x() + (double) direction.getStepX() * 1.125;
+		double y = Math.floor(source.y()) + (double) direction.getStepY();
+		double z = source.z() + (double) direction.getStepZ() * 1.125;
+		BlockPos blockpos = source.getPos().relative(direction);
+		BlockState blockState = world.getBlockState(blockpos);
+		RailShape railShape = blockState.getBlock() instanceof BaseRailBlock
+				? blockState.getValue(((BaseRailBlock) blockState.getBlock()).getShapeProperty())
+				: RailShape.NORTH_SOUTH;
+		double yOffset;
+		if (blockState.is(BlockTags.RAILS)) {
+			if (railShape.isAscending()) {
+				yOffset = 0.6;
 			} else {
-				d3 = 0.1D;
+				yOffset = 0.1;
 			}
 		} else {
-			if (!iblockstate.isAir() || !world.getBlockState(blockpos.below()).is(BlockTags.RAILS)) {
+			if (!blockState.isAir() || !world.getBlockState(blockpos.below()).is(BlockTags.RAILS)) {
 				return this.behaviourDefaultDispenseItem.dispense(source, stack);
 			}
 
-			BlockState iblockstate1 = world.getBlockState(blockpos.below());
-			RailShape railshape1 = iblockstate1.getBlock() instanceof BaseRailBlock ? iblockstate1.getValue(((BaseRailBlock) iblockstate1.getBlock()).getShapeProperty()) : RailShape.NORTH_SOUTH;
-			if (enumfacing != Direction.DOWN && railshape1.isAscending()) {
-				d3 = -0.4D;
+			BlockState blockStateBelow = world.getBlockState(blockpos.below());
+			RailShape railShapeBelow = blockStateBelow.getBlock() instanceof BaseRailBlock
+					? blockStateBelow.getValue(((BaseRailBlock) blockStateBelow.getBlock()).getShapeProperty())
+					: RailShape.NORTH_SOUTH;
+			if (direction != Direction.DOWN && railShapeBelow.isAscending()) {
+				yOffset = -0.4;
 			} else {
-				d3 = -0.9D;
+				yOffset = -0.9;
 			}
 		}
 
-		AbstractMinecart entityminecart = new ManaPoolMinecartEntity(world, d0, d1 + d3, d2);
+		// changed from vanilla, because it uses AbstractMinecart.Type enum to resolve the entity type
+		AbstractMinecart minecart = new ManaPoolMinecartEntity(world, x, y + yOffset, z);
 		if (stack.hasCustomHoverName()) {
-			entityminecart.setCustomName(stack.getHoverName());
+			minecart.setCustomName(stack.getHoverName());
 		}
 
-		world.addFreshEntity(entityminecart);
+		world.addFreshEntity(minecart);
 		stack.shrink(1);
 		return stack;
 	}

--- a/Xplat/src/main/java/vazkii/botania/common/block/dispenser/ManaSparkBehavior.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/dispenser/ManaSparkBehavior.java
@@ -26,7 +26,7 @@ public class ManaSparkBehavior extends OptionalDispenseItemBehavior {
 	@Override
 	protected ItemStack execute(BlockSource source, @NotNull ItemStack stack) {
 		Level world = source.getLevel();
-		Direction facing = world.getBlockState(source.getPos()).getValue(DispenserBlock.FACING);
+		Direction facing = source.getBlockState().getValue(DispenserBlock.FACING);
 		BlockPos pos = source.getPos().relative(facing);
 
 		setSuccess(ManaSparkItem.attachSpark(world, pos, stack));

--- a/Xplat/src/main/java/vazkii/botania/common/block/dispenser/StickBehavior.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/dispenser/StickBehavior.java
@@ -26,7 +26,7 @@ public class StickBehavior extends OptionalDispenseItemBehavior {
 	@Override
 	protected ItemStack execute(BlockSource source, ItemStack stack) {
 		Level world = source.getLevel();
-		Direction facing = world.getBlockState(source.getPos()).getValue(DispenserBlock.FACING);
+		Direction facing = source.getBlockState().getValue(DispenserBlock.FACING);
 		BlockPos pos = source.getPos().relative(facing);
 
 		setSuccess(FloralObedienceStickItem.applyStick(world, pos));

--- a/Xplat/src/main/java/vazkii/botania/common/block/dispenser/WandBehavior.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/dispenser/WandBehavior.java
@@ -28,7 +28,7 @@ public class WandBehavior extends OptionalDispenseItemBehavior {
 	@Override
 	protected ItemStack execute(BlockSource source, ItemStack stack) {
 		Level world = source.getLevel();
-		Direction facing = world.getBlockState(source.getPos()).getValue(DispenserBlock.FACING);
+		Direction facing = source.getBlockState().getValue(DispenserBlock.FACING);
 		BlockPos pos = source.getPos().relative(facing);
 		BlockState state = world.getBlockState(pos);
 		Wandable wandable = XplatAbstractions.INSTANCE.findWandable(world, pos, state, world.getBlockEntity(pos));

--- a/web/changelog.md
+++ b/web/changelog.md
@@ -37,6 +37,7 @@ thanks to Wormbo for a lot of work on this feature!
 * Fix: A comparator reading from a Thermalily through a solid block no longer keeps outputting a value after breaking the Thermalily
 * Fix: Potential crash issues in combination with mods that add colors have been resolved
 * Fix: Workaround for missing food properties in some items that are nonetheless flagged as edible
+* Fix: Potential crash with certain modded dispenser variants when trying to attach a mana/corporea spark or applying a Wand of the Forest or Floral Obedience Stick that way
 * Language update:
   * de_de completed (Wormbo, thanks to Kartabass and PssbleTrngle for reviewing)
   * ko_kr updated (UnineVesiKass)


### PR DESCRIPTION
Fixes #4788 for:
- attaching corporea/mana spark
- applying floral obedience stick
- applying wand of the (elven) forest

Also cleaned up pool minecart placing code and emphasized why that VanillaCopy exists.