### PR TITLE
Allow sheep to eat Botania grasses

### DIFF
--- a/Fabric/src/main/java/vazkii/botania/fabric/FabricCommonInitializer.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/FabricCommonInitializer.java
@@ -69,6 +69,7 @@ import net.minecraft.world.level.material.Fluids;
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.BotaniaFabricCapabilities;
 import vazkii.botania.api.BotaniaRegistries;
+import vazkii.botania.api.block.EdibleBlockWithEffects;
 import vazkii.botania.api.block.ExoflameHeatable;
 import vazkii.botania.api.block.HourglassTrigger;
 import vazkii.botania.api.block.IslandType;
@@ -371,6 +372,12 @@ public class FabricCommonInitializer implements ModInitializer {
 		relicItemLookup.registerForItems((st, c) -> RingOfLokiItem.makeRelic(st), BotaniaItems.lokiRing);
 		relicItemLookup.registerForItems((st, c) -> RingOfOdinItem.makeRelic(st), BotaniaItems.odinRing);
 		relicItemLookup.registerForItems((st, c) -> RingOfThorItem.makeRelic(st), BotaniaItems.thorRing);
+
+		BlockApiLookup<EdibleBlockWithEffects, Unit> edibleBlockWithEffectLookup = BotaniaFabricCapabilities.getBlockApiLookupById(EdibleBlockWithEffects.LOOKUP);
+		// these two blocks implement the capability directly
+		edibleBlockWithEffectLookup.registerForBlocks(
+				(world, pos, state, blockEntity, context) -> (EdibleBlockWithEffects) state.getBlock(),
+				BotaniaBlocks.mutatedGrass, BotaniaBlocks.infusedGrass);
 
 		BlockApiLookup<ExoflameHeatable, Unit> exoflameHeatableBlockLookup = BotaniaFabricCapabilities.getBlockApiLookupById(ExoflameHeatable.LOOKUP);
 		exoflameHeatableBlockLookup.registerFallback((world, pos, state, blockEntity, context) -> {

--- a/NeoForge/src/main/java/vazkii/botania/neoforge/ForgeCommonInitializer.java
+++ b/NeoForge/src/main/java/vazkii/botania/neoforge/ForgeCommonInitializer.java
@@ -70,6 +70,7 @@ import net.neoforged.neoforge.registries.RegisterEvent;
 import vazkii.botania.api.BotaniaAPI;
 import vazkii.botania.api.BotaniaForgeCapabilities;
 import vazkii.botania.api.BotaniaRegistries;
+import vazkii.botania.api.block.EdibleBlockWithEffects;
 import vazkii.botania.api.block.ExoflameHeatable;
 import vazkii.botania.api.block.HourglassTrigger;
 import vazkii.botania.api.block.PhantomInkableBlock;
@@ -566,6 +567,13 @@ public class ForgeCommonInitializer {
 	}
 
 	private void registerBlockCapabilities(RegisterCapabilitiesEvent e) {
+		BlockCapability<EdibleBlockWithEffects, Void> edibleBlockWithEffectCapability =
+				BotaniaForgeCapabilities.getBlockApiLookupById(EdibleBlockWithEffects.LOOKUP);
+		// these two blocks implement the capability directly
+		e.registerBlock(edibleBlockWithEffectCapability,
+				(level, pos, state, blockEntity, context) -> (EdibleBlockWithEffects) state.getBlock(),
+				BotaniaBlocks.mutatedGrass, BotaniaBlocks.infusedGrass);
+
 		// TODO: is there any way to identify all BlockEntityTypes for AbstractFurnaceBlock subclasses?
 		BlockCapability<ExoflameHeatable, Void> exoflameHeatableBlockCap =
 				BotaniaForgeCapabilities.getBlockApiLookupById(ExoflameHeatable.LOOKUP);

--- a/Xplat/src/generated/resources/.cache/bfa01a6ca2555c100103725bf5c9e6da285f29c3
+++ b/Xplat/src/generated/resources/.cache/bfa01a6ca2555c100103725bf5c9e6da285f29c3
@@ -37,6 +37,7 @@ a4e8097fff07f9a74259d6b5dd583f3437ff28a2 data/botania/tags/block/munchdew_consum
 663d521c50e341acbabb82cc9003e4e4002c16be data/botania/tags/block/mystical_flowers.json
 59cf23d61f960b6b3a9ec635bc618ed84e654812 data/botania/tags/block/pasture_seed_replaceable.json
 cb5d86906c3b7a5c47f636395fc1880af8493190 data/botania/tags/block/quartz_blocks.json
+245211371d5edf3bb5b5acd2cba7ac8e359530c3 data/botania/tags/block/sheep_edible_grasses.json
 625f245864e2ad11e8c90733f3dd20dd2d2f4b35 data/botania/tags/block/shields_from_magnet_ring.json
 dd1e587761f42b287b76aff2eb9c8d8adead4853 data/botania/tags/block/shimmering_mushrooms.json
 b2a13a55f649c4722a9fec47fbe9c46df7410133 data/botania/tags/block/shiny_flowers.json

--- a/Xplat/src/generated/resources/data/botania/tags/block/sheep_edible_grasses.json
+++ b/Xplat/src/generated/resources/data/botania/tags/block/sheep_edible_grasses.json
@@ -1,0 +1,10 @@
+{
+  "values": [
+    "botania:dry_grass",
+    "botania:golden_grass",
+    "botania:infused_grass",
+    "botania:mutated_grass",
+    "botania:scorched_grass",
+    "botania:vivid_grass"
+  ]
+}

--- a/Xplat/src/main/java/vazkii/botania/api/block/EdibleBlockWithEffects.java
+++ b/Xplat/src/main/java/vazkii/botania/api/block/EdibleBlockWithEffects.java
@@ -1,0 +1,20 @@
+package vazkii.botania.api.block;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.block.state.BlockState;
+
+import vazkii.botania.api.capability.BlockApiNoContext;
+
+import static vazkii.botania.api.BotaniaAPI.botaniaRL;
+
+/**
+ * When a block of this kind is consumed by a mob, it can have certain side effects on that mob.
+ */
+public interface EdibleBlockWithEffects {
+	ResourceLocation ID = botaniaRL("edible_with_effects");
+	BlockApiNoContext<EdibleBlockWithEffects> LOOKUP = new BlockApiNoContext<>(ID, EdibleBlockWithEffects.class);
+
+	void onEatenBy(BlockPos pos, BlockState state, LivingEntity entity);
+}

--- a/Xplat/src/main/java/vazkii/botania/common/BotaniaCapabilities.java
+++ b/Xplat/src/main/java/vazkii/botania/common/BotaniaCapabilities.java
@@ -2,6 +2,7 @@ package vazkii.botania.common;
 
 import org.jetbrains.annotations.ApiStatus;
 
+import vazkii.botania.api.block.EdibleBlockWithEffects;
 import vazkii.botania.api.block.ExoflameHeatable;
 import vazkii.botania.api.block.HourglassTrigger;
 import vazkii.botania.api.block.PhantomInkableBlock;
@@ -35,6 +36,7 @@ public final class BotaniaCapabilities {
 		registration.register(Relic.LOOKUP);
 
 		// block capabilities
+		registration.register(EdibleBlockWithEffects.LOOKUP);
 		registration.register(ExoflameHeatable.LOOKUP);
 		registration.register(HourglassTrigger.LOOKUP);
 		registration.register(ManaCollisionGhost.LOOKUP);

--- a/Xplat/src/main/java/vazkii/botania/common/block/BotaniaInfusedGrassBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/BotaniaInfusedGrassBlock.java
@@ -12,12 +12,19 @@ package vazkii.botania.common.block;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
+import vazkii.botania.api.block.EdibleBlockWithEffects;
 import vazkii.botania.client.fx.SparkleParticleData;
 
-public class BotaniaInfusedGrassBlock extends BotaniaGrassBlock {
+public class BotaniaInfusedGrassBlock extends BotaniaGrassBlock implements EdibleBlockWithEffects {
+
+	public static final int EFFECT_DURATION = 160;
+
 	public BotaniaInfusedGrassBlock(Properties builder) {
 		super(builder);
 	}
@@ -29,5 +36,10 @@ public class BotaniaInfusedGrassBlock extends BotaniaGrassBlock {
 			SparkleParticleData data = SparkleParticleData.sparkle(random.nextFloat() * 0.2F + 1F, 0F, 1F, 1F, 5);
 			level.addParticle(data, pos.getX() + random.nextFloat(), pos.getY() + 1.05, pos.getZ() + random.nextFloat(), 0, 0, 0);
 		}
+	}
+
+	@Override
+	public void onEatenBy(BlockPos pos, BlockState state, LivingEntity entity) {
+		entity.addEffect(new MobEffectInstance(MobEffects.REGENERATION, EFFECT_DURATION, 0, true, true));
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/block/BotaniaMutatedGrassBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/BotaniaMutatedGrassBlock.java
@@ -10,14 +10,50 @@
 
 package vazkii.botania.common.block;
 
+import it.unimi.dsi.fastutil.objects.Object2IntArrayMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+
+import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.effect.MobEffect;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.effect.MobEffects;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.animal.Sheep;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
+import vazkii.botania.api.block.EdibleBlockWithEffects;
 import vazkii.botania.client.fx.SparkleParticleData;
+import vazkii.botania.mixin.LivingEntityAccessor;
 
-public class BotaniaMutatedGrassBlock extends BotaniaGrassBlock {
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class BotaniaMutatedGrassBlock extends BotaniaGrassBlock implements EdibleBlockWithEffects {
+
+	/**
+	 * Random (typically useless) effects to apply. No instant effects, event-centric effects (omens, darkness, etc.),
+	 * or wither (too dangerous). Also, no glowing, since that's a bit too disruptive.
+	 */
+	public static final List<Holder<MobEffect>> RANDOM_EFFECTS = List.of(
+			MobEffects.ABSORPTION, MobEffects.BLINDNESS, MobEffects.CONFUSION, MobEffects.DAMAGE_BOOST,
+			MobEffects.DAMAGE_RESISTANCE, MobEffects.DIG_SLOWDOWN, MobEffects.DIG_SPEED, MobEffects.FIRE_RESISTANCE,
+			MobEffects.HUNGER, MobEffects.INFESTED, MobEffects.INVISIBILITY, MobEffects.JUMP, MobEffects.LEVITATION,
+			MobEffects.LUCK, MobEffects.MOVEMENT_SLOWDOWN, MobEffects.MOVEMENT_SPEED, MobEffects.NIGHT_VISION,
+			MobEffects.OOZING, MobEffects.POISON, MobEffects.REGENERATION, MobEffects.SATURATION,
+			MobEffects.SLOW_FALLING, MobEffects.UNLUCK, MobEffects.WATER_BREATHING, MobEffects.WEAKNESS,
+			MobEffects.WEAVING, MobEffects.WIND_CHARGED
+	);
+	public static final Object2IntMap<Holder<MobEffect>> EFFECT_DURATIONS = Util.make(new Object2IntArrayMap<>(), map -> {
+		map.defaultReturnValue(300);
+		map.put(MobEffects.POISON, 45);
+		map.put(MobEffects.LEVITATION, 10);
+	});
+
 	public BotaniaMutatedGrassBlock(Properties builder) {
 		super(builder);
 	}
@@ -31,5 +67,29 @@ public class BotaniaMutatedGrassBlock extends BotaniaGrassBlock {
 					: SparkleParticleData.sparkle(random.nextFloat() * 0.2F + 1F, 1F, 1F, 0F, 5);
 			level.addParticle(data, pos.getX() + random.nextFloat(), pos.getY() + 1.05, pos.getZ() + random.nextFloat(), 0, 0, 0);
 		}
+	}
+
+	@Override
+	public void onEatenBy(BlockPos pos, BlockState state, LivingEntity entity) {
+		if (entity instanceof Sheep sheep && entity.getRandom().nextInt(5) == 0) {
+			((LivingEntityAccessor) entity).botania_playHurtSound(entity.damageSources().generic());
+			sheep.setSheared(true);
+		}
+		int numEffects = entity.getRandom().nextInt(3) + entity.getRandom().nextInt(3);
+		if (numEffects == 1) {
+			applyEffect(entity, RANDOM_EFFECTS.get(entity.getRandom().nextInt(RANDOM_EFFECTS.size())));
+		} else if (numEffects > 1) {
+			var randomEffects = new ArrayList<>(RANDOM_EFFECTS);
+			Collections.shuffle(randomEffects);
+			for (int i = 0; i < numEffects; i++) {
+				applyEffect(entity, randomEffects.get(i));
+			}
+		}
+	}
+
+	private static void applyEffect(LivingEntity entity, Holder<MobEffect> effect) {
+		entity.addEffect(new MobEffectInstance(effect, EFFECT_DURATIONS.getInt(effect), 0,
+				// make invis particles easier to see
+				effect != MobEffects.INVISIBILITY, true));
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/lib/BotaniaTags.java
+++ b/Xplat/src/main/java/vazkii/botania/common/lib/BotaniaTags.java
@@ -337,6 +337,11 @@ public class BotaniaTags {
 		public static final TagKey<Block> MUNCHDEW_CONSUMABLE = tag("munchdew_consumable");
 
 		/**
+		 * Grass blocks sheep try to eat, not including the vanilla grass.
+		 */
+		public static final TagKey<Block> SHEEP_EDIBLE_GRASSES = tag("sheep_edible_grasses");
+
+		/**
 		 * Blocks in this tag work are likely to cause major issues when used with Abstruse/Spectral Platform blocks.
 		 * This tag can only be a last resort option, as it is likely an error in Botania or the block's origin mod
 		 * that causes the issues, which should be fixed properly.

--- a/Xplat/src/main/java/vazkii/botania/data/BlockTagProvider.java
+++ b/Xplat/src/main/java/vazkii/botania/data/BlockTagProvider.java
@@ -108,6 +108,10 @@ public class BlockTagProvider extends IntrinsicHolderTagsProvider<Block> {
 		tag(BlockTags.DRAGON_IMMUNE).add(BotaniaBlocks.infrangiblePlatform);
 		tag(BlockTags.WITHER_IMMUNE).add(BotaniaBlocks.infrangiblePlatform);
 
+		tag(BotaniaTags.Blocks.SHEEP_EDIBLE_GRASSES).add(
+				dryGrass, goldenGrass, infusedGrass, mutatedGrass, scorchedGrass, vividGrass
+		);
+
 		tag(BotaniaTags.Blocks.MUNDANE_FLOATING_FLOWERS).add(
 				ColorHelper.supportedColors()
 						.map(BotaniaBlocks::getFloatingFlower)

--- a/Xplat/src/main/java/vazkii/botania/mixin/EatBlockGoalMixin.java
+++ b/Xplat/src/main/java/vazkii/botania/mixin/EatBlockGoalMixin.java
@@ -1,0 +1,113 @@
+package vazkii.botania.mixin;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.ai.goal.EatBlockGoal;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+import org.jetbrains.annotations.Nullable;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+import vazkii.botania.api.block.EdibleBlockWithEffects;
+import vazkii.botania.common.lib.BotaniaTags;
+
+/**
+ * Allows sheep to eat Botania grass variants and applies effects of blocks that are an {@link EdibleBlockWithEffects}.
+ */
+@Mixin(EatBlockGoal.class)
+public class EatBlockGoalMixin {
+	@Unique
+	private static final String BOTANIA_EATEN_BLOCK_POS_REF = "eatenBlockPos";
+	@Unique
+	private static final String BOTANIA_EATEN_BLOCK_STATE_REF = "eatenBlockState";
+
+	@Final
+	@Shadow
+	private Level level;
+
+	/**
+	 * Ensure the mob can properly use this goal not just for vanilla grass blocks, but also for those added by Botania.
+	 */
+	@WrapOperation(
+		method = { "canUse", "tick" },
+		at = @At(
+			value = "INVOKE",
+			target = "Lnet/minecraft/world/level/block/state/BlockState;is(Lnet/minecraft/world/level/block/Block;)Z",
+			ordinal = 0
+		),
+		slice = @Slice(
+			from = @At(
+				value = "FIELD",
+				target = "Lnet/minecraft/world/level/block/Blocks;GRASS_BLOCK:Lnet/minecraft/world/level/block/Block;",
+				opcode = Opcodes.GETSTATIC
+			)
+		)
+	)
+	private boolean canEatBotaniaGrasses(BlockState instance, Block block, Operation<Boolean> original) {
+		return original.call(instance, block) || instance.is(BotaniaTags.Blocks.SHEEP_EDIBLE_GRASSES);
+	}
+
+	/**
+	 * After eating an {@link EdibleBlockWithEffects}, apply that block's eating effect(s)
+	 */
+	@WrapOperation(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Mob;ate()V"))
+	private void addEffectsAfterEating(Mob mob, Operation<Void> original,
+			@Share(BOTANIA_EATEN_BLOCK_POS_REF) LocalRef<@Nullable BlockPos> posRef,
+			@Share(BOTANIA_EATEN_BLOCK_STATE_REF) LocalRef<@Nullable BlockState> stateRef) {
+		@Nullable
+		BlockPos pos = posRef.get();
+		@Nullable
+		BlockState state = stateRef.get();
+		original.call(mob);
+		if (pos == null || state == null) {
+			// failed to capture values
+			return;
+		}
+		EdibleBlockWithEffects capability = EdibleBlockWithEffects.LOOKUP.find(level, pos, state, null);
+		if (capability != null) {
+			capability.onEatenBy(pos, state, mob);
+		}
+	}
+
+	// helper methods for capturing relevant values for addEffectsAfterEating()
+
+	@ModifyExpressionValue(
+		method = "tick",
+		at = {
+				@At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Mob;blockPosition()Lnet/minecraft/core/BlockPos;"),
+				@At(value = "INVOKE", target = "Lnet/minecraft/core/BlockPos;below()Lnet/minecraft/core/BlockPos;")
+		}
+	)
+	private BlockPos captureEatenBlockPosition(BlockPos value,
+			@Share(BOTANIA_EATEN_BLOCK_POS_REF) LocalRef<BlockPos> posRef) {
+		posRef.set(value);
+		return value;
+	}
+
+	@ModifyExpressionValue(
+		method = "tick",
+		at = @At(
+			value = "INVOKE",
+			target = "Lnet/minecraft/world/level/Level;getBlockState(Lnet/minecraft/core/BlockPos;)Lnet/minecraft/world/level/block/state/BlockState;"
+		)
+	)
+	private BlockState captureEatenBlockState(BlockState value,
+			@Share(BOTANIA_EATEN_BLOCK_STATE_REF) LocalRef<BlockState> stateRef) {
+		stateRef.set(value);
+		return value;
+	}
+}

--- a/Xplat/src/main/resources/botania.xplat.mixins.json
+++ b/Xplat/src/main/resources/botania.xplat.mixins.json
@@ -25,6 +25,7 @@
     "ConstantIntMixin",
     "CreeperAccessor",
     "CreeperMixin",
+    "EatBlockGoalMixin",
     "EntityAccessor",
     "EntityMixin",
     "ExperienceOrbAccessor",


### PR DESCRIPTION
Some of these may not be "just" food:
- infused grass heals the mob that eats it
- mutated grass has random (though not immediately threatening) side effects on the mob

(implements #4743)