### PR TITLE
Add getProvidedBlock method to BlockProvider

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/api/item/BlockProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/api/item/BlockProvider.java
@@ -40,7 +40,10 @@ public interface BlockProvider {
 	int getBlockCount(Player player, ItemStack requestor, Block block);
 
 	/**
-	 * @return the block that this provides. null if the block is not easily determinable
+	 * The value returned here may be null, to represent that the block that this provides is not easily
+	 * determinable or that this can provide multiple blocks and none of them are a 'main' block that this
+	 * item intuitively provides.
+	 * @return the block that this provides.
 	 */
 	@Nullable // TODO: in 1.21 this may be able to be made not default as a breaking API change
 	default Block getProvidedBlock(Player player, ItemStack requestor) {

--- a/Xplat/src/main/java/vazkii/botania/api/item/BlockProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/api/item/BlockProvider.java
@@ -43,6 +43,7 @@ public interface BlockProvider {
 	 * The value returned here may be null, to represent that the block that this provides is not easily
 	 * determinable or that this can provide multiple blocks and none of them are a 'main' block that this
 	 * item intuitively provides.
+	 * 
 	 * @return the block that this provides.
 	 */
 	@Nullable // TODO: in 1.21 this may be able to be made not default as a breaking API change

--- a/Xplat/src/main/java/vazkii/botania/api/item/BlockProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/api/item/BlockProvider.java
@@ -12,7 +12,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * An Item that has this capability can provide blocks to other items that use them.

--- a/Xplat/src/main/java/vazkii/botania/api/item/BlockProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/api/item/BlockProvider.java
@@ -12,6 +12,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 
+import javax.annotation.Nullable;
+
 /**
  * An Item that has this capability can provide blocks to other items that use them.
  * For example, the Black Hole Talisman uses this in order to allow for
@@ -37,4 +39,11 @@ public interface BlockProvider {
 	 */
 	int getBlockCount(Player player, ItemStack requestor, Block block);
 
+	/**
+	 * @return the block that this provides. null if the block is not easily determinable
+	 */
+	@Nullable // TODO: in 1.21 this may be able to be made not default as a breaking API change
+	default Block getProvidedBlock(Player player, ItemStack requestor) {
+		return null;
+	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/helper/BlockProviderHelper.java
+++ b/Xplat/src/main/java/vazkii/botania/common/helper/BlockProviderHelper.java
@@ -6,6 +6,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 
 import org.jetbrains.annotations.Nullable;
+
 import vazkii.botania.api.item.BlockProvider;
 
 public class BlockProviderHelper {

--- a/Xplat/src/main/java/vazkii/botania/common/helper/BlockProviderHelper.java
+++ b/Xplat/src/main/java/vazkii/botania/common/helper/BlockProviderHelper.java
@@ -1,9 +1,11 @@
 package vazkii.botania.common.helper;
 
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 
+import org.jetbrains.annotations.Nullable;
 import vazkii.botania.api.item.BlockProvider;
 
 public class BlockProviderHelper {
@@ -32,6 +34,11 @@ public class BlockProviderHelper {
 				return 0;
 			}
 			return player.getAbilities().instabuild ? -1 : stack.getCount();
+		}
+
+		@Override
+		public @Nullable Block getProvidedBlock(Player player, ItemStack requestor) {
+			return stack.getItem() instanceof BlockItem blockItem ? blockItem.getBlock() : null;
 		}
 	}
 

--- a/Xplat/src/main/java/vazkii/botania/common/item/BlackHoleTalismanItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/BlackHoleTalismanItem.java
@@ -267,6 +267,11 @@ public class BlackHoleTalismanItem extends Item {
 			}
 			return 0;
 		}
+
+		@Override
+		public @Nullable Block getProvidedBlock(Player player, ItemStack requestor) {
+			return getBlock(stack);
+		}
 	}
 
 	@Override

--- a/Xplat/src/main/java/vazkii/botania/common/item/rod/DepthsRodItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/rod/DepthsRodItem.java
@@ -52,6 +52,11 @@ public class DepthsRodItem extends Item {
 			}
 			return 0;
 		}
+
+		@Override
+		public Block getProvidedBlock(Player player, ItemStack requestor) {
+			return Blocks.COBBLESTONE;
+		}
 	}
 
 }

--- a/Xplat/src/main/java/vazkii/botania/common/item/rod/LandsRodItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/rod/LandsRodItem.java
@@ -99,6 +99,11 @@ public class LandsRodItem extends Item {
 			}
 			return 0;
 		}
+
+		@Override
+		public Block getProvidedBlock(Player player, ItemStack requestor) {
+			return Blocks.DIRT;
+		}
 	}
 
 	public static class AvatarBehavior implements AvatarWieldable {

--- a/Xplat/src/main/java/vazkii/botania/common/item/rod/TerraFirmaRodItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/rod/TerraFirmaRodItem.java
@@ -161,5 +161,10 @@ public class TerraFirmaRodItem extends Item {
 			}
 			return 0;
 		}
+
+		@Override
+		public Block getProvidedBlock(Player player, ItemStack requestor) {
+			return Blocks.DIRT;
+		}
 	}
 }


### PR DESCRIPTION
This lets people determine what a block provider provides without iterating the registry.

My plan for this is compatibility with Tinkers Construct exchanging ability, which replaces mined blocks with the block in the offhand, and adding the ability to provide blocks from things such as the black hole talisman. To replace the block Tinkers needs to know what block its placing.

This is not a breaking change to the API as the method has a default implementation, so the two published addons that implement this interface won't break.