### PR TITLE
Improve mana burst handling of potentially unloaded chunks

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/api/internal/ManaBurst.java
+++ b/Xplat/src/main/java/vazkii/botania/api/internal/ManaBurst.java
@@ -9,11 +9,14 @@
 package vazkii.botania.api.internal;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.GlobalPos;
 import net.minecraft.world.entity.projectile.ThrowableProjectile;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ManaBurst {
@@ -56,6 +59,14 @@ public interface ManaBurst {
 	BlockPos getBurstSourceBlockPos();
 
 	void setBurstSourceCoords(BlockPos pos);
+
+	Optional<GlobalPos> getBurstSource();
+
+	void setBurstSource(@Nullable GlobalPos sourcePos);
+
+	default boolean isBurstSourceDimension(Level testLevel) {
+		return getBurstSource().map(GlobalPos::dimension).map(testLevel.dimension()::equals).orElse(false);
+	}
 
 	ItemStack getSourceLens();
 

--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/SpectranthemumBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/SpectranthemumBlockEntity.java
@@ -24,6 +24,7 @@ import vazkii.botania.api.block_entity.FunctionalFlowerBlockEntity;
 import vazkii.botania.api.block_entity.RadiusDescriptor;
 import vazkii.botania.common.block.BotaniaFlowerBlocks;
 import vazkii.botania.common.helper.DelayHelper;
+import vazkii.botania.common.helper.EntityHelper;
 import vazkii.botania.common.proxy.Proxy;
 import vazkii.botania.network.EffectType;
 import vazkii.botania.network.clientbound.BotaniaEffectPacket;
@@ -70,7 +71,9 @@ public class SpectranthemumBlockEntity extends FunctionalFlowerBlockEntity {
 				double cost = BASE_COST * stack.getCount() * Math.sqrt(bindPos.distToCenterSqr(item.position()));
 				if (getMana() >= cost) {
 					spawnExplosionParticles(item, 10);
+					BlockPos sourcePos = item.blockPosition();
 					item.setPos(bindPos.getX() + 0.5, bindPos.getY() + 1.5, bindPos.getZ() + 0.5);
+					EntityHelper.addTeleportTicketIfFarAway(item, sourcePos);
 					item.setDeltaMovement(Vec3.ZERO);
 					spawnExplosionParticles(item, 10);
 					addMana(-(int) cost);

--- a/Xplat/src/main/java/vazkii/botania/common/entity/ManaBurstEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/entity/ManaBurstEntity.java
@@ -9,6 +9,8 @@
 package vazkii.botania.common.entity;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.GlobalPos;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
@@ -16,6 +18,8 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.network.syncher.EntityDataSerializers;
 import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
@@ -63,6 +67,7 @@ public class ManaBurstEntity extends ThrowableProjectile implements ManaBurst {
 	private static final String TAG_SPREADER_X = "spreaderX";
 	private static final String TAG_SPREADER_Y = "spreaderY";
 	private static final String TAG_SPREADER_Z = "spreaderZ";
+	private static final String TAG_SPREADER_DIM = "spreaderDim";
 	private static final String TAG_GRAVITY = "gravity";
 	private static final String TAG_LENS_STACK = "lensStack";
 	private static final String TAG_HAS_SHOOTER = "hasShooter";
@@ -83,7 +88,7 @@ public class ManaBurstEntity extends ThrowableProjectile implements ManaBurst {
 	private static final EntityDataAccessor<Integer> MIN_MANA_LOSS = SynchedEntityData.defineId(ManaBurstEntity.class, EntityDataSerializers.INT);
 	private static final EntityDataAccessor<Float> MANA_LOSS_PER_TICK = SynchedEntityData.defineId(ManaBurstEntity.class, EntityDataSerializers.FLOAT);
 	private static final EntityDataAccessor<Float> GRAVITY = SynchedEntityData.defineId(ManaBurstEntity.class, EntityDataSerializers.FLOAT);
-	private static final EntityDataAccessor<BlockPos> SOURCE_COORDS = SynchedEntityData.defineId(ManaBurstEntity.class, EntityDataSerializers.BLOCK_POS);
+	private static final EntityDataAccessor<Optional<GlobalPos>> SOURCE_COORDS = SynchedEntityData.defineId(ManaBurstEntity.class, EntityDataSerializers.OPTIONAL_GLOBAL_POS);
 	private static final EntityDataAccessor<ItemStack> SOURCE_LENS = SynchedEntityData.defineId(ManaBurstEntity.class, EntityDataSerializers.ITEM_STACK);
 	private static final EntityDataAccessor<Boolean> LEFT_SOURCE_POS = SynchedEntityData.defineId(ManaBurstEntity.class, EntityDataSerializers.BOOLEAN);
 
@@ -114,7 +119,7 @@ public class ManaBurstEntity extends ThrowableProjectile implements ManaBurst {
 		entityData.define(MIN_MANA_LOSS, 0);
 		entityData.define(MANA_LOSS_PER_TICK, 0F);
 		entityData.define(GRAVITY, 0F);
-		entityData.define(SOURCE_COORDS, ManaBurst.NO_SOURCE);
+		entityData.define(SOURCE_COORDS, Optional.<GlobalPos>empty());
 		entityData.define(SOURCE_LENS, ItemStack.EMPTY);
 		entityData.define(LEFT_SOURCE_POS, false);
 	}
@@ -158,7 +163,7 @@ public class ManaBurstEntity extends ThrowableProjectile implements ManaBurst {
 		setTicksExisted(getTicksExisted() + 1);
 		if ((!level().isClientSide || fake)
 				&& !hasLeftSource()
-				&& !blockPosition().equals(getBurstSourceBlockPos())) {
+				&& (!blockPosition().equals(getBurstSourceBlockPos()) || !isBurstSourceDimension(level()))) {
 			// XXX: Should this check by bounding box instead of simply blockPosition()?
 			// The burst's origin could be in another coord but part of its box still intersecting the source block
 			// Not sure if that will trigger a collision then
@@ -262,10 +267,14 @@ public class ManaBurstEntity extends ThrowableProjectile implements ManaBurst {
 		}
 		tag.put(TAG_LENS_STACK, lensCmp);
 
-		BlockPos coords = getBurstSourceBlockPos();
+		Optional<GlobalPos> sourcePos = getBurstSource();
+		BlockPos coords = sourcePos.map(GlobalPos::pos).orElse(NO_SOURCE);
 		tag.putInt(TAG_SPREADER_X, coords.getX());
 		tag.putInt(TAG_SPREADER_Y, coords.getY());
 		tag.putInt(TAG_SPREADER_Z, coords.getZ());
+		if (sourcePos.isPresent()) {
+			tag.putString(TAG_SPREADER_DIM, sourcePos.get().dimension().location().toString());
+		}
 
 		if (lastCollision != null) {
 			tag.putInt(TAG_LAST_COLLISION_X, lastCollision.getX());
@@ -316,8 +325,13 @@ public class ManaBurstEntity extends ThrowableProjectile implements ManaBurst {
 		int x = cmp.getInt(TAG_SPREADER_X);
 		int y = cmp.getInt(TAG_SPREADER_Y);
 		int z = cmp.getInt(TAG_SPREADER_Z);
-
-		setBurstSourceCoords(new BlockPos(x, y, z));
+		BlockPos sourceCoords = new BlockPos(x, y, z);
+		if (NO_SOURCE.equals(sourceCoords)) {
+			setBurstSource(null);
+		} else {
+			ResourceLocation dim = cmp.contains(TAG_SPREADER_DIM) ? ResourceLocation.tryParse(cmp.getString(TAG_SPREADER_DIM)) : null;
+			setBurstSource(GlobalPos.of(dim != null ? ResourceKey.create(Registries.DIMENSION, dim) : level().dimension(), sourceCoords));
+		}
 
 		if (cmp.contains(TAG_LAST_COLLISION_X)) {
 			x = cmp.getInt(TAG_LAST_COLLISION_X);
@@ -610,9 +624,17 @@ public class ManaBurstEntity extends ThrowableProjectile implements ManaBurst {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	@Nullable
 	private ManaSpreader getShooter() {
-		var receiver = XplatAbstractions.INSTANCE.findManaReceiver(level(), getBurstSourceBlockPos(), null);
+		if (!isBurstSourceDimension(level())) {
+			return null;
+		}
+		BlockPos sourceBlockPos = getBurstSourceBlockPos();
+		if (!level().hasChunkAt(sourceBlockPos)) {
+			return null;
+		}
+		var receiver = XplatAbstractions.INSTANCE.findManaReceiver(level(), sourceBlockPos, null);
 		return receiver instanceof ManaSpreader spreader ? spreader : null;
 	}
 
@@ -697,12 +719,28 @@ public class ManaBurstEntity extends ThrowableProjectile implements ManaBurst {
 
 	@Override
 	public BlockPos getBurstSourceBlockPos() {
-		return entityData.get(SOURCE_COORDS);
+		return entityData.get(SOURCE_COORDS).map(GlobalPos::pos).orElse(NO_SOURCE);
 	}
 
 	@Override
 	public void setBurstSourceCoords(BlockPos pos) {
-		entityData.set(SOURCE_COORDS, pos);
+		if (pos.equals(NO_SOURCE)) {
+			entityData.set(SOURCE_COORDS, Optional.empty());
+		} else {
+			Optional<GlobalPos> source = entityData.get(SOURCE_COORDS);
+			entityData.set(SOURCE_COORDS,
+					Optional.of(GlobalPos.of(source.map(GlobalPos::dimension).orElse(level().dimension()), pos)));
+		}
+	}
+
+	@Override
+	public Optional<GlobalPos> getBurstSource() {
+		return entityData.get(SOURCE_COORDS);
+	}
+
+	@Override
+	public void setBurstSource(@Nullable GlobalPos sourcePos) {
+		entityData.set(SOURCE_COORDS, Optional.ofNullable(sourcePos));
 	}
 
 	@Override

--- a/Xplat/src/main/java/vazkii/botania/common/helper/EntityHelper.java
+++ b/Xplat/src/main/java/vazkii/botania/common/helper/EntityHelper.java
@@ -1,10 +1,15 @@
 package vazkii.botania.common.helper;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.TicketType;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ChunkPos;
 
 public class EntityHelper {
 	/**
@@ -62,6 +67,20 @@ public class EntityHelper {
 		MobEffectInstance effect = living.getEffect(mobEffect);
 		if (effect != null && effect.getAmplifier() == expectedAmplifier && effect.isInfiniteDuration()) {
 			living.removeEffect(mobEffect);
+		}
+	}
+
+	/**
+	 * Creates a "post-teleport" chunk loading ticket for the specified entity if it is located at least two chunks
+	 * away from the specified source position in one of the cardinal directions.
+	 * The post-teleport ticket only keeps the target chunk loaded for a bit to potentially reduce loading/unloading
+	 * related lag spikes, but does not necessarily make the target chunk entity-/redstone-processing.
+	 */
+	public static void addTeleportTicketIfFarAway(Entity entity, BlockPos sourcePos) {
+		ChunkPos entityChunk = new ChunkPos(entity.blockPosition());
+		ChunkPos sourceChunk = new ChunkPos(sourcePos);
+		if (entity.level() instanceof ServerLevel serverLevel && entityChunk.getChessboardDistance(sourceChunk) > 2) {
+			serverLevel.getChunkSource().addRegionTicket(TicketType.POST_TELEPORT, entityChunk, 0, entity.getId());
 		}
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/item/lens/BoreLens.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/lens/BoreLens.java
@@ -31,6 +31,7 @@ import vazkii.botania.api.internal.ManaBurst;
 import vazkii.botania.common.block.BotaniaBlocks;
 import vazkii.botania.common.block.block_entity.mana.ManaSpreaderBlockEntity;
 import vazkii.botania.common.entity.ManaBurstEntity;
+import vazkii.botania.common.helper.EntityHelper;
 import vazkii.botania.common.item.BotaniaItems;
 import vazkii.botania.xplat.BotaniaConfig;
 
@@ -81,7 +82,7 @@ public class BoreLens extends Lens {
 						world.levelEvent(LevelEvent.PARTICLES_DESTROY_BLOCK, collidePos, Block.getId(state));
 					}
 
-					boolean sourceless = source.equals(ManaBurst.NO_SOURCE);
+					boolean sourceless = source.equals(ManaBurst.NO_SOURCE) || !burst.isBurstSourceDimension(world);
 					boolean doWarp = warpItems && !sourceless;
 					Vec3 dropPosition;
 					if (doWarp && world.getBlockEntity(source) instanceof ManaSpreaderBlockEntity spreader) {
@@ -104,7 +105,7 @@ public class BoreLens extends Lens {
 						for (ItemStack stack_ : items) {
 							ItemEntity itemEntity = new ItemEntity(world, dropPosition.x, dropPosition.y, dropPosition.z, stack_);
 							itemEntity.setDefaultPickUpDelay();
-							world.addFreshEntity(itemEntity);
+							EntityHelper.addTeleportTicketIfFarAway(itemEntity, collidePos);
 						}
 					}
 

--- a/Xplat/src/main/java/vazkii/botania/common/item/lens/RedirectiveLens.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/lens/RedirectiveLens.java
@@ -11,6 +11,7 @@ package vazkii.botania.common.item.lens;
 import net.minecraft.commands.arguments.EntityAnchorArgument;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.*;
 import net.minecraft.world.phys.shapes.VoxelShape;
 
@@ -42,15 +43,17 @@ public class RedirectiveLens extends Lens {
 		return shouldKill;
 	}
 
+	@SuppressWarnings("deprecation")
 	@Nullable
 	private static Vec3 getSourceVec(ManaBurst burst) {
 		var entity = burst.entity();
 		var owner = entity.getOwner();
 		var sourcePos = burst.getBurstSourceBlockPos();
-		if (!sourcePos.equals(ManaBurst.NO_SOURCE)) {
+		Level level = entity.level();
+		if (!sourcePos.equals(ManaBurst.NO_SOURCE) && burst.isBurstSourceDimension(level) && level.hasChunkAt(sourcePos)) {
 			var sourceVec = Vec3.atCenterOf(sourcePos);
 			AABB axis;
-			VoxelShape collideShape = entity.level().getBlockState(sourcePos).getCollisionShape(entity.level(), sourcePos);
+			VoxelShape collideShape = level.getBlockState(sourcePos).getCollisionShape(level, sourcePos);
 			if (collideShape.isEmpty()) {
 				axis = new AABB(sourcePos, sourcePos.offset(1, 1, 1));
 			} else {

--- a/Xplat/src/main/java/vazkii/botania/common/item/lens/WarpLens.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/lens/WarpLens.java
@@ -18,6 +18,7 @@ import net.minecraft.world.phys.HitResult;
 import vazkii.botania.api.internal.ManaBurst;
 import vazkii.botania.common.block.BotaniaBlocks;
 import vazkii.botania.common.block.ForceRelayBlock;
+import vazkii.botania.common.helper.EntityHelper;
 
 public class WarpLens extends Lens {
 
@@ -33,12 +34,14 @@ public class WarpLens extends Lens {
 		}
 
 		BlockPos hit = ((BlockHitResult) pos).getBlockPos();
-		if (entity.level().getBlockState(hit).is(BotaniaBlocks.pistonRelay)) {
-			ForceRelayBlock.WorldData data = ForceRelayBlock.WorldData.get(entity.level());
+		if (world.getBlockState(hit).is(BotaniaBlocks.pistonRelay)) {
+			ForceRelayBlock.WorldData data = ForceRelayBlock.WorldData.get(world);
 			BlockPos dest = data.mapping.get(hit);
 
 			if (dest != null) {
-				entity.setPos(dest.getX() + 0.5, dest.getY() + 0.5, dest.getZ() + 0.5);
+				BlockPos sourcePos = entity.blockPosition();
+				entity.setPos(dest.getCenter());
+				EntityHelper.addTeleportTicketIfFarAway(entity, sourcePos);
 				burst.setCollidedAt(dest);
 
 				burst.setWarped(true);


### PR DESCRIPTION
- bursts track their source dimension so they don't attempt to look at a completely unrelated position in a different dimension when looking for their source spreader
- redirective lens can only operate in its source dimension, and only if its source spreader is still loaded
- warp lens adds a "post-teleport" chunk loading ticket when the burst is teleported via a force relay, similar to entities traveling through an end gateway (this does not enable block entity ticking on its own)
- bore-warp lens can only teleport items in its source dimension; it adds a "post-teleport" chunk loading ticket when teleporting items to the source spreader

(fixes #4928)