### PR TITLE
Update animated torch visuals to match redstone torch

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/client/render/block_entity/AnimatedTorchBlockEntityRenderer.java
+++ b/Xplat/src/main/java/vazkii/botania/client/render/block_entity/AnimatedTorchBlockEntityRenderer.java
@@ -9,15 +9,18 @@
 package vazkii.botania.client.render.block_entity;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.VertexConsumer;
 
-import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.block.BlockRenderDispatcher;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
-import net.minecraft.world.item.ItemDisplayContext;
-import net.minecraft.world.item.ItemStack;
+import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.RedstoneTorchBlock;
+import net.minecraft.world.level.block.state.BlockState;
 
 import vazkii.botania.client.core.handler.ClientTickHandler;
 import vazkii.botania.common.block.AnimatedTorchBlock;
@@ -31,7 +34,11 @@ public class AnimatedTorchBlockEntityRenderer implements BlockEntityRenderer<Ani
 	private static final double ANIM_VERTICAL_TICK_SCALE = 0.04;
 	private static final double ANIM_TICK_CYCLE = 2 * Math.PI / ANIM_HORIZONTAL_TICK_SCALE / ANIM_VERTICAL_TICK_SCALE;
 
-	public AnimatedTorchBlockEntityRenderer(BlockEntityRendererProvider.Context ctx) {}
+	private final BlockRenderDispatcher blockRenderDispatcher;
+
+	public AnimatedTorchBlockEntityRenderer(BlockEntityRendererProvider.Context ctx) {
+		this.blockRenderDispatcher = ctx.getBlockRenderDispatcher();
+	}
 
 	@Override
 	public void render(AnimatedTorchBlockEntity torch, float partialTicks, PoseStack ms, MultiBufferSource buffers, int light, int overlay) {
@@ -44,12 +51,7 @@ public class AnimatedTorchBlockEntityRenderer implements BlockEntityRenderer<Ani
 						+ partialTicks
 						+ new Random(torch.getBlockState().getSeed(torch.getBlockPos())).nextDouble(ANIM_TICK_CYCLE);
 
-		float xt = 0.5F + (float) Math.cos(time * ANIM_HORIZONTAL_TICK_SCALE) * 0.025F;
-		float yt = 0.1F + (float) (Math.sin(time * ANIM_VERTICAL_TICK_SCALE) + 1) * 0.05F;
-		float zt = 0.5F + (float) Math.sin(time * ANIM_HORIZONTAL_TICK_SCALE) * 0.025F;
-		ms.translate(xt, yt, zt);
-
-		ms.scale(2, 2, 2);
+		ms.translate(0.5, 0.2, 0.5);
 		ms.mulPose(VecHelper.rotateX(90));
 
 		if (level != null) {
@@ -78,8 +80,19 @@ public class AnimatedTorchBlockEntityRenderer implements BlockEntityRenderer<Ani
 			}
 			ms.mulPose(VecHelper.rotateZ(torch.rotation));
 		}
-		Minecraft.getInstance().getItemRenderer().renderStatic(new ItemStack(Blocks.REDSTONE_TORCH),
-				ItemDisplayContext.GROUND, light, overlay, ms, buffers, level, 0);
+
+		double xt = -0.5 + Math.cos(time * ANIM_HORIZONTAL_TICK_SCALE) * 0.025;
+		double yt = -0.3 + Math.sin(time * ANIM_VERTICAL_TICK_SCALE) * 0.05;
+		double zt = -0.5 + Math.sin(time * ANIM_HORIZONTAL_TICK_SCALE) * 0.025;
+		ms.translate(xt, yt, zt);
+
+		BlockState torchBaseState = Blocks.REDSTONE_TORCH.defaultBlockState();
+		BlockState torchState = torch.getBlockState().getValue(AnimatedTorchBlock.TRIGGERED)
+				? torchBaseState.setValue(RedstoneTorchBlock.LIT, false)
+				: torchBaseState;
+		BakedModel model = blockRenderDispatcher.getBlockModel(torchState);
+		VertexConsumer buffer = buffers.getBuffer(ItemBlockRenderTypes.getChunkRenderType(torchState));
+		blockRenderDispatcher.getModelRenderer().renderModel(ms.last(), buffer, torchState, model, 1, 1, 1, light, overlay);
 		ms.popPose();
 	}
 

--- a/Xplat/src/main/java/vazkii/botania/common/block/AnimatedTorchBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/AnimatedTorchBlock.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.Nullable;
 
 import vazkii.botania.api.state.BotaniaStateProperties;
 import vazkii.botania.api.state.enums.TorchMode;
+import vazkii.botania.client.fx.SparkleParticleData;
 import vazkii.botania.common.block.block_entity.AnimatedTorchBlockEntity;
 import vazkii.botania.common.block.block_entity.BotaniaBlockEntities;
 
@@ -50,7 +51,7 @@ public class AnimatedTorchBlock extends BotaniaWaterloggedBlock implements Entit
 	public static final EnumProperty<TorchMode> MODE = BotaniaStateProperties.TORCH_MODE;
 	public static final BooleanProperty TRIGGERED = BlockStateProperties.TRIGGERED;
 
-	private static final VoxelShape SHAPE = box(0, 0, 0, 16, 4, 16);
+	private static final VoxelShape SHAPE = box(0, 0, 0, 16, 6, 16);
 
 	public AnimatedTorchBlock(Properties builder) {
 		super(builder);
@@ -158,12 +159,28 @@ public class AnimatedTorchBlock extends BotaniaWaterloggedBlock implements Entit
 
 	@Override
 	public void animateTick(BlockState state, Level level, BlockPos pos, RandomSource random) {
-		if (!state.getValue(TRIGGERED)) {
-			Direction facing = state.getValue(FACING);
-			double x = pos.getX() + 0.5 + (random.nextDouble() - 0.5) * 0.2 + facing.getStepX() * 0.35;
-			double y = pos.getY() + 0.2 + (random.nextDouble() - 0.5) * 0.2 + facing.getStepY() * 0.35;
-			double z = pos.getZ() + 0.5 + (random.nextDouble() - 0.5) * 0.2 + facing.getStepZ() * 0.35;
-			level.addParticle(DustParticleOptions.REDSTONE, x, y, z, 0.0, 0.0, 0.0);
+		Direction facing = state.getValue(FACING);
+		if (!state.getValue(TRIGGERED) && random.nextInt(3) != 0) {
+			level.addParticle(
+					DustParticleOptions.REDSTONE,
+					pos.getX() + 0.5 + (random.nextDouble() - 0.5) * 0.2 + facing.getStepX() * 0.3,
+					pos.getY() + 0.3 + (random.nextDouble() - 0.5) * 0.2 + facing.getStepY() * 0.3,
+					pos.getZ() + 0.5 + (random.nextDouble() - 0.5) * 0.2 + facing.getStepZ() * 0.3,
+					0, 0, 0
+			);
+		}
+		if (random.nextInt(3) == 0) {
+			level.addParticle(
+					SparkleParticleData.sparkle(random.nextFloat(),
+							0.2f * random.nextFloat(),
+							0.5f + 0.2f * random.nextFloat(),
+							0.8f + 0.2f * random.nextFloat(),
+							5),
+					pos.getX() + 0.5 + (random.nextDouble() - 0.5) * (0.1 + 0.6 * facing.getStepX()),
+					pos.getY() + 0.2 + (random.nextDouble() - 0.5) * (0.1 + 0.6 * facing.getStepY()),
+					pos.getZ() + 0.5 + (random.nextDouble() - 0.5) * (0.1 + 0.6 * facing.getStepZ()),
+					0, 0, 0
+			);
 		}
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/block/BotaniaBlocks.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/BotaniaBlocks.java
@@ -750,7 +750,7 @@ public final class BotaniaBlocks {
 	public static final Block root = make(LibBlockNames.ROOT, new LivingRootBlock(BlockBehaviour.Properties.of().strength(1.2F).sound(SoundType.WOOD)));
 	public static final Block felPumpkin = make(LibBlockNames.FEL_PUMPKIN, new FelPumpkinBlock(BlockBehaviour.Properties.ofFullCopy(Blocks.CARVED_PUMPKIN)));
 	public static final Block cocoon = make(LibBlockNames.COCOON, new CocoonBlock(BlockBehaviour.Properties.of().strength(3, 60).sound(SoundType.WOOL)));
-	public static final Block animatedTorch = make(LibBlockNames.ANIMATED_TORCH, new AnimatedTorchBlock(BlockBehaviour.Properties.of().lightLevel(s -> 7).noOcclusion()));
+	public static final Block animatedTorch = make(LibBlockNames.ANIMATED_TORCH, new AnimatedTorchBlock(BlockBehaviour.Properties.of().noCollission().instabreak().lightLevel(s -> s.getValue(AnimatedTorchBlock.TRIGGERED) ? 0 : 7).sound(SoundType.WOOD).pushReaction(PushReaction.DESTROY)));
 	public static final Block starfield = make(LibBlockNames.STARFIELD, new StarfieldCreatorBlock(BlockBehaviour.Properties.of().mapColor(DyeColor.PINK).strength(5, 2000).sound(SoundType.METAL)));
 
 	public static final Block azulejo0 = make(LibBlockNames.AZULEJO_PREFIX + 0, new Block(BlockBehaviour.Properties.of().mapColor(MapColor.LAPIS).strength(2, 5)


### PR DESCRIPTION
- looks like an actual floating redstone torch now
- visually turns off while rotating (torch off texture, no redstone particles, light level zero)
- bonus "magic floaty" particles
- now uses wood sounds for placing and breaking
- no more entity collision (still counts as spawn-proof due to being defined as a redstone signal source)