### PR TITLE
Add noOcclusion to manaPylon block properties

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/BotaniaBlocks.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/BotaniaBlocks.java
@@ -330,7 +330,7 @@ public final class BotaniaBlocks {
 	public static final Block alfPortal = new AlfheimPortalBlock(BlockBehaviour.Properties.copy(livingwood).strength(10).sound(SoundType.WOOD)
 			.lightLevel(s -> s.getValue(BotaniaStateProperties.ALFPORTAL_STATE) != AlfheimPortalState.OFF ? 15 : 0));
 
-	public static final Block manaPylon = new PylonBlock(PylonBlock.Variant.MANA, BlockBehaviour.Properties.of().mapColor(DyeColor.LIGHT_BLUE).strength(5.5F).sound(SoundType.METAL).lightLevel(s -> 7).requiresCorrectToolForDrops());
+	public static final Block manaPylon = new PylonBlock(PylonBlock.Variant.MANA, BlockBehaviour.Properties.of().mapColor(DyeColor.LIGHT_BLUE).strength(5.5F).sound(SoundType.METAL).lightLevel(s -> 7).requiresCorrectToolForDrops().noOcclusion());
 	public static final Block naturaPylon = new PylonBlock(PylonBlock.Variant.NATURA, BlockBehaviour.Properties.copy(manaPylon).mapColor(MapColor.EMERALD));
 	public static final Block gaiaPylon = new PylonBlock(PylonBlock.Variant.GAIA, BlockBehaviour.Properties.copy(manaPylon).mapColor(DyeColor.PINK));
 


### PR DESCRIPTION
Add noOcclusion property to manaPylon block so that the faces of the blocks directly adjacent to the crystal can be properly rendered.

<img width="466" height="554" alt="image" src="https://github.com/user-attachments/assets/7ffea471-03f0-465e-bac7-e04dcf65039e" />


<img width="638" height="507" alt="image" src="https://github.com/user-attachments/assets/78fe5200-7f8e-458c-b6b3-461269cd8d2b" />
