### PR TITLE
Track crafting stats and trigger recipe_crafted advancements

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/PetalApothecaryBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/PetalApothecaryBlockEntity.java
@@ -20,6 +20,7 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -107,6 +108,7 @@ public class PetalApothecaryBlockEntity extends SimpleInventoryBlockEntity imple
 			if (recipe.getReagent().test(item.getItem())) {
 				saveLastRecipe(recipe.getReagent());
 				ItemStack output = recipe.assemble(getItemHandler(), getLevel().registryAccess());
+				Entity thrower = item.getOwner();
 
 				for (int i = 0; i < inventorySize(); i++) {
 					getItemHandler().setItem(i, ItemStack.EMPTY);
@@ -116,6 +118,10 @@ public class PetalApothecaryBlockEntity extends SimpleInventoryBlockEntity imple
 
 				ItemEntity outputItem = new ItemEntity(level, worldPosition.getX() + 0.5, worldPosition.getY() + 1.5, worldPosition.getZ() + 0.5, output);
 				XplatAbstractions.INSTANCE.itemFlagsComponent(outputItem).apothecarySpawned = true;
+				if (thrower instanceof Player player) {
+					player.triggerRecipeCrafted(recipe, List.of(output));
+					output.onCraftedBy(level, player, output.getCount());
+				}
 				level.addFreshEntity(outputItem);
 
 				setFluid(State.EMPTY, false);

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/RunicAltarBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/RunicAltarBlockEntity.java
@@ -286,6 +286,10 @@ public class RunicAltarBlockEntity extends SimpleInventoryBlockEntity implements
 				ItemStack output = recipe.assemble(getItemHandler(), getLevel().registryAccess());
 				ItemEntity outputItem = new ItemEntity(level, worldPosition.getX() + 0.5, worldPosition.getY() + 1.5, worldPosition.getZ() + 0.5, output);
 				XplatAbstractions.INSTANCE.itemFlagsComponent(outputItem).runicAltarSpawned = true;
+				if (player != null) {
+					player.triggerRecipeCrafted(recipe, List.of(output));
+					output.onCraftedBy(level, player, output.getCount());
+				}
 				level.addFreshEntity(outputItem);
 				currentRecipe = null;
 				level.gameEvent(null, GameEvent.BLOCK_ACTIVATE, getBlockPos());

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/mana/ManaPoolBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/mana/ManaPoolBlockEntity.java
@@ -192,6 +192,10 @@ public class ManaPoolBlockEntity extends BotaniaBlockEntity implements ManaPool,
 
 				ItemEntity outputItem = new ItemEntity(level, worldPosition.getX() + 0.5, worldPosition.getY() + 1.5, worldPosition.getZ() + 0.5, output);
 				XplatAbstractions.INSTANCE.itemFlagsComponent(outputItem).manaInfusionSpawned = true;
+				if (item.getOwner() instanceof Player player) {
+					player.triggerRecipeCrafted(recipe, List.of(output));
+					output.onCraftedBy(level, player, output.getCount());
+				}
 				level.addFreshEntity(outputItem);
 
 				craftingEffect(true);


### PR DESCRIPTION
Increments item crafted statistics and fires appropriate recipe_crafted advancement triggers when a player operates Botania blocks to make new items:
- crafty crate counts as player-operated if crafting is activated via the wand of the forest
- mana pool counts for the player who threw the input item
- petal apothecary counts for the player who threw the final reagent item (usually a seed)
- runic altar counts for the player who activated the altar via want of the forest
- terra plate counts for the last player who threw an ingredient onto the plate