### PR TITLE
Fix issue #4986: Rod of the Bifrost now consumes mana in survival 

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/item/rod/BifrostRodItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/rod/BifrostRodItem.java
@@ -109,7 +109,7 @@ public class BifrostRodItem extends SelfReturningItem {
 			if (placedAny) {
 				world.playSound(null, player.getX(), player.getY(), player.getZ(), BotaniaSounds.bifrostRod, SoundSource.PLAYERS, 1F, 1F);
 				player.gameEvent(GameEvent.ITEM_INTERACT_FINISH);
-				ManaItemHandler.instance().requestManaExactForTool(stack, player, MANA_COST, false);
+				ManaItemHandler.instance().requestManaExactForTool(stack, player, MANA_COST, true);
 				player.getCooldowns().addCooldown(this, player.isCreative() ? 10 : TIME);
 			}
 		}


### PR DESCRIPTION
Rod of the Bifrost now consumes mana in survival in Fabric and Forge changing the requestManaExactForTool remove boolean variable to true from false (line 112), used the issuer's suggestion. 