### PR TITLE
Remove redundant beheading code for Elementium Axe on Forge

### DIFF
--- a/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
+++ b/Forge/src/main/java/vazkii/botania/forge/ForgeCommonInitializer.java
@@ -110,7 +110,6 @@ import vazkii.botania.common.integration.corporea.CorporeaNodeDetectors;
 import vazkii.botania.common.item.*;
 import vazkii.botania.common.item.equipment.armor.terrasteel.TerrasteelHelmItem;
 import vazkii.botania.common.item.equipment.bauble.*;
-import vazkii.botania.common.item.equipment.tool.elementium.ElementiumAxeItem;
 import vazkii.botania.common.item.equipment.tool.terrasteel.TerraBladeItem;
 import vazkii.botania.common.item.equipment.tool.terrasteel.TerraShattererItem;
 import vazkii.botania.common.item.equipment.tool.terrasteel.TerraTruncatorItem;
@@ -396,11 +395,6 @@ public class ForgeCommonInitializer {
 		{
 			bus.addListener((LivingDropsEvent e) -> {
 				var living = e.getEntity();
-				ElementiumAxeItem.onEntityDrops(e.isRecentlyHit(), e.getSource(), living, stack -> {
-					var ent = new ItemEntity(living.level(), living.getX(), living.getY(), living.getZ(), stack);
-					ent.setDefaultPickUpDelay();
-					e.getDrops().add(ent);
-				});
 				LooniumBlockEntity.dropLooniumItems(living, stack -> {
 					e.getDrops().clear();
 					if (!stack.isEmpty()) {

--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ElementiumAxeItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/elementium/ElementiumAxeItem.java
@@ -9,25 +9,17 @@
 package vazkii.botania.common.item.equipment.tool.elementium;
 
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.Enchantments;
-import net.minecraft.world.level.storage.loot.LootParams;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 
 import org.jetbrains.annotations.NotNull;
 
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.common.annotations.SoftImplement;
 import vazkii.botania.common.item.equipment.tool.manasteel.ManasteelAxeItem;
-
-import java.util.function.Consumer;
 
 import static vazkii.botania.common.lib.ResourceLocationHelper.prefix;
 
@@ -36,23 +28,6 @@ public class ElementiumAxeItem extends ManasteelAxeItem {
 
 	public ElementiumAxeItem(Properties props) {
 		super(BotaniaAPI.instance().getElementiumItemTier(), 6F, -3.1F, props);
-	}
-
-	public static void onEntityDrops(boolean hitRecently, DamageSource source, LivingEntity target,
-			Consumer<ItemStack> consumer) {
-		LootParams.Builder ctx = (new LootParams.Builder((ServerLevel) target.level()))
-				.withParameter(LootContextParams.THIS_ENTITY, target)
-				.withParameter(LootContextParams.ORIGIN, target.position())
-				.withParameter(LootContextParams.DAMAGE_SOURCE, source)
-				.withOptionalParameter(LootContextParams.KILLER_ENTITY, source.getEntity())
-				.withOptionalParameter(LootContextParams.DIRECT_KILLER_ENTITY, source.getDirectEntity());
-
-		if (hitRecently && target.getKillCredit() != null && target.getKillCredit() instanceof Player p) {
-			ctx = ctx.withParameter(LootContextParams.LAST_DAMAGE_PLAYER, p).withLuck(p.getLuck());
-		}
-
-		target.level().getServer().getLootData().getLootTable(BEHEADING_LOOT_TABLE)
-				.getRandomItems(ctx.create(LootContextParamSets.ENTITY), target.getLootTableSeed(), consumer);
 	}
 
 	@SoftImplement("IForgeItem")

--- a/web/changelog.md
+++ b/web/changelog.md
@@ -42,6 +42,7 @@ In the meantime, Botania for Minecraft 1.20.1 may still receive updates for bug 
 * Fix: Mana bursts going through a nether portal could cause lag spikes
 * Fix: Potential client memory leak in ManaNetworkHandler
 * Fix: Guardian of Gaia stopped teleporting until getting hit after a world reload
+* Fix: Elementium Axe beheading logic could run twice and still duplicate LootJS script executions on Forge
 
 ---
 


### PR DESCRIPTION
(left-over from #4752; fixes #4954)