### PR TITLE
Fix NPE attenuating sounds if temporary field is unset from elsewhere

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/mixin/client/SoundEngineMixin.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/client/SoundEngineMixin.java
@@ -61,20 +61,22 @@ public class SoundEngineMixin {
 
 	@ModifyArg(index = 0, at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Mth;clamp(FFF)F"), method = "calculateVolume(FLnet/minecraft/sounds/SoundSource;)F")
 	private float bergamuateAttenuate(float volume) {
-		if (tmpSound != null && shouldSilence(tmpSound)) {
+		SoundInstance sound = this.tmpSound;
+
+		if (sound != null && shouldSilence(sound)) {
 			// We halve the volume for each flower (see return below)
 			// halving 8 times already brings the multiplier to near zero, so no
 			// need to keep going if we've seen more than 8.
 			var level = Minecraft.getInstance().level;
 			Pair<Integer, BergamuteBlockEntity> countAndBerg = level == null
 					? Pair.of(0, null)
-					: BergamuteBlockEntity.getBergamutesNearby(level, tmpSound.getX(), tmpSound.getY(), tmpSound.getZ(), 8);
+					: BergamuteBlockEntity.getBergamutesNearby(level, sound.getX(), sound.getY(), sound.getZ(), 8);
 			int count = countAndBerg.getFirst();
 			if (count > 0) {
 				if (mutedSounds == null) {
 					mutedSounds = Collections.newSetFromMap(new WeakHashMap<>());
 				}
-				if (mutedSounds.add(tmpSound) && Math.random() < 0.5) {
+				if (mutedSounds.add(sound) && Math.random() < 0.5) {
 					BergamuteBlockEntity.particle(countAndBerg.getSecond());
 				}
 


### PR DESCRIPTION
Fix NPE in sound engine mixin if the `tmpSound` field is unset while sounds are attenuated by storing it locally.  
This would probably be better off using [MixinExtras' Share](https://github.com/LlamaLad7/MixinExtras/wiki/Share), but I was unsure whether I should add a new dependency.

A user reported this issue to a different mod I maintain, however since it keeps all its sound engine operations on the main thread it shouldn't be the cause. See the issue here: https://github.com/juliand665/Dynamic-FPS/issues/257