### PR TITLE
Skip zero-amount mana transfers between sparks

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/entity/ManaSparkEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/entity/ManaSparkEntity.java
@@ -237,10 +237,12 @@ public class ManaSparkEntity extends SparkBaseEntity implements ManaSpark {
 					}
 
 					int gained = Math.min(attachedReceiver.getCurrentMana(), (manaNeeded - manaRecieved) / (count + 1));
-					attachedReceiver.receiveMana(-gained);
-					manaRecieved += gained;
+					if (gained > 0) {
+						attachedReceiver.receiveMana(-gained);
+						manaRecieved += gained;
 
-					particlesFrom(spark.entity());
+						particlesFrom(spark.entity());
+					}
 				}
 				receiver.receiveMana(manaRecieved);
 			}

--- a/Xplat/src/main/java/vazkii/botania/common/entity/ManaSparkEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/entity/ManaSparkEntity.java
@@ -206,11 +206,14 @@ public class ManaSparkEntity extends SparkBaseEntity implements ManaSpark {
 					}
 
 					int spend = Math.min(attached.getAvailableSpaceForMana(), (manaTotal - manaSpent) / (count + 1));
-					attachedReceiver.receiveMana(spend);
-					manaSpent += spend;
-					spark.checkReceiverFull();
 
-					particlesTowards(spark.entity());
+					if (spend > 0) {
+						attachedReceiver.receiveMana(spend);
+						manaSpent += spend;
+						spark.checkReceiverFull();
+
+						particlesTowards(spark.entity());
+					}
 				}
 				receiver.receiveMana(-manaSpent);
 			}


### PR DESCRIPTION
When a dominant spark needs a small amount of mana (e.g., 2 mana) but has many inbound sparks available (e.g., 12), integer division in the fair share calculation causes most sparks to compute gained=0. This resulted in unnecessary receiveMana() calls and particle effects for transfers that moved no actual mana.

The proposed change performs transfers and spawns particles when gained > 0, reducing visual clutter and eliminating redundant operations.

Related

* https://github.com/VazkiiMods/Botania/pull/4963
* #4964