### PR TITLE
Support lighting incense plate with custom lighters (Forge) and fire charges

### DIFF
--- a/Fabric/src/main/java/vazkii/botania/fabric/xplat/FabricXplatImpl.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/xplat/FabricXplatImpl.java
@@ -63,6 +63,7 @@ import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -621,6 +622,11 @@ public class FabricXplatImpl implements XplatAbstractions {
 	@Override
 	public FoodProperties getFoodProperties(ItemStack stack) {
 		return stack.getItem().getFoodProperties();
+	}
+
+	@Override
+	public boolean canToolLightFire(ItemStack stack) {
+		return stack.is(Items.FLINT_AND_STEEL);
 	}
 
 	@Override

--- a/Forge/src/main/java/vazkii/botania/forge/xplat/ForgeXplatImpl.java
+++ b/Forge/src/main/java/vazkii/botania/forge/xplat/ForgeXplatImpl.java
@@ -35,6 +35,7 @@ import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.BucketItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.item.crafting.RecipeType;
 import net.minecraft.world.level.ChunkPos;
@@ -57,6 +58,7 @@ import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.Tags;
+import net.minecraftforge.common.ToolAction;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.extensions.IForgeMenuType;
 import net.minecraftforge.common.util.LazyOptional;
@@ -608,6 +610,11 @@ public class ForgeXplatImpl implements XplatAbstractions {
 	@Override
 	public FoodProperties getFoodProperties(ItemStack stack) {
 		return stack.getFoodProperties(null);
+	}
+
+	@Override
+	public boolean canToolLightFire(ItemStack stack) {
+		return stack.is(Items.FLINT_AND_STEEL) || stack.canPerformAction(ToolAction.get("light_fire"));
 	}
 
 	@Override

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/IncensePlateBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/IncensePlateBlockEntity.java
@@ -113,6 +113,7 @@ public class IncensePlateBlockEntity extends ExposedSimpleInventoryBlockEntity i
 		if (self.comparatorOutput != newComparator) {
 			self.comparatorOutput = newComparator;
 			level.updateNeighbourForOutputSignal(worldPosition, state.getBlock());
+			self.setChanged();
 		}
 	}
 
@@ -145,7 +146,7 @@ public class IncensePlateBlockEntity extends ExposedSimpleInventoryBlockEntity i
 		burning = true;
 		Brew brew = ((IncenseStickItem) BotaniaItems.incenseStick).getBrew(stack);
 		timeLeft = brew.getPotionEffects(stack).get(0).getDuration() * IncenseStickItem.TIME_MULTIPLIER;
-		level.playSound(null, getBlockPos(), BotaniaSounds.incensePlateIgnite, SoundSource.BLOCKS, 1F, 1F);
+		level.playSound(null, getBlockPos(), BotaniaSounds.incensePlateIgnite, SoundSource.BLOCKS, 0.5F, 1.75F);
 		level.gameEvent(null, GameEvent.BLOCK_ACTIVATE, getBlockPos());
 	}
 

--- a/Xplat/src/main/java/vazkii/botania/xplat/XplatAbstractions.java
+++ b/Xplat/src/main/java/vazkii/botania/xplat/XplatAbstractions.java
@@ -210,6 +210,7 @@ public interface XplatAbstractions {
 	int transferEnergyToNeighbors(Level level, BlockPos pos, int energy);
 	@Nullable
 	FoodProperties getFoodProperties(ItemStack stack);
+	boolean canToolLightFire(ItemStack stack);
 
 	// Red string container
 	boolean isRedStringContainerTarget(BlockEntity be);

--- a/Xplat/src/main/resources/assets/botania/sounds.json
+++ b/Xplat/src/main/resources/assets/botania/sounds.json
@@ -324,12 +324,7 @@
 		"subtitle": "botania.subtitle.hornDoot"
 	},
 	"incense_plate_ignite": {
-		"sounds": [
-			{
-				"type": "event",
-				"name": "minecraft:item.flintandsteel.use"
-			}
-		],
+		"sounds": ["botania:spreaderfire"],
 		"subtitle": "botania.subtitle.incensePlateIgnite"
 	},
 	"labellia": {

--- a/web/changelog.md
+++ b/web/changelog.md
@@ -29,6 +29,7 @@ of time the maintainers are able to spend on this effort. For the time being, up
 * Add: Cauldrons can be filled with the Rod of the Seas (as if using a water bucket) and emptied with the
   Extrapolated Bucket (as if using an empty bucket on a full version of the cauldron)
 * Add: Short descriptions for lexicon categories (based on contributions by bellasalmonella)
+* Add: Incense plate supports fire charges and custom igniters (e.g. Tinkers Flint and Brick) to light the incense stick
 * Change: Sparks can no longer be hit by projectiles other than mana bursts
 * Change: Fake players using a wand of the forest on either type of spark are now treated as if the player was sneaking, since that is likely the intended interaction
 * Fix: The boss bar for the gaia ritual no longer starts full and quickly empties at the start of the spawn sequence


### PR DESCRIPTION
Includes better audio cue, properly marks the block entity as changed, and fixes #4875.