### PR TITLE
Restrict dominant sparks to pulling from a single spark per tick

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/entity/ManaSparkEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/entity/ManaSparkEntity.java
@@ -60,7 +60,8 @@ public class ManaSparkEntity extends SparkBaseEntity implements ManaSpark {
 
 	private final Set<ManaSpark> outgoingTransfers = Collections.newSetFromMap(new WeakHashMap<>());
 
-	private final ArrayList<ManaSpark> inboundTransfers = new ArrayList<>();
+	@Nullable
+	private ManaSpark inboundTransfer = null;
 
 	private boolean shouldFilterTransfers = true;
 	private boolean receiverWasFull = true;
@@ -215,34 +216,26 @@ public class ManaSparkEntity extends SparkBaseEntity implements ManaSpark {
 				receiver.receiveMana(-manaSpent);
 			}
 		}
-		if (!inboundTransfers.isEmpty()) {
-			int manaNeeded = Math.min(TRANSFER_RATE * inboundTransfers.size(), tile.getAvailableSpaceForMana());
-			int count = inboundTransfers.size();
-			int manaRecieved = 0;
+		int manaNeeded = Math.min(TRANSFER_RATE, tile.getAvailableSpaceForMana());
 
-			if (manaNeeded > 0) {
-				if (shouldFilterTransfers) {
-					filterTransfers();
-					shouldFilterTransfers = false;
-				}
+		if (manaNeeded > 0) {
+			if (shouldFilterTransfers) {
+				filterTransfers();
+				shouldFilterTransfers = false;
+			}
 
-				inboundTransfers.sort(Comparator.comparingInt(s -> s.getAttachedManaReceiver().getCurrentMana()));
-				for (ManaSpark spark : inboundTransfers) {
-					count--;
-					SparkAttachable attached = spark.getAttachedTile();
-					var attachedReceiver = spark.getAttachedManaReceiver();
-					if (attached == null || attachedReceiver == null) {
-						shouldFilterTransfers = true;
-						continue;
-					}
-
-					int gained = Math.min(attachedReceiver.getCurrentMana(), (manaNeeded - manaRecieved) / (count + 1));
+			if (inboundTransfer != null) {
+				SparkAttachable attached = inboundTransfer.getAttachedTile();
+				var attachedReceiver = inboundTransfer.getAttachedManaReceiver();
+				if (attached == null || attachedReceiver == null) {
+					shouldFilterTransfers = true;
+				} else {
+					int gained = Math.min(attachedReceiver.getCurrentMana(), manaNeeded);
 					attachedReceiver.receiveMana(-gained);
-					manaRecieved += gained;
+					receiver.receiveMana(gained);
 
-					particlesFrom(spark.entity());
+					particlesFrom(inboundTransfer.entity());
 				}
-				receiver.receiveMana(manaRecieved);
 			}
 		}
 
@@ -261,7 +254,7 @@ public class ManaSparkEntity extends SparkBaseEntity implements ManaSpark {
 
 	@Override
 	public void updateTransfers() {
-		inboundTransfers.clear();
+		inboundTransfer = null;
 		outgoingTransfers.clear();
 		switch (getUpgrade()) {
 			case RECESSIVE -> {
@@ -283,8 +276,8 @@ public class ManaSparkEntity extends SparkBaseEntity implements ManaSpark {
 				for (var spark : validSparks) {
 					SparkUpgradeType otherUpgrade = spark.getUpgrade();
 					if (spark != this && otherUpgrade == SparkUpgradeType.NONE && spark.getAttachedManaReceiver() instanceof ManaPool) {
-						inboundTransfers.add(spark);
-						break; // Only add one spark
+						inboundTransfer = spark;
+						break;
 					}
 				}
 			}
@@ -424,9 +417,8 @@ public class ManaSparkEntity extends SparkBaseEntity implements ManaSpark {
 			}
 		}
 
-		Iterator<ManaSpark> iter2 = inboundTransfers.iterator();
-		while (iter2.hasNext()) {
-			ManaSpark spark = iter2.next();
+		if (inboundTransfer != null) {
+			ManaSpark spark = inboundTransfer;
 			SparkUpgradeType supgr = spark.getUpgrade();
 			ManaReceiver arecv = spark.getAttachedManaReceiver();
 
@@ -438,7 +430,7 @@ public class ManaSparkEntity extends SparkBaseEntity implements ManaSpark {
 					|| getAttachedManaReceiver().isFull()
 					|| !(upgr == SparkUpgradeType.DOMINANT && supgr == SparkUpgradeType.NONE
 							|| !(arecv instanceof ManaPool))) {
-				iter2.remove();
+				inboundTransfer = null;
 			}
 		}
 	}

--- a/Xplat/src/main/java/vazkii/botania/common/entity/ManaSparkEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/entity/ManaSparkEntity.java
@@ -284,6 +284,7 @@ public class ManaSparkEntity extends SparkBaseEntity implements ManaSpark {
 					SparkUpgradeType otherUpgrade = spark.getUpgrade();
 					if (spark != this && otherUpgrade == SparkUpgradeType.NONE && spark.getAttachedManaReceiver() instanceof ManaPool) {
 						inboundTransfers.add(spark);
+						break; // Only add one spark
 					}
 				}
 			}


### PR DESCRIPTION
The changes in https://github.com/VazkiiMods/Botania/pull/4963 generally fixed behaviors associated with establishing and re-establishing mana transfers to dominant sparks, but I think introduced an unintended consequence: it made it possible for dominant sparks to receive `TRANSFER_RATE` mana every tick from each unaugmented spark in range.

Prior to the change, a dominant spark could receive at most `TRANSFER_RATE` mana from a single pool per tick. This change restores that behavior.

On my own build, this issue was immediately apparent just because of the number of particles moving around. My dominant pool (on the left, surrounded by glass) had only a small mana drain from a Tainted Blood Pendant I was wearing, but tons of particles were moving towards the dominant pool. I suspect a bunch of particles were coming from 0-mana transfers to the dominant pool. In other words, the first couple of sparks in a tick fill up the dominant pool, but the remaining sparks in `incomingTransfers` still end up being processed and transfer `0` mana but still spawn particles.

Normal behavior (prior to #4963 and with the proposed fix):

<img width="3456" height="2102" alt="2026-02-14_22 22 21" src="https://github.com/user-attachments/assets/f6104e27-fff3-493c-b08b-cf8479d08851" />

Current behavior (introduced by #4963)

<img width="3456" height="2102" alt="2026-02-14_22 24 21" src="https://github.com/user-attachments/assets/7103d10c-9837-4d8a-9281-6b210c976622" />
