### PR TITLE
Allow written book in head recipe for historic skins

### DIFF
--- a/Xplat/src/generated/resources/.cache/cc3f2b57729a50761cd506b810b841f2b4fbd4d1
+++ b/Xplat/src/generated/resources/.cache/cc3f2b57729a50761cd506b810b841f2b4fbd4d1
@@ -6,7 +6,7 @@ c4d5f2f0463e30f027633f823206abdcbad51615 data/botania/recipes/runic_altar/earth.
 c338f61ea4e5a71f8a077f441d22876a3210d883 data/botania/recipes/runic_altar/fire.json
 60c53a002299c3c09834ae064fea39f2b27d0b43 data/botania/recipes/runic_altar/gluttony.json
 c1fc0e465c8841a957fd089ff03cc4016495d02d data/botania/recipes/runic_altar/greed.json
-6b78f960968e8ecf702133fbe5eab7d2d69e0f90 data/botania/recipes/runic_altar/head.json
+dcbdca59341d7299f41e404a39facdcc36c7e8a1 data/botania/recipes/runic_altar/head.json
 e3fbdc270b0f4683037339c343a66f4cd164a0f9 data/botania/recipes/runic_altar/lust.json
 01f95a3f44dfe54a8decd884b59ae6eff1a9e630 data/botania/recipes/runic_altar/mana.json
 afd58f8ffe62da670ae78440894df295a91abbf3 data/botania/recipes/runic_altar/pride.json

--- a/Xplat/src/generated/resources/data/botania/recipes/runic_altar/head.json
+++ b/Xplat/src/generated/resources/data/botania/recipes/runic_altar/head.json
@@ -10,9 +10,14 @@
     {
       "item": "minecraft:prismarine_crystals"
     },
-    {
-      "item": "minecraft:name_tag"
-    },
+    [
+      {
+        "item": "minecraft:name_tag"
+      },
+      {
+        "item": "minecraft:written_book"
+      }
+    ],
     {
       "item": "minecraft:golden_apple"
     }

--- a/Xplat/src/main/java/vazkii/botania/common/crafting/recipe/HeadRecipe.java
+++ b/Xplat/src/main/java/vazkii/botania/common/crafting/recipe/HeadRecipe.java
@@ -8,18 +8,33 @@
  */
 package vazkii.botania.common.crafting.recipe;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.minecraft.MinecraftProfileTexture;
+import com.mojang.authlib.properties.Property;
+import com.mojang.authlib.yggdrasil.response.MinecraftTexturesPayload;
+import com.mojang.util.UUIDTypeAdapter;
 
 import net.minecraft.core.RegistryAccess;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.NbtUtils;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.FormattedText;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.GsonHelper;
 import net.minecraft.world.Container;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.WrittenBookItem;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.item.crafting.RecipeSerializer;
 import net.minecraft.world.item.crafting.ShapedRecipe;
@@ -31,10 +46,24 @@ import vazkii.botania.common.crafting.BotaniaRecipeTypes;
 import vazkii.botania.common.crafting.RunicAltarRecipe;
 import vazkii.botania.common.helper.ItemNBTHelper;
 
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class HeadRecipe extends RunicAltarRecipe {
+	private static final Pattern PROFILE_PATTERN = Pattern.compile(
+			"(?<base64>[A-Za-z0-9+/]{100,}={0,2})" +
+					"|(?<url>(?=\\S{50,})https?://(?!bugs|education|feedback)\\w+\\.(?:minecraft\\.net|mojang\\.com)/\\S+)" +
+					"|(?<hash>[0-9a-f]{64})");
+	public static final String TEXTURE_URL_BASE = "https://textures.minecraft.net/texture/";
+	private static final Supplier<Gson> gson = Suppliers.memoize(() -> new GsonBuilder()
+			.registerTypeAdapter(UUID.class, new UUIDTypeAdapter()).create());
+	private static final GameProfile PROFILE_VALID_RESULT = new GameProfile(null, "valid");
 
 	public HeadRecipe(ResourceLocation id, ItemStack output, int mana, Ingredient... inputs) {
 		super(id, output, mana, inputs);
@@ -43,6 +72,7 @@ public class HeadRecipe extends RunicAltarRecipe {
 	@Override
 	public boolean matches(Container inv, @NotNull Level world) {
 		boolean matches = super.matches(inv, world);
+		boolean foundName = false;
 
 		if (matches) {
 			for (int i = 0; i < inv.getContainerSize(); i++) {
@@ -51,11 +81,18 @@ public class HeadRecipe extends RunicAltarRecipe {
 					break;
 				}
 
+				// either exactly one name tag or exactly one written book among ingredients
 				if (stack.is(Items.NAME_TAG)) {
-					String defaultName = Component.translatable(Items.NAME_TAG.getDescriptionId()).getString();
-					if (stack.getHoverName().getString().equals(defaultName)) {
+					if (foundName || !stack.hasCustomHoverName() || stack.getHoverName().getString().isBlank()) {
 						return false;
 					}
+					foundName = true;
+				} else if (stack.is(Items.WRITTEN_BOOK)) {
+					if (foundName || !WrittenBookItem.makeSureTagIsValid(stack.getTag())
+							|| parseProfileFromBook(stack, true) == null) {
+						return false;
+					}
+					foundName = true;
 				}
 			}
 		}
@@ -73,8 +110,87 @@ public class HeadRecipe extends RunicAltarRecipe {
 				ItemNBTHelper.setString(stack, "SkullOwner", ingr.getHoverName().getString());
 				break;
 			}
+			if (ingr.is(Items.WRITTEN_BOOK)) {
+				GameProfile profile = parseProfileFromBook(ingr, false);
+				ItemNBTHelper.setCompound(stack, "SkullOwner", NbtUtils.writeGameProfile(new CompoundTag(), profile));
+				break;
+			}
 		}
 		return stack;
+	}
+
+	private GameProfile parseProfileFromBook(ItemStack stack, boolean validateOnly) {
+		// tag has been validated, so we know all relevant elements exist
+		CompoundTag tag = stack.getTag();
+		String name = tag.getString(WrittenBookItem.TAG_TITLE);
+		if (name.isBlank()) {
+			return null;
+		}
+
+		ListTag pages = tag.getList(WrittenBookItem.TAG_PAGES, Tag.TAG_STRING);
+
+		// no-nonsense check; at most the first two pages are scanned, and the check fails at the first error
+		int maxPages = Math.min(2, pages.size());
+		for (int i = 0; i < maxPages; ++i) {
+			String pageJson = pages.getString(i);
+			String pageText = parsePage(pageJson);
+
+			Matcher matcher = PROFILE_PATTERN.matcher(pageText);
+			if (matcher.matches()) {
+				// this appears to be the page we were looking for, figure out the skin texture it encodes
+				String textureUrl;
+				String hash, base64, url;
+				if ((hash = matcher.group("hash")) != null) {
+					// simplest case: just the texture hash; complete the URL
+					textureUrl = TEXTURE_URL_BASE + hash;
+				} else if ((url = matcher.group("url")) != null) {
+					// an entire URL was specified; make sure it looks valid
+					try {
+						// just basic URL validation so we don't potentially spam error logs
+						URL validUrl = new URL(url);
+						textureUrl = validUrl.toString();
+					} catch (Exception e) {
+						return null;
+					}
+				} else if ((base64 = matcher.group("base64")) != null) {
+					// complete profile properties; do rudimentary parsing
+					try {
+						final String json = new String(Base64.getDecoder().decode(base64), StandardCharsets.UTF_8);
+						MinecraftTexturesPayload result = gson.get().fromJson(json, MinecraftTexturesPayload.class);
+						MinecraftProfileTexture skinTexture = result.getTextures().get(MinecraftProfileTexture.Type.SKIN);
+						String skinTextureUrl = skinTexture.getUrl();
+						if (!PROFILE_PATTERN.matcher(skinTextureUrl).matches()) {
+							return null;
+						}
+						URL validUrl = new URL(skinTextureUrl);
+						textureUrl = validUrl.toString();
+					} catch (Exception e) {
+						return null;
+					}
+				} else {
+					return null;
+				}
+				if (validateOnly) {
+					return PROFILE_VALID_RESULT;
+				}
+				// we got something that looks like a valid skin texture URL, now build rudimentary profile data
+				String profileTextureJson = "{textures:{SKIN:{url:\"%s\"}}}".formatted(textureUrl);
+				var profile = new GameProfile(null, name);
+				String propertyBase64 = Base64.getEncoder().encodeToString(profileTextureJson.getBytes(StandardCharsets.UTF_8));
+				profile.getProperties().put("textures", new Property("Value", propertyBase64));
+				return profile;
+			}
+		}
+		return null;
+	}
+
+	private static String parsePage(String pageJson) {
+		try {
+			FormattedText formattedtext = Component.Serializer.fromJson(pageJson);
+			return formattedtext != null ? formattedtext.getString() : pageJson;
+		} catch (Exception exception) {
+			return pageJson;
+		}
 	}
 
 	public static class Serializer implements RecipeSerializer<HeadRecipe> {

--- a/Xplat/src/main/java/vazkii/botania/data/recipes/RunicAltarProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/data/recipes/RunicAltarProvider.java
@@ -88,7 +88,7 @@ public class RunicAltarProvider extends BotaniaRecipeProvider {
 		consumer.accept(new FinishedRecipe(idFor("envy"), new ItemStack(BotaniaItems.runeEnvy), costTier3, manaDiamond, manaDiamond, winter, water));
 		consumer.accept(new FinishedRecipe(idFor("pride"), new ItemStack(BotaniaItems.runePride), costTier3, manaDiamond, manaDiamond, summer, fire));
 
-		consumer.accept(new FinishedHeadRecipe(idFor("head"), new ItemStack(Items.PLAYER_HEAD), 22500, Ingredient.of(Items.SKELETON_SKULL), Ingredient.of(BotaniaItems.pixieDust), Ingredient.of(Items.PRISMARINE_CRYSTALS), Ingredient.of(Items.NAME_TAG), Ingredient.of(Items.GOLDEN_APPLE)));
+		consumer.accept(new FinishedHeadRecipe(idFor("head"), new ItemStack(Items.PLAYER_HEAD), 22500, Ingredient.of(Items.SKELETON_SKULL), Ingredient.of(BotaniaItems.pixieDust), Ingredient.of(Items.PRISMARINE_CRYSTALS), Ingredient.of(Items.NAME_TAG, Items.WRITTEN_BOOK), Ingredient.of(Items.GOLDEN_APPLE)));
 	}
 
 	private static ResourceLocation idFor(String s) {

--- a/Xplat/src/main/resources/assets/botania/lang/de_de.json
+++ b/Xplat/src/main/resources/assets/botania/lang/de_de.json
@@ -3608,7 +3608,8 @@
     "botania.entry.headCreating": "Kopfherstellung",
     "botania.tagline.headCreating": "Herstellen des Kopfes beliebiger Spieler",
     "botania.page.headCreating0": "Ein oft angewandter Zauberspruch der Elfen ist die Nutzung einiger Ressourcen und eines $(item)Namensschilds$(0), um ein Stück $(l:basics/pure_daisy)$(item)Lebestein$(0)$(/l) in den Kopf des benannten $(thing)Spielers$(0) zu verwandeln.$(p)Seine genaue Funktionsweise ist unbekannt, aber der Spruch scheint recht einfach mit einem $(l:basics/rune_altar)$(item)Runenaltar$(0)$(/l) replizierbar zu sein.",
-    "botania.page.headCreating2": "Ein Teil der $(thing)Minecraft$(0)-Gemeinde (huch, vierte Wand) hat sich der Herstellung von Köpfen verschrieben, die als Dekoration benutzt werden können. Für begeisterte Dekorateure gibt es Webseiten mit Sammlungen solcher Köpfe.",
+    "botania.page.headCreating3": "Ersetzt man das Namensschild durch ein $(item)Beschriebenes Buch$(0), können dem Prozess noch mehr Informationen zugeführt werden:$(p)Ist der Geheimcode für einen vergangenen $(thing)Skin$(0) in der obskuren Sprache $(thing)Base64$(0) bekannt, kann er in das Buch geschrieben werden, um dieses frühere Aussehen des $(thing)Spielerkopfes$(0) zu beschwören.",
+    "botania.page.headCreating2": "Ein Teil der $(thing)Minecraft$(0)-Gemeinde (huch, vierte Wand) hat sich der Herstellung von Köpfen verschrieben, die als Dekoration benutzt werden können. Für begeisterte Dekorateure gibt es Webseiten mit Sammlungen solcher Köpfe.$(p)Einige Sites bieten auch Befehle mit den notwendigen Base64-codierten Textur-Referenzdaten für die Buchversion des Rezepts. Die Skin-URL oder der Skin-Hash funktionieren ebenfalls.",
     "botania.page.headCreating1": "Bring deinen Kopf ins Spiel",
 
     "botania.entry.azulejo": "Azulejo",

--- a/Xplat/src/main/resources/assets/botania/lang/en_us.json
+++ b/Xplat/src/main/resources/assets/botania/lang/en_us.json
@@ -3621,7 +3621,8 @@
   "botania.entry.headCreating": "Head Creation",
   "botania.tagline.headCreating": "Create any player's head",
   "botania.page.headCreating0": "A commonly-invoked spell of the Elves is the use of a few resources and a $(item)Name Tag$(0) to transmute a piece of $(l:basics/pure_daisy)$(item)Livingrock$(0)$(/l) into the head of the $(thing)Player$(0) named by the tag.$(p)Its exact mechanics are unknown, but the spell seems easy enough to replicate on a $(l:basics/rune_altar)$(item)Runic Altar$(0)$(/l).",
-  "botania.page.headCreating2": "A subset of the $(thing)Minecraft$(0) community (whoops fourth wall) has dedicated itself to creating heads that serve as all sorts of decorations. Avid decorators might consider visiting some community websites that aggregate these heads.",
+  "botania.page.headCreating3": "Replacing the name tag with a $(item)Written Book$(0) (copies work as well) allows channeling even more information into the process:$(p)If the secret code to evoke a past $(thing)Skin$(0) is known in the arcane language of $(thing)Base64$(0), it may be written into a book to conjure that specific historic look of the $(thing)Player$(0)'s head.",
+  "botania.page.headCreating2": "A subset of the $(thing)Minecraft$(0) community (whoops fourth wall) has dedicated itself to creating heads that serve as all sorts of decorations. Avid decorators might consider visiting some community websites that aggregate these heads.$(br)Some sites also provide advanced commands that include the necessary Base64-encoded texture reference data for the book version of the recipe. The actual skin URL or hash will also work.",
   "botania.page.headCreating1": "Get your head in the game",
 
   "botania.entry.azulejo": "Azulejos",

--- a/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/misc/head_creating.json
+++ b/Xplat/src/main/resources/assets/botania/patchouli_books/lexicon/en_us/entries/misc/head_creating.json
@@ -11,6 +11,10 @@
     },
     {
       "type": "text",
+      "text": "botania.page.headCreating3"
+    },
+    {
+      "type": "text",
       "text": "botania.page.headCreating2"
     },
     {

--- a/web/changelog.md
+++ b/web/changelog.md
@@ -22,6 +22,8 @@ of time the maintainers are able to spend on this effort. For the time being, up
 
 * Add: Several missing Forge tags for blocks, items, and entities
 * Add: Munchdew displays particles while in cooldown, similar to a Thermalily (this used to be a thing a long time ago already, but somehow got lost)
+* Add: Creating past versions of player heads is now possible by replacing the name tag with a written book, containing
+  the base64 texture reference data you can find in the player head commands provided by various player skin websites
 * Add: While not in Creative mode, the "Pick Block" feature (usually middle mouse button) can also select certain block
   providers, such as the Rod of the Lands or Black Hole Talisman, if the targeted block's item itself is not available
 * Add: Cauldrons can be filled with the Rod of the Seas (as if using a water bucket) and emptied with the


### PR DESCRIPTION
The name tag in the head recipe can be replaced by a written book. The book's name becomes the player name associated with the head (this name is not validated), and the book's first or second page's content is parsed as the base64 part of the player profile information stored in player heads.

(resolves #4641, supersedes #4770)