### PR TITLE
Skip Advancement checks for ManaItem updates

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/mixin/ServerPlayerMixin.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/ServerPlayerMixin.java
@@ -10,6 +10,8 @@ package vazkii.botania.mixin;
 
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.ItemStack;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -39,4 +41,14 @@ public class ServerPlayerMixin {
 		}
 	}
 
+	@Mixin(targets = "net/minecraft/server/level/ServerPlayer$2")
+	public static class ContainerListenerMixin {
+		@Inject(at = @At("HEAD"), method = "slotChanged", cancellable = true)
+		private void onSlotChanged(AbstractContainerMenu containerMenu, int slotIndex, ItemStack itemStack, CallbackInfo ci) {
+			// ManaItems update frequently - skip advancement processing for them
+			if (XplatAbstractions.INSTANCE.findManaItem(itemStack) != null) {
+				ci.cancel();
+			}
+		}
+	}
 }

--- a/Xplat/src/main/java/vazkii/botania/mixin/ServerPlayerMixin.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/ServerPlayerMixin.java
@@ -14,11 +14,13 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import vazkii.botania.common.handler.EquipmentHandler;
+import vazkii.botania.common.item.BotaniaItems;
 import vazkii.botania.common.world.SkyblockWorldEvents;
 import vazkii.botania.xplat.XplatAbstractions;
 
@@ -43,8 +45,16 @@ public class ServerPlayerMixin {
 
 	@Mixin(targets = "net/minecraft/server/level/ServerPlayer$2")
 	public static class ContainerListenerMixin {
+		@Unique
+		private boolean botania$seenManaTablet;
+
 		@Inject(at = @At("HEAD"), method = "slotChanged", cancellable = true)
 		private void onSlotChanged(AbstractContainerMenu containerMenu, int slotIndex, ItemStack itemStack, CallbackInfo ci) {
+			if (!botania$seenManaTablet && itemStack.is(BotaniaItems.manaTablet)) {
+				// This might be the player's first mana tablet - let recipe advancement triggers run
+				botania$seenManaTablet = true;
+				return;
+			}
 			// ManaItems update frequently - skip advancement processing for them
 			if (XplatAbstractions.INSTANCE.findManaItem(itemStack) != null) {
 				ci.cancel();

--- a/Xplat/src/main/resources/botania_xplat.mixins.json
+++ b/Xplat/src/main/resources/botania_xplat.mixins.json
@@ -55,6 +55,7 @@
     "ServerLevelMixin",
     "ServerPlayerGameModeAccessor",
     "ServerPlayerMixin",
+    "ServerPlayerMixin$ContainerListenerMixin",
     "SpawnPlacementsMixin",
     "StatsAccessor",
     "TextureSlotAccessor",


### PR DESCRIPTION
Advancement checking is expensive, and mana items will often update every tick.

I don't think this will interfere with any actual advancements? The bauble advancement uses and ImpossibleTrigger and is manually granted in the BaubleItem onEquipped method. Worst case scenario, the advancement will just be delayed until a non-mana item triggers the check.

Should address #4793 