### PR TITLE
1.21.1 Rosa Arcana rework

### DIFF
--- a/Fabric/src/main/java/vazkii/botania/fabric/network/FabricPacketHandler.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/network/FabricPacketHandler.java
@@ -21,6 +21,7 @@ import vazkii.botania.network.clientbound.AvatarSkiesRodUpdatePacket;
 import vazkii.botania.network.clientbound.BlackLotusDissolveEffectPacket;
 import vazkii.botania.network.clientbound.DivaCharmEffectPacket;
 import vazkii.botania.network.clientbound.EnchanterDestroyEffectPacket;
+import vazkii.botania.network.clientbound.FlowerTakeItemEffectPacket;
 import vazkii.botania.network.clientbound.FluegelEyeEffectPacket;
 import vazkii.botania.network.clientbound.GogWorldPacket;
 import vazkii.botania.network.clientbound.GrassSeedsEffectPacket;
@@ -55,6 +56,7 @@ public final class FabricPacketHandler {
 		PayloadTypeRegistry.playS2C().register(BlackLotusDissolveEffectPacket.ID, BlackLotusDissolveEffectPacket.STREAM_CODEC);
 		PayloadTypeRegistry.playS2C().register(DivaCharmEffectPacket.ID, DivaCharmEffectPacket.STREAM_CODEC);
 		PayloadTypeRegistry.playS2C().register(EnchanterDestroyEffectPacket.ID, EnchanterDestroyEffectPacket.STREAM_CODEC);
+		PayloadTypeRegistry.playS2C().register(FlowerTakeItemEffectPacket.ID, FlowerTakeItemEffectPacket.STREAM_CODEC);
 		PayloadTypeRegistry.playS2C().register(FluegelEyeEffectPacket.ID, FluegelEyeEffectPacket.STREAM_CODEC);
 		PayloadTypeRegistry.playS2C().register(GogWorldPacket.ID, GogWorldPacket.STREAM_CODEC);
 		PayloadTypeRegistry.playS2C().register(GrassSeedsEffectPacket.ID, GrassSeedsEffectPacket.STREAM_CODEC);
@@ -86,6 +88,7 @@ public final class FabricPacketHandler {
 		ClientPlayNetworking.registerGlobalReceiver(BlackLotusDissolveEffectPacket.ID, makeClientBoundHandler(BlackLotusDissolveEffectPacket.Handler::handle));
 		ClientPlayNetworking.registerGlobalReceiver(DivaCharmEffectPacket.ID, makeClientBoundHandler(DivaCharmEffectPacket.Handler::handle));
 		ClientPlayNetworking.registerGlobalReceiver(EnchanterDestroyEffectPacket.ID, makeClientBoundHandler(EnchanterDestroyEffectPacket.Handler::handle));
+		ClientPlayNetworking.registerGlobalReceiver(FlowerTakeItemEffectPacket.ID, makeClientBoundHandler(FlowerTakeItemEffectPacket.Handler::handle));
 		ClientPlayNetworking.registerGlobalReceiver(FluegelEyeEffectPacket.ID, makeClientBoundHandler(FluegelEyeEffectPacket.Handler::handle));
 		ClientPlayNetworking.registerGlobalReceiver(GogWorldPacket.ID, makeClientBoundHandler(GogWorldPacket.Handler::handle));
 		ClientPlayNetworking.registerGlobalReceiver(GrassSeedsEffectPacket.ID, makeClientBoundHandler(GrassSeedsEffectPacket.Handler::handle));

--- a/NeoForge/src/main/java/vazkii/botania/neoforge/network/ForgePacketHandler.java
+++ b/NeoForge/src/main/java/vazkii/botania/neoforge/network/ForgePacketHandler.java
@@ -13,6 +13,7 @@ import vazkii.botania.network.clientbound.AvatarSkiesRodUpdatePacket;
 import vazkii.botania.network.clientbound.BlackLotusDissolveEffectPacket;
 import vazkii.botania.network.clientbound.DivaCharmEffectPacket;
 import vazkii.botania.network.clientbound.EnchanterDestroyEffectPacket;
+import vazkii.botania.network.clientbound.FlowerTakeItemEffectPacket;
 import vazkii.botania.network.clientbound.FluegelEyeEffectPacket;
 import vazkii.botania.network.clientbound.GogWorldPacket;
 import vazkii.botania.network.clientbound.GrassSeedsEffectPacket;
@@ -49,6 +50,7 @@ public class ForgePacketHandler {
 		registrar.playToClient(BlackLotusDissolveEffectPacket.ID, BlackLotusDissolveEffectPacket.STREAM_CODEC, makeClientBoundHandler(BlackLotusDissolveEffectPacket.Handler::handle));
 		registrar.playToClient(DivaCharmEffectPacket.ID, DivaCharmEffectPacket.STREAM_CODEC, makeClientBoundHandler(DivaCharmEffectPacket.Handler::handle));
 		registrar.playToClient(EnchanterDestroyEffectPacket.ID, EnchanterDestroyEffectPacket.STREAM_CODEC, makeClientBoundHandler(EnchanterDestroyEffectPacket.Handler::handle));
+		registrar.playToClient(FlowerTakeItemEffectPacket.ID, FlowerTakeItemEffectPacket.STREAM_CODEC, makeClientBoundHandler(FlowerTakeItemEffectPacket.Handler::handle));
 		registrar.playToClient(FluegelEyeEffectPacket.ID, FluegelEyeEffectPacket.STREAM_CODEC, makeClientBoundHandler(FluegelEyeEffectPacket.Handler::handle));
 		registrar.playToClient(GogWorldPacket.ID, GogWorldPacket.STREAM_CODEC, makeClientBoundHandler(GogWorldPacket.Handler::handle));
 		registrar.playToClient(GrassSeedsEffectPacket.ID, GrassSeedsEffectPacket.STREAM_CODEC, makeClientBoundHandler(GrassSeedsEffectPacket.Handler::handle));

--- a/Xplat/src/main/java/vazkii/botania/api/block_entity/BindableSpecialFlowerBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/api/block_entity/BindableSpecialFlowerBlockEntity.java
@@ -41,7 +41,6 @@ import vazkii.botania.api.BotaniaAPIClient;
 import vazkii.botania.api.block.Bound;
 import vazkii.botania.api.block.WandBindable;
 import vazkii.botania.api.block.WandHUD;
-import vazkii.botania.api.mana.ManaReceiver;
 import vazkii.botania.client.core.helper.RenderHelper;
 import vazkii.botania.common.helper.MathHelper;
 import vazkii.botania.common.item.BotaniaItems;
@@ -50,6 +49,7 @@ import vazkii.botania.xplat.XplatAbstractions;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 /**
  * Superclass of flowers that can be bound to some kind of target with the Wand of the Forest,
@@ -96,6 +96,16 @@ public abstract class BindableSpecialFlowerBlockEntity<T> extends SpecialFlowerB
 
 	@Nullable
 	protected BlockPos getClosestManaReceiver(Class<T> receiverType, Level level, BlockPos center, int rangeLimit) {
+		return getClosestMatchingBlockEntity(
+				level, center, rangeLimit, blockEntity -> receiverType.isInstance(
+						XplatAbstractions.instance().findManaReceiver(blockEntity))
+		);
+	}
+
+	// TODO: maybe find a better home for this very generic helper method
+	@Nullable
+	public static BlockPos getClosestMatchingBlockEntity(Level level, BlockPos center,
+			int rangeLimit, Predicate<BlockEntity> blockEntityPredicate) {
 		long minDist = Long.MAX_VALUE;
 		long limitSquared = (long) rangeLimit * rangeLimit;
 		BlockPos closestPos = null;
@@ -115,9 +125,7 @@ public abstract class BindableSpecialFlowerBlockEntity<T> extends SpecialFlowerB
 					if (dist > minDist || dist > limitSquared) {
 						continue;
 					}
-					BlockEntity be = entry.getValue();
-					ManaReceiver manaReceiver = XplatAbstractions.instance().findManaReceiver(be);
-					if (receiverType.isInstance(manaReceiver)) {
+					if (blockEntityPredicate.test(entry.getValue())) {
 						minDist = dist;
 						closestPos = pos;
 					}

--- a/Xplat/src/main/java/vazkii/botania/client/fx/FlowerItemPickupParticle.java
+++ b/Xplat/src/main/java/vazkii/botania/client/fx/FlowerItemPickupParticle.java
@@ -1,0 +1,84 @@
+package vazkii.botania.client.fx;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+
+import net.minecraft.client.Camera;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.particle.Particle;
+import net.minecraft.client.particle.ParticleRenderType;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderBuffers;
+import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.phys.Vec3;
+
+// [VanillaCopy] ItemPickupParticle, but with BlockPos as target instead of an entity
+public class FlowerItemPickupParticle extends Particle {
+	private static final int LIFE_TIME = 3;
+	private final RenderBuffers renderBuffers;
+	private final Entity itemEntity;
+	private final BlockPos target;
+	private int life;
+	private final EntityRenderDispatcher entityRenderDispatcher;
+	// Botania: target doesn't move, so no need for position updates (I can already hear Sable noises, though)
+
+	public FlowerItemPickupParticle(EntityRenderDispatcher entityRenderDispatcher, RenderBuffers buffers,
+			ClientLevel level, Entity itemEntity, BlockPos target) {
+		this(entityRenderDispatcher, buffers, level, itemEntity, target, itemEntity.getDeltaMovement());
+	}
+
+	private FlowerItemPickupParticle(EntityRenderDispatcher entityRenderDispatcher, RenderBuffers buffers,
+			ClientLevel level, Entity itemEntity, BlockPos target, Vec3 speedVector) {
+		super(level, itemEntity.getX(), itemEntity.getY(), itemEntity.getZ(), speedVector.x, speedVector.y, speedVector.z);
+		this.renderBuffers = buffers;
+		this.itemEntity = this.getSafeCopy(itemEntity);
+		this.target = target;
+		this.entityRenderDispatcher = entityRenderDispatcher;
+	}
+
+	private Entity getSafeCopy(Entity entity) {
+		return !(entity instanceof ItemEntity) ? entity : ((ItemEntity) entity).copy();
+	}
+
+	@Override
+	public ParticleRenderType getRenderType() {
+		return ParticleRenderType.CUSTOM;
+	}
+
+	@Override
+	public void render(VertexConsumer buffer, Camera renderInfo, float partialTicks) {
+		float time = ((float) this.life + partialTicks) / LIFE_TIME;
+		time *= time;
+		Vec3 targetPos = target.getCenter().add(level.getBlockState(target).getOffset(level, target));
+		double xx = Mth.lerp(time, this.itemEntity.getX(), targetPos.x);
+		double yy = Mth.lerp(time, this.itemEntity.getY(), targetPos.y);
+		double zz = Mth.lerp(time, this.itemEntity.getZ(), targetPos.z);
+		MultiBufferSource.BufferSource source = this.renderBuffers.bufferSource();
+		Vec3 pos = renderInfo.getPosition();
+		this.entityRenderDispatcher
+				.render(
+						this.itemEntity,
+						xx - pos.x(),
+						yy - pos.y(),
+						zz - pos.z(),
+						this.itemEntity.getYRot(),
+						partialTicks,
+						new PoseStack(),
+						source,
+						this.entityRenderDispatcher.getPackedLightCoords(this.itemEntity, partialTicks)
+				);
+		source.endBatch();
+	}
+
+	@Override
+	public void tick() {
+		this.life++;
+		if (this.life == LIFE_TIME) {
+			this.remove();
+		}
+	}
+}

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/flower/functional/HopperhockBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/flower/functional/HopperhockBlockEntity.java
@@ -31,6 +31,7 @@ import vazkii.botania.api.state.BotaniaStateProperties;
 import vazkii.botania.api.state.enums.HopperhockFilterType;
 import vazkii.botania.common.block.block_entity.BotaniaBlockEntities;
 import vazkii.botania.common.helper.*;
+import vazkii.botania.network.clientbound.FlowerTakeItemEffectPacket;
 import vazkii.botania.xplat.XplatAbstractions;
 
 import java.util.EnumMap;
@@ -128,7 +129,8 @@ public class HopperhockBlockEntity extends FunctionalFlowerBlockEntity implement
 			}
 
 			if (stack.getCount() < originalCount && item.isAlive()) {
-				SpectranthemumBlockEntity.spawnExplosionParticles(item, 3);
+				XplatAbstractions.instance().sendToTracking(item, new FlowerTakeItemEffectPacket(item.getId(),
+						getEffectivePos(), originalCount - stack.getCount()));
 				item.setItem(stack);
 				if (stack == originalStack) {
 					EntityHelper.syncItem(item);

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/flower/generating/RosaArcanaBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/flower/generating/RosaArcanaBlockEntity.java
@@ -13,6 +13,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.tags.EnchantmentTags;
@@ -36,11 +37,13 @@ import vazkii.botania.common.helper.EntityHelper;
 import vazkii.botania.common.helper.MathHelper;
 import vazkii.botania.mixin.ExperienceOrbAccessor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class RosaArcanaBlockEntity extends GeneratingFlowerBlockEntity {
 	private static final int MANA_PER_XP = 50;
 	private static final int RANGE = 1;
+	public static final int PLAYER_TAKE_XP_DELAY = 10;
 
 	public RosaArcanaBlockEntity(BlockPos pos, BlockState state) {
 		super(BotaniaBlockEntities.ROSA_ARCANA, pos, state);
@@ -50,28 +53,49 @@ public class RosaArcanaBlockEntity extends GeneratingFlowerBlockEntity {
 	public void tickFlower() {
 		super.tickFlower();
 
-		if (level.isClientSide() || getMana() >= getMaxMana()) {
+		if (!(level instanceof ServerLevel serverLevel) || getMana() >= getMaxMana()) {
 			return;
 		}
 
 		AABB effectBounds = MathHelper.inflateBoxAround(getEffectivePos(), RANGE);
 
-		/* TODO: Now that player and orb yields are identical, it might look better/funnier
-		to instead make xp orbs leak out of the player's head instead directly consuming.
-		*/
-		List<Player> players = getLevel().getEntitiesOfClass(Player.class, effectBounds,
-				// You would think checking totalExperience is right, but it seems to be
-				// possibly equal to zero even when the level is > 0.
-				// Instead, check the level and intra-level progress separately.
-				player -> (player.experienceLevel > 0 || player.experienceProgress > 0)
-						&& player.onGround());
-		for (Player player : players) {
-			player.giveExperiencePoints(-1);
-			addMana(MANA_PER_XP);
+		if (consumeXpOrb(serverLevel, effectBounds)) {
 			return;
 		}
+		if (disenchantAnItem(serverLevel, effectBounds)) {
+			return;
+		}
+		drainPlayerXp(serverLevel, effectBounds);
+	}
 
-		List<ExperienceOrb> orbs = getLevel().getEntitiesOfClass(ExperienceOrb.class, effectBounds, ExperienceOrb::isAlive);
+	private static void drainPlayerXp(ServerLevel serverLevel, AABB effectBounds) {
+		List<Player> players = new ArrayList<>();
+		// entity search selects subchunks by assuming all entities are ghast-sized, so this is likely faster:
+		serverLevel.players().stream()
+				.filter(player -> player.isAlive() && !player.isSpectator()
+						&& player.getBoundingBox().intersects(effectBounds))
+				.forEach(players::add);
+		// prevent players from picking up XP orbs
+		for (Player player : players) {
+			player.takeXpDelay = Math.max(PLAYER_TAKE_XP_DELAY, player.takeXpDelay);
+		}
+		// You would think checking totalExperience is right, but it seems to be
+		// possibly equal to zero even when the level is > 0.
+		// Instead, check the level and intra-level progress separately.
+		players.removeIf(player -> player.experienceProgress == 0 && player.experienceLevel == 0);
+		if (players.isEmpty()) {
+			return;
+		}
+		// pull XP from one random player
+		Player player = players.get(serverLevel.random.nextInt(players.size()));
+		// this effectively only happens every other tick, so average out the XP drain to 1 per tick
+		int drainAmount = player.experienceLevel > 0 && serverLevel.random.nextBoolean() ? 3 : 1;
+		player.giveExperiencePoints(-drainAmount);
+		ExperienceOrb.award(serverLevel, player.position().add(0, 0.5 * player.getEyeHeight(), 0), drainAmount);
+	}
+
+	private boolean consumeXpOrb(ServerLevel serverLevel, AABB effectBounds) {
+		List<ExperienceOrb> orbs = serverLevel.getEntitiesOfClass(ExperienceOrb.class, effectBounds, ExperienceOrb::isAlive);
 		for (ExperienceOrb orb : orbs) {
 			int count = ((ExperienceOrbAccessor) orb).botania_getCount();
 			if (count > 0) {
@@ -80,96 +104,75 @@ public class RosaArcanaBlockEntity extends GeneratingFlowerBlockEntity {
 				if (count == 1) {
 					orb.discard();
 				}
-				float pitch = (level.getRandom().nextFloat() - level.getRandom().nextFloat()) * 0.35F + 0.9F;
+				// TODO: make a block-specific version of ClientboundTakeItemEntityPacket for this and the Hopperhock
+				// [VanillaCoppy] ClientPacketListener::handleTakeItemEntity (sound for ExperienceOrb)
+				float pitch = (serverLevel.getRandom().nextFloat() - serverLevel.getRandom().nextFloat()) * 0.35F + 0.9F;
 				//Usage of vanilla sound event: Subtitle is "Experience gained", and this is about gaining experience anyways.
-				level.playSound(null, getEffectivePos(), SoundEvents.EXPERIENCE_ORB_PICKUP, SoundSource.BLOCKS, 0.07F, pitch);
-				return;
+				serverLevel.playSound(null, getEffectivePos(), SoundEvents.EXPERIENCE_ORB_PICKUP, SoundSource.BLOCKS, 0.07F, pitch);
+				return true;
 			}
 		}
+		return false;
+	}
 
-		List<ItemEntity> items = getLevel().getEntitiesOfClass(ItemEntity.class, effectBounds, e -> e.isAlive() && !e.getItem().isEmpty());
+	private boolean disenchantAnItem(ServerLevel serverLevel, AABB effectBounds) {
+		List<ItemEntity> items = serverLevel.getEntitiesOfClass(ItemEntity.class, effectBounds,
+				e -> e.isAlive() && !e.getItem().isEmpty() && EnchantmentHelper.hasAnyEnchantments(e.getItem())
+		);
 		for (ItemEntity entity : items) {
 			ItemStack stack = entity.getItem();
-			if (stack.is(Items.ENCHANTED_BOOK) || stack.isEnchanted()) {
-				int xp = getEnchantmentXpValue(stack);
-				if (xp > 0) {
-					ItemStack newStack = removeNonCurses(stack);
-					newStack.setCount(1);
-					EntityHelper.shrinkItem(entity);
-
-					ItemEntity newEntity = new ItemEntity(level, entity.getX(), entity.getY(), entity.getZ(), newStack);
-					newEntity.setDeltaMovement(entity.getDeltaMovement());
-					level.addFreshEntity(newEntity);
-
-					level.playSound(null, getEffectivePos(), BotaniaSounds.arcaneRoseDisenchant, SoundSource.BLOCKS, 1F, this.level.getRandom().nextFloat() * 0.1F + 0.9F);
-					while (xp > 0) {
-						int i = ExperienceOrb.getExperienceValue(xp);
-						xp -= i;
-						level.addFreshEntity(new ExperienceOrb(level, getEffectivePos().getX() + 0.5D, getEffectivePos().getY() + 0.5D, getEffectivePos().getZ() + 0.5D, i));
-					}
-					return;
-				}
+			int xp = getEnchantmentXpValue(stack);
+			if (xp <= 0) {
+				continue;
 			}
+			ItemStack newStack = removeNonCurses(stack.copyWithCount(1));
+			EntityHelper.shrinkItem(entity);
+
+			ItemEntity newEntity = new ItemEntity(serverLevel, entity.getX(), entity.getY(), entity.getZ(), newStack);
+			newEntity.setDeltaMovement(entity.getDeltaMovement());
+			serverLevel.addFreshEntity(newEntity);
+
+			serverLevel.playSound(null, getEffectivePos(), BotaniaSounds.arcaneRoseDisenchant,
+					SoundSource.BLOCKS, 1F, serverLevel.random.nextFloat() * 0.1F + 0.9F);
+			ExperienceOrb.award(serverLevel, entity.getEyePosition(), xp);
+			return true;
 		}
+		return false;
 	}
 
-	// [VanillaCopy] GrindstoneMenu
-	private static int getEnchantmentXpValue(ItemStack stack) {
-		int ret = 0;
-		ItemEnchantments itemenchantments = EnchantmentHelper.getEnchantmentsForCrafting(stack);
+	// [VanillaCopy] GrindstoneMenu::<init> -> [anonymous class for resultSlot]::getExperienceFromItem
+	private static int getEnchantmentXpValue(ItemStack item) {
+		int amount = 0;
+		ItemEnchantments enchantments = EnchantmentHelper.getEnchantmentsForCrafting(item);
 
-		for (Object2IntMap.Entry<Holder<Enchantment>> entry : itemenchantments.entrySet()) {
-			Holder<Enchantment> holder = entry.getKey();
-			int integer = entry.getIntValue();
-			if (!holder.is(EnchantmentTags.CURSE)) {
-				ret += holder.value().getMinCost(integer);
+		for (Object2IntMap.Entry<Holder<Enchantment>> entry : enchantments.entrySet()) {
+			Holder<Enchantment> enchant = entry.getKey();
+			int lvl = entry.getIntValue();
+			if (!enchant.is(EnchantmentTags.CURSE)) {
+				amount += enchant.value().getMinCost(lvl);
 			}
 		}
 
-		return ret;
+		return amount;
 	}
 
-	// [VanillaCopy] GrindstoneMenu, no damage and count setting
-	private static ItemStack removeNonCurses(ItemStack stack) {
-		/*
-		ItemStack itemstack = stack.copy();
-		itemstack.removeTagKey("Enchantments");
-		itemstack.removeTagKey("StoredEnchantments");
-		
-		Map<Enchantment, Integer> map = EnchantmentHelper.getEnchantments(stack);
-		map.keySet().removeIf(e -> !e.isCurse());
-		EnchantmentHelper.setEnchantments(map, itemstack);
-		itemstack.setRepairCost(0);
-		if (itemstack.is(Items.ENCHANTED_BOOK) && map.size() == 0) {
-			itemstack = new ItemStack(Items.BOOK);
-			if (stack.hasCustomHoverName()) {
-				itemstack.setHoverName(stack.getHoverName());
-			}
-		}
-		
-		for (int i = 0; i < map.size(); ++i) {
-			itemstack.setRepairCost(AnvilMenu.calculateIncreasedRepairCost(itemstack.getBaseRepairCost()));
-		}
-		
-		return itemstack;
-		
-		 */
-		//TODO check if functionality is the same. I just copied the code from GrindstoneMenu
-		ItemEnchantments itemenchantments = EnchantmentHelper.updateEnchantments(
-				stack, p_330066_ -> p_330066_.removeIf(p_344368_ -> !p_344368_.is(EnchantmentTags.CURSE))
+	// [VanillaCopy] GrindstoneMenu::removeNonCursesFrom
+	private static ItemStack removeNonCurses(ItemStack item) {
+		ItemEnchantments newEnchantments = EnchantmentHelper.updateEnchantments(
+				item, enchantments -> enchantments.removeIf(enchantment -> !enchantment.is(EnchantmentTags.CURSE))
 		);
-		if (stack.is(Items.ENCHANTED_BOOK) && itemenchantments.isEmpty()) {
-			stack = stack.transmuteCopy(Items.BOOK);
+		if (item.is(Items.ENCHANTED_BOOK) && newEnchantments.isEmpty()) {
+			item = item.transmuteCopy(Items.BOOK);
 		}
 
-		int i = 0;
+		int repairCost = 0;
 
-		for (int j = 0; j < itemenchantments.size(); j++) {
-			i = AnvilMenu.calculateIncreasedRepairCost(i);
+		for (int i = 0; i < newEnchantments.size(); i++) {
+			repairCost = AnvilMenu.calculateIncreasedRepairCost(repairCost);
 		}
 
-		stack.set(DataComponents.REPAIR_COST, i);
-		return stack;
+		item.set(DataComponents.REPAIR_COST, repairCost);
+		return item;
 	}
 
 	@Override

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/flower/generating/RosaArcanaBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/flower/generating/RosaArcanaBlockEntity.java
@@ -14,7 +14,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.tags.EnchantmentTags;
 import net.minecraft.world.entity.ExperienceOrb;
@@ -36,6 +35,8 @@ import vazkii.botania.common.handler.BotaniaSounds;
 import vazkii.botania.common.helper.EntityHelper;
 import vazkii.botania.common.helper.MathHelper;
 import vazkii.botania.mixin.ExperienceOrbAccessor;
+import vazkii.botania.network.clientbound.FlowerTakeItemEffectPacket;
+import vazkii.botania.xplat.XplatAbstractions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -101,14 +102,11 @@ public class RosaArcanaBlockEntity extends GeneratingFlowerBlockEntity {
 			if (count > 0) {
 				addMana(orb.getValue() * MANA_PER_XP);
 				((ExperienceOrbAccessor) orb).botania_setCount(count - 1);
+				XplatAbstractions.instance().sendToTracking(orb,
+						new FlowerTakeItemEffectPacket(orb.getId(), getEffectivePos(), 1));
 				if (count == 1) {
 					orb.discard();
 				}
-				// TODO: make a block-specific version of ClientboundTakeItemEntityPacket for this and the Hopperhock
-				// [VanillaCoppy] ClientPacketListener::handleTakeItemEntity (sound for ExperienceOrb)
-				float pitch = (serverLevel.getRandom().nextFloat() - serverLevel.getRandom().nextFloat()) * 0.35F + 0.9F;
-				//Usage of vanilla sound event: Subtitle is "Experience gained", and this is about gaining experience anyways.
-				serverLevel.playSound(null, getEffectivePos(), SoundEvents.EXPERIENCE_ORB_PICKUP, SoundSource.BLOCKS, 0.07F, pitch);
 				return true;
 			}
 		}

--- a/Xplat/src/main/java/vazkii/botania/mixin/ExperienceOrbMixin.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/ExperienceOrbMixin.java
@@ -1,0 +1,69 @@
+package vazkii.botania.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.ExperienceOrb;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import vazkii.botania.common.block.block_entity.flower.generating.RosaArcanaBlockEntity;
+import vazkii.botania.common.helper.MathHelper;
+
+@Mixin(ExperienceOrb.class)
+public abstract class ExperienceOrbMixin extends Entity {
+	@Unique
+	@Nullable
+	private BlockPos botania_followingFlower;
+
+	public ExperienceOrbMixin(EntityType<?> entityType, Level level) {
+		super(entityType, level);
+	}
+
+	@Inject(method = "scanForEntities", at = @At("HEAD"))
+	private void scanForFlower(CallbackInfo ci) {
+		if (this.botania_followingFlower == null
+				|| MathHelper.distSqr(this.botania_followingFlower, this.blockPosition()) > 64.0) {
+			this.botania_followingFlower = RosaArcanaBlockEntity.getClosestMatchingBlockEntity(
+					this.level(), this.blockPosition(), 8, RosaArcanaBlockEntity.class::isInstance);
+		}
+	}
+
+	@WrapOperation(
+		method = "tick",
+		at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Player;isSpectator()Z")
+	)
+	private boolean skipFollowingPlayerIfFollowingFlower(Player instance, Operation<Boolean> original) {
+		return this.botania_followingFlower != null || original.call(instance);
+	}
+
+	@Inject(
+		method = "tick",
+		at = @At(
+			value = "INVOKE",
+			target = "Lnet/minecraft/world/entity/ExperienceOrb;move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V"
+		)
+	)
+	private void setMovementTowardsFlower(CallbackInfo ci) {
+		// [VanillaCopy] ExperienceOrb::tick, section "if (this.followingPlayer != null)"
+		if (this.botania_followingFlower != null) {
+			Vec3 vec3 = this.botania_followingFlower.getCenter().subtract(this.position());
+			double d0 = vec3.lengthSqr();
+			if (d0 < 64.0) {
+				double d1 = 1.0 - Math.sqrt(d0) / 8.0;
+				this.setDeltaMovement(this.getDeltaMovement().add(vec3.normalize().scale(d1 * d1 * 0.1)));
+			}
+		}
+	}
+}

--- a/Xplat/src/main/java/vazkii/botania/network/clientbound/FlowerTakeItemEffectPacket.java
+++ b/Xplat/src/main/java/vazkii/botania/network/clientbound/FlowerTakeItemEffectPacket.java
@@ -1,0 +1,90 @@
+package vazkii.botania.network.clientbound;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.ExperienceOrb;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+import vazkii.botania.client.fx.FlowerItemPickupParticle;
+
+import static vazkii.botania.api.BotaniaAPI.botaniaRL;
+
+import io.netty.buffer.ByteBuf;
+
+public record FlowerTakeItemEffectPacket(int itemId, BlockPos pos, int amount) implements CustomPacketPayload {
+
+	public static final Type<FlowerTakeItemEffectPacket> ID = new Type<>(botaniaRL("ti"));
+	public static final StreamCodec<ByteBuf, FlowerTakeItemEffectPacket> STREAM_CODEC = StreamCodec.composite(
+			ByteBufCodecs.VAR_INT, FlowerTakeItemEffectPacket::itemId,
+			BlockPos.STREAM_CODEC, FlowerTakeItemEffectPacket::pos,
+			ByteBufCodecs.VAR_INT, FlowerTakeItemEffectPacket::amount,
+			FlowerTakeItemEffectPacket::new
+	);
+
+	@Override
+	public Type<FlowerTakeItemEffectPacket> type() {
+		return ID;
+	}
+
+	public static class Handler {
+		// [VanillaCopy] ClientPacketListener::handleTakeItemEntity
+		public static void handle(FlowerTakeItemEffectPacket packet, Player localPlayer) {
+			ClientLevel level = (ClientLevel) localPlayer.level();
+			RandomSource random = level.random;
+			Entity entity = level.getEntity(packet.itemId());
+
+			// Usage of vanilla sound events: Subtitles are "Experience gained" and "Item picked up", which both apply
+			if (entity != null) {
+				if (entity instanceof ExperienceOrb) {
+					level.playLocalSound(
+							entity.getX(),
+							entity.getY(),
+							entity.getZ(),
+							SoundEvents.EXPERIENCE_ORB_PICKUP,
+							SoundSource.BLOCKS,
+							0.1f,
+							(random.nextFloat() - random.nextFloat()) * 0.35f + 0.9f,
+							false
+					);
+				} else {
+					level.playLocalSound(
+							entity.getX(),
+							entity.getY(),
+							entity.getZ(),
+							SoundEvents.ITEM_PICKUP,
+							SoundSource.BLOCKS,
+							0.2f,
+							(random.nextFloat() - random.nextFloat()) * 1.4f + 2.0f,
+							false
+					);
+				}
+
+				Minecraft minecraft = Minecraft.getInstance();
+				minecraft.particleEngine.add(new FlowerItemPickupParticle(minecraft.getEntityRenderDispatcher(),
+						minecraft.renderBuffers(), level, entity, packet.pos()));
+				if (entity instanceof ItemEntity itementity) {
+					ItemStack itemstack = itementity.getItem();
+					if (!itemstack.isEmpty()) {
+						itemstack.shrink(packet.amount());
+					}
+
+					if (itemstack.isEmpty()) {
+						level.removeEntity(packet.itemId(), Entity.RemovalReason.DISCARDED);
+					}
+				} else if (!(entity instanceof ExperienceOrb)) {
+					level.removeEntity(packet.itemId(), Entity.RemovalReason.DISCARDED);
+				}
+			}
+		}
+	}
+}

--- a/Xplat/src/main/resources/botania.xplat.mixins.json
+++ b/Xplat/src/main/resources/botania.xplat.mixins.json
@@ -27,6 +27,7 @@
     "EntityAccessor",
     "EntityMixin",
     "ExperienceOrbAccessor",
+    "ExperienceOrbMixin",
     "FarmBlockMixin",
     "FlowingFluidAccessor",
     "GrowingPlantBodyBlockMixin",


### PR DESCRIPTION
This updates the mechanics and visuals of the Rosa Arcana (and related Hopperhock visuals) as follows:

- instead of trying to first draining players, then consuming XP orbs, and finally disenchanting items, the flower now primarily consumes XP orbs, then attempts to disenchant items, and only if neither of those work, it extracts XP orbs from nearby players (instead of draining them directly)
- players cannot pick up XP orbs while they are near the flower
- the flower attracts XP orbs, similar to players, and the orbs even prefer moving towards a Rosa Arcana over moving towards a player
- for visuals, the Rosa Arcana and Hopperhock now use a vanilla-like pickup animation for XP orbs and items, respectively