### PR TITLE
Unbreaking fix but for real

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/ToolCommons.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/ToolCommons.java
@@ -48,7 +48,7 @@ public final class ToolCommons {
 		}
 
 		while (amount > 0) {
-			if (entity.getRNG().nextInt(EnchantmentHelper.getEnchantmentLevel(Enchantment.unbreaking.effectId, stack) + 1) == 0 || ManaItemHandler.instance().requestManaExactForTool(stack, player, manaPerDamage, true)) {
+			if (entity.level().getRandom().nextInt(EnchantmentHelper.getEnchantmentLevel(Enchantment.unbreaking.effectId, stack) + 1) == 0 || ManaItemHandler.instance().requestManaExactForTool(stack, player, manaPerDamage, true)) {
 				amount--;
 			} else {
 				break;

--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/ToolCommons.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/ToolCommons.java
@@ -48,7 +48,7 @@ public final class ToolCommons {
 		}
 
 		while (amount > 0) {
-			if (entity.getRNG().nextInt(EnchantmentHelper.getEnchantmentLevel(Enchantment.unbreaking.effectId, stack) + 1) == 0 && ManaItemHandler.instance().requestManaExactForTool(stack, player, manaPerDamage, true)) {
+			if (entity.getRNG().nextInt(EnchantmentHelper.getEnchantmentLevel(Enchantment.unbreaking.effectId, stack) + 1) == 0 || ManaItemHandler.instance().requestManaExactForTool(stack, player, manaPerDamage, true)) {
 				amount--;
 			} else {
 				break;

--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/ToolCommons.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/ToolCommons.java
@@ -48,7 +48,7 @@ public final class ToolCommons {
 		}
 
 		while (amount > 0) {
-			if (entity.level().getRandom().nextInt(EnchantmentHelper.getEnchantmentLevel(Enchantment.unbreaking.effectId, stack) + 1) == 0 || ManaItemHandler.instance().requestManaExactForTool(stack, player, manaPerDamage, true)) {
+			if (entity.level().getRandom().nextInt(EnchantmentHelper.getItemEnchantmentLevel(Enchantments.UNBREAKING, stack) + 1) == 0 || ManaItemHandler.instance().requestManaExactForTool(stack, player, manaPerDamage, true)) {
 				amount--;
 			} else {
 				break;

--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/ToolCommons.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/ToolCommons.java
@@ -48,7 +48,7 @@ public final class ToolCommons {
 		}
 
 		while (amount > 0) {
-			if (ManaItemHandler.instance().requestManaExactForTool(stack, player, manaPerDamage, true)) {
+			if (entity.getRNG().nextInt(EnchantmentHelper.getEnchantmentLevel(Enchantment.unbreaking.effectId, stack) + 1) == 0 && ManaItemHandler.instance().requestManaExactForTool(stack, player, manaPerDamage, true)) {
 				amount--;
 			} else {
 				break;

--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/ToolCommons.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/ToolCommons.java
@@ -48,7 +48,8 @@ public final class ToolCommons {
 		}
 
 		while (amount > 0) {
-			if (entity.level().getRandom().nextInt(EnchantmentHelper.getItemEnchantmentLevel(Enchantments.UNBREAKING, stack) + 1) == 0 || ManaItemHandler.instance().requestManaExactForTool(stack, player, manaPerDamage, true)) {
+			if (ManaItemHandler.instance().requestManaExactForTool(stack, player, manaPerDamage, false) && entity.level().getRandom().nextInt(EnchantmentHelper.getItemEnchantmentLevel(Enchantments.UNBREAKING, stack) + 1) == 0) {
+				ManaItemHandler.instance().requestManaExactForTool(stack, player, manaPerDamage, true);
 				amount--;
 			} else {
 				break;


### PR DESCRIPTION
Allows the unbreaking enchant to reduce mana costs. Currently uses the default unbreaking logic for all items, making it more efficient than normal on armor pieces, but I'd argue that's on the armor for using ToolCommons