### PR TITLE
Fixed Integer overflow for TerraShatterer

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/terrasteel/TerraShattererItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/equipment/tool/terrasteel/TerraShattererItem.java
@@ -291,7 +291,13 @@ public class TerraShattererItem extends ManasteelPickaxeItem implements Sequenti
 
 		@Override
 		public void addMana(int mana) {
-			setMana(stack, Math.min(getMana() + mana, getMaxMana()) / stack.getCount());
+			int currentMana = getMana();
+			int maxMana = getMaxMana();
+			if (mana <= 0) {
+				setMana(stack, Math.min(currentMana + mana, maxMana) / stack.getCount());
+				return;
+			}
+			setMana(stack, (maxMana - mana < currentMana ? maxMana : currentMana + mana) / stack.getCount());
 		}
 
 		@Override


### PR DESCRIPTION
Hi there!
I found an issue with the TerraShatterer. Since its mana cap is `Integer.MAX_VALUE`, it is the only item vulnerable to the Integer Overflow problem

If the pickaxe has `(MAX_MANA - 5)` mana and we try to add 10 mana, the mana value will wrap around and reset to 0. I've fixed it using a safe comparison before adding

I also want to draw attention to the `getMana` method: it returns `stack mana * stack count`, which can also cause an overflow. However, that bug is not as critical as this one (since it requires a `stack size > 1` for an unstackable item) and would require a much more complex fix using long arithmetics