### PR TITLE
Register ManaSpreader test in fabric.mod.json

### DIFF
--- a/Fabric/src/main/resources/fabric.mod.json
+++ b/Fabric/src/main/resources/fabric.mod.json
@@ -46,6 +46,7 @@
       "vazkii.botania.test.block.ApothecaryRecipeTest",
       "vazkii.botania.test.block.EntropinnyumUnethicalTntDetectionTest",
       "vazkii.botania.test.block.DrumBlockTest",
+      "vazkii.botania.test.block.ManaSpreaderTest",
       "vazkii.botania.test.item.AstrolabeTest",
       "vazkii.botania.test.item.CacophoniumTest",
       "vazkii.botania.test.item.FlowerPouchTest",


### PR DESCRIPTION
The `ManaSpreaderTest` was added in commit 795208d3d to test the fix for issue #4458, but was never registered in the fabric-gametest entrypoint, so it didn't run in CI. This registers it so the test actually runs.

The test seems to pass just fine when executed in-game and headlessly