### PR TITLE
Cleaning pass over Level::getBlockEntity(BlockPos) calls

### DIFF
--- a/Fabric/src/main/java/vazkii/botania/fabric/block/FabricSpecialFlowerBlock.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/block/FabricSpecialFlowerBlock.java
@@ -88,7 +88,9 @@ public class FabricSpecialFlowerBlock extends FlowerBlock implements EntityBlock
 
 	@Override
 	public void setPlacedBy(Level level, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack stack) {
-		((SpecialFlowerBlockEntity) level.getBlockEntity(pos)).setPlacedBy(level, pos, state, placer, stack);
+		if (level.getBlockEntity(pos) instanceof SpecialFlowerBlockEntity flower) {
+			flower.setPlacedBy(level, pos, state, placer, stack);
+		}
 	}
 
 	@Override
@@ -111,24 +113,19 @@ public class FabricSpecialFlowerBlock extends FlowerBlock implements EntityBlock
 
 	@Override
 	public int getAnalogOutputSignal(BlockState bs, Level level, BlockPos pos) {
-		if (level.getBlockEntity(pos) instanceof SpecialFlowerBlockEntity flower) {
-			return flower.getComparatorSignal();
-		}
-		return 0;
+		return level.getBlockEntity(pos) instanceof SpecialFlowerBlockEntity flower ? flower.getComparatorSignal() : 0;
 	}
 
 	public static void redstoneParticlesIfPowered(BlockState state, Level world, BlockPos pos, RandomSource rand) {
-		BlockEntity te = world.getBlockEntity(pos);
-		if (te instanceof FunctionalFlowerBlockEntity flower && rand.nextBoolean()) {
-			if (flower.acceptsRedstone() && flower.redstoneSignal > 0) {
-				VoxelShape shape = state.getShape(world, pos);
-				if (!shape.isEmpty()) {
-					AABB localBox = shape.bounds();
-					double x = pos.getX() + localBox.minX + rand.nextDouble() * (localBox.maxX - localBox.minX);
-					double y = pos.getY() + localBox.minY + rand.nextDouble() * (localBox.maxY - localBox.minY);
-					double z = pos.getZ() + localBox.minZ + rand.nextDouble() * (localBox.maxZ - localBox.minZ);
-					world.addParticle(DustParticleOptions.REDSTONE, x, y, z, 0, 0, 0);
-				}
+		if (world.getBlockEntity(pos) instanceof FunctionalFlowerBlockEntity flower
+				&& rand.nextBoolean() && flower.acceptsRedstone() && flower.redstoneSignal > 0) {
+			VoxelShape shape = state.getShape(world, pos);
+			if (!shape.isEmpty()) {
+				AABB localBox = shape.bounds();
+				double x = pos.getX() + localBox.minX + rand.nextDouble() * (localBox.maxX - localBox.minX);
+				double y = pos.getY() + localBox.minY + rand.nextDouble() * (localBox.maxY - localBox.minY);
+				double z = pos.getZ() + localBox.minZ + rand.nextDouble() * (localBox.maxZ - localBox.minZ);
+				world.addParticle(DustParticleOptions.REDSTONE, x, y, z, 0, 0, 0);
 			}
 		}
 	}

--- a/Fabric/src/main/java/vazkii/botania/fabric/xplat/FabricXplatImpl.java
+++ b/Fabric/src/main/java/vazkii/botania/fabric/xplat/FabricXplatImpl.java
@@ -351,9 +351,7 @@ public class FabricXplatImpl implements XplatAbstractions {
 
 	@Override
 	public boolean hasInventory(Level level, BlockPos pos, Direction sideOfPos) {
-		var state = level.getBlockState(pos);
-		var be = level.getBlockEntity(pos);
-		return ItemStorage.SIDED.find(level, pos, state, be, sideOfPos) != null;
+		return ItemStorage.SIDED.find(level, pos, sideOfPos) != null;
 	}
 
 	@Override
@@ -364,8 +362,7 @@ public class FabricXplatImpl implements XplatAbstractions {
 		}
 
 		var state = level.getBlockState(pos);
-		var be = level.getBlockEntity(pos);
-		var storage = ItemStorage.SIDED.find(level, pos, state, be, sideOfPos);
+		var storage = ItemStorage.SIDED.find(level, pos, state, null, sideOfPos);
 		if (storage == null) {
 			return toInsert;
 		}

--- a/Forge/src/main/java/vazkii/botania/forge/block/ForgeSpecialFlowerBlock.java
+++ b/Forge/src/main/java/vazkii/botania/forge/block/ForgeSpecialFlowerBlock.java
@@ -80,7 +80,9 @@ public class ForgeSpecialFlowerBlock extends FlowerBlock implements EntityBlock 
 
 	@Override
 	public void setPlacedBy(Level level, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack stack) {
-		((SpecialFlowerBlockEntity) level.getBlockEntity(pos)).setPlacedBy(level, pos, state, placer, stack);
+		if (level.getBlockEntity(pos) instanceof SpecialFlowerBlockEntity flower) {
+			flower.setPlacedBy(level, pos, state, placer, stack);
+		}
 	}
 
 	@Override
@@ -103,10 +105,7 @@ public class ForgeSpecialFlowerBlock extends FlowerBlock implements EntityBlock 
 
 	@Override
 	public int getAnalogOutputSignal(BlockState bs, Level level, BlockPos pos) {
-		if (level.getBlockEntity(pos) instanceof SpecialFlowerBlockEntity flower) {
-			return flower.getComparatorSignal();
-		}
-		return 0;
+		return level.getBlockEntity(pos) instanceof SpecialFlowerBlockEntity flower ? flower.getComparatorSignal() : 0;
 	}
 
 }

--- a/Xplat/src/main/java/vazkii/botania/common/block/AnimatedTorchBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/AnimatedTorchBlock.java
@@ -45,8 +45,8 @@ public class AnimatedTorchBlock extends BotaniaWaterloggedBlock implements Entit
 
 	@Override
 	public InteractionResult use(BlockState state, Level worldIn, BlockPos pos, Player playerIn, InteractionHand hand, BlockHitResult hit) {
-		if (playerIn.isSecondaryUseActive()) {
-			((AnimatedTorchBlockEntity) worldIn.getBlockEntity(pos)).handRotate();
+		if (playerIn.isSecondaryUseActive() && worldIn.getBlockEntity(pos) instanceof AnimatedTorchBlockEntity torch) {
+			torch.handRotate();
 			return InteractionResult.sidedSuccess(worldIn.isClientSide());
 		}
 
@@ -55,7 +55,9 @@ public class AnimatedTorchBlock extends BotaniaWaterloggedBlock implements Entit
 
 	@Override
 	public void setPlacedBy(Level world, BlockPos pos, BlockState state, @Nullable LivingEntity entity, ItemStack stack) {
-		((AnimatedTorchBlockEntity) world.getBlockEntity(pos)).onPlace(entity);
+		if (world.getBlockEntity(pos) instanceof AnimatedTorchBlockEntity torch) {
+			torch.onPlace(entity);
+		}
 	}
 
 	@Override
@@ -64,19 +66,21 @@ public class AnimatedTorchBlock extends BotaniaWaterloggedBlock implements Entit
 	}
 
 	@Override
-	public int getDirectSignal(BlockState blockState, BlockGetter blockAccess, BlockPos pos, Direction side) {
-		return getSignal(blockState, blockAccess, pos, side);
+	public int getDirectSignal(BlockState state, BlockGetter level, BlockPos pos, Direction side) {
+		return getSignal(state, level, pos, side);
 	}
 
 	@Override
-	public int getSignal(BlockState blockState, BlockGetter blockAccess, BlockPos pos, Direction side) {
-		AnimatedTorchBlockEntity tile = (AnimatedTorchBlockEntity) blockAccess.getBlockEntity(pos);
-
-		if (tile.rotating || !tile.directionInitialized) {
+	public int getSignal(BlockState state, BlockGetter level, BlockPos pos, Direction side) {
+		if (!(level.getBlockEntity(pos) instanceof AnimatedTorchBlockEntity torch)) {
 			return 0;
 		}
 
-		if (AnimatedTorchBlockEntity.SIDES[tile.side] == side) {
+		if (torch.rotating || !torch.directionInitialized) {
+			return 0;
+		}
+
+		if (AnimatedTorchBlockEntity.SIDES[torch.side] == side) {
 			return 15;
 		}
 

--- a/Xplat/src/main/java/vazkii/botania/common/block/AvatarBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/AvatarBlock.java
@@ -71,16 +71,18 @@ public class AvatarBlock extends BotaniaWaterloggedBlock implements EntityBlock 
 
 	@Override
 	public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
-		AvatarBlockEntity avatar = (AvatarBlockEntity) world.getBlockEntity(pos);
-		ItemStack stackOnAvatar = avatar.getItemHandler().getItem(0);
-		ItemStack stackOnPlayer = player.getItemInHand(hand);
-		if (!stackOnAvatar.isEmpty()) {
-			avatar.getItemHandler().setItem(0, ItemStack.EMPTY);
-			player.getInventory().placeItemBackInInventory(stackOnAvatar);
-			return InteractionResult.sidedSuccess(world.isClientSide());
-		} else if (!stackOnPlayer.isEmpty() && XplatAbstractions.INSTANCE.findAvatarWieldable(stackOnPlayer) != null) {
-			avatar.getItemHandler().setItem(0, stackOnPlayer.split(1));
-			return InteractionResult.sidedSuccess(world.isClientSide());
+		if (world.getBlockEntity(pos) instanceof AvatarBlockEntity avatar) {
+			ItemStack stackOnAvatar = avatar.getItemHandler().getItem(0);
+			ItemStack stackOnPlayer = player.getItemInHand(hand);
+			if (!stackOnAvatar.isEmpty()) {
+				avatar.getItemHandler().setItem(0, ItemStack.EMPTY);
+				player.getInventory().placeItemBackInInventory(stackOnAvatar);
+				return InteractionResult.sidedSuccess(world.isClientSide());
+			} else if (!stackOnPlayer.isEmpty() &&
+					XplatAbstractions.INSTANCE.findAvatarWieldable(stackOnPlayer) != null) {
+				avatar.getItemHandler().setItem(0, stackOnPlayer.split(1));
+				return InteractionResult.sidedSuccess(world.isClientSide());
+			}
 		}
 
 		return InteractionResult.PASS;
@@ -89,8 +91,7 @@ public class AvatarBlock extends BotaniaWaterloggedBlock implements EntityBlock 
 	@Override
 	public void onRemove(@NotNull BlockState state, @NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState newstate, boolean isMoving) {
 		if (!state.is(newstate.getBlock())) {
-			BlockEntity be = world.getBlockEntity(pos);
-			if (be instanceof SimpleInventoryBlockEntity inventory) {
+			if (world.getBlockEntity(pos) instanceof SimpleInventoryBlockEntity inventory) {
 				Containers.dropContents(world, pos, inventory.getItemHandler());
 			}
 			super.onRemove(state, world, pos, newstate, isMoving);

--- a/Xplat/src/main/java/vazkii/botania/common/block/CacophoniumBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/CacophoniumBlock.java
@@ -39,8 +39,7 @@ public class CacophoniumBlock extends BotaniaBlock implements EntityBlock {
 		boolean powered = state.getValue(BlockStateProperties.POWERED);
 
 		if (power && !powered) {
-			BlockEntity tile = world.getBlockEntity(pos);
-			if (tile instanceof CacophoniumBlockEntity cacophonium) {
+			if (world.getBlockEntity(pos) instanceof CacophoniumBlockEntity cacophonium) {
 				cacophonium.annoyDirewolf();
 			}
 			world.setBlock(pos, state.setValue(BlockStateProperties.POWERED, true), Block.UPDATE_INVISIBLE);
@@ -52,8 +51,7 @@ public class CacophoniumBlock extends BotaniaBlock implements EntityBlock {
 	@Override
 	public void onRemove(BlockState state, Level world, BlockPos pos, BlockState newState, boolean isMoving) {
 		if (!state.is(newState.getBlock())) {
-			BlockEntity te = world.getBlockEntity(pos);
-			if (te instanceof CacophoniumBlockEntity cacophonium) {
+			if (world.getBlockEntity(pos) instanceof CacophoniumBlockEntity cacophonium) {
 				Containers.dropItemStack(world, pos.getX(), pos.getY(), pos.getZ(), cacophonium.stack);
 			}
 			super.onRemove(state, world, pos, newState, isMoving);

--- a/Xplat/src/main/java/vazkii/botania/common/block/CocoonBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/CocoonBlock.java
@@ -77,29 +77,34 @@ public class CocoonBlock extends BotaniaWaterloggedBlock implements EntityBlock 
 	}
 
 	private InteractionResult addStack(Level world, BlockPos pos, ItemStack stack, boolean creative) {
-		CocoonBlockEntity cocoon = (CocoonBlockEntity) world.getBlockEntity(pos);
-
-		if (cocoon != null && (stack.is(Items.EMERALD) || stack.is(Items.CHORUS_FRUIT) || stack.is(BotaniaItems.lifeEssence))) {
+		if (!(world.getBlockEntity(pos) instanceof CocoonBlockEntity cocoon)) {
+			return InteractionResult.PASS;
+		}
+		if (stack.is(Items.EMERALD) || stack.is(Items.CHORUS_FRUIT) || stack.is(BotaniaItems.lifeEssence)) {
 			if (!world.isClientSide) {
 				if (stack.is(Items.EMERALD) && cocoon.emeraldsGiven < CocoonBlockEntity.MAX_EMERALDS) {
 					if (!creative) {
 						stack.shrink(1);
 					}
 					cocoon.emeraldsGiven++;
-					((ServerLevel) world).sendParticles(ParticleTypes.HAPPY_VILLAGER, pos.getX() + 0.5, pos.getY() + 1, pos.getZ() + 0.5, 1, 0.1, 0.05, 0.1, 0.5);
-				} else if (stack.is(Items.CHORUS_FRUIT) && cocoon.chorusFruitGiven < CocoonBlockEntity.MAX_CHORUS_FRUITS) {
+					((ServerLevel) world).sendParticles(ParticleTypes.HAPPY_VILLAGER, pos.getX() + 0.5,
+							pos.getY() + 1, pos.getZ() + 0.5, 1, 0.1, 0.05, 0.1, 0.5);
+				} else if (stack.is(Items.CHORUS_FRUIT) &&
+						cocoon.chorusFruitGiven < CocoonBlockEntity.MAX_CHORUS_FRUITS) {
 					if (!creative) {
 						stack.shrink(1);
 					}
 					cocoon.chorusFruitGiven++;
-					((ServerLevel) world).sendParticles(ParticleTypes.PORTAL, pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5, 32, 0, 0, 0, 0.5);
+					((ServerLevel) world).sendParticles(ParticleTypes.PORTAL, pos.getX() + 0.5, pos.getY(),
+							pos.getZ() + 0.5, 32, 0, 0, 0, 0.5);
 				} else if (stack.is(BotaniaItems.lifeEssence) && !cocoon.gaiaSpiritGiven) {
 					if (!creative) {
 						stack.shrink(1);
 					}
 					cocoon.forceRare();
 					WispParticleData data = WispParticleData.wisp(0.6F, 0F, 1F, 0F);
-					((ServerLevel) world).sendParticles(data, pos.getX() + 0.5, pos.getY() + 0.7, pos.getZ() + 0.5, 8, 0.1, 0.1, 0.1, 0.04);
+					((ServerLevel) world).sendParticles(data, pos.getX() + 0.5, pos.getY() + 0.7, pos.getZ() + 0.5,
+							8, 0.1, 0.1, 0.1, 0.04);
 				}
 			}
 

--- a/Xplat/src/main/java/vazkii/botania/common/block/CraftyCrateBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/CraftyCrateBlock.java
@@ -44,11 +44,7 @@ public class CraftyCrateBlock extends OpenCrateBlock {
 
 	@Override
 	public int getAnalogOutputSignal(BlockState state, Level world, BlockPos pos) {
-		BlockEntity block = world.getBlockEntity(pos);
-		if (block instanceof CraftyCrateBlockEntity crate) {
-			return crate.getSignal();
-		}
-		return 0;
+		return world.getBlockEntity(pos) instanceof CraftyCrateBlockEntity crate ? crate.getSignal() : 0;
 	}
 
 	@NotNull

--- a/Xplat/src/main/java/vazkii/botania/common/block/EyeOfTheAncientsBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/EyeOfTheAncientsBlock.java
@@ -46,8 +46,9 @@ public class EyeOfTheAncientsBlock extends BotaniaWaterloggedBlock implements En
 
 	@Override
 	public int getAnalogOutputSignal(BlockState state, Level world, BlockPos pos) {
-		EyeOfTheAncientsBlockEntity eye = (EyeOfTheAncientsBlockEntity) world.getBlockEntity(pos);
-		return eye == null ? 0 : Math.min(15, Math.max(0, eye.entities - 1));
+		return world.getBlockEntity(pos) instanceof EyeOfTheAncientsBlockEntity eye
+				? Math.min(15, Math.max(0, eye.entities - 1))
+				: 0;
 	}
 
 	@NotNull

--- a/Xplat/src/main/java/vazkii/botania/common/block/FloatingSpecialFlowerBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/FloatingSpecialFlowerBlock.java
@@ -54,8 +54,7 @@ public class FloatingSpecialFlowerBlock extends FloatingFlowerBlock {
 	}
 
 	public static void redstoneParticlesIfPowered(BlockState state, Level world, BlockPos pos, RandomSource rand) {
-		BlockEntity te = world.getBlockEntity(pos);
-		if (te instanceof FunctionalFlowerBlockEntity flower && rand.nextBoolean()) {
+		if (world.getBlockEntity(pos) instanceof FunctionalFlowerBlockEntity flower && rand.nextBoolean()) {
 			if (flower.acceptsRedstone() && flower.redstoneSignal > 0) {
 				VoxelShape shape = state.getShape(world, pos);
 				if (!shape.isEmpty()) {
@@ -71,7 +70,9 @@ public class FloatingSpecialFlowerBlock extends FloatingFlowerBlock {
 
 	@Override
 	public void setPlacedBy(Level world, BlockPos pos, BlockState state, @Nullable LivingEntity entity, ItemStack stack) {
-		((SpecialFlowerBlockEntity) world.getBlockEntity(pos)).setPlacedBy(world, pos, state, entity, stack);
+		if (world.getBlockEntity(pos) instanceof SpecialFlowerBlockEntity flower) {
+			flower.setPlacedBy(world, pos, state, entity, stack);
+		}
 	}
 
 	@Override
@@ -103,9 +104,6 @@ public class FloatingSpecialFlowerBlock extends FloatingFlowerBlock {
 
 	@Override
 	public int getAnalogOutputSignal(BlockState bs, Level level, BlockPos pos) {
-		if (level.getBlockEntity(pos) instanceof SpecialFlowerBlockEntity flower) {
-			return flower.getComparatorSignal();
-		}
-		return 0;
+		return level.getBlockEntity(pos) instanceof SpecialFlowerBlockEntity flower ? flower.getComparatorSignal() : 0;
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/block/HoveringHourglassBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/HoveringHourglassBlock.java
@@ -64,7 +64,9 @@ public class HoveringHourglassBlock extends BotaniaWaterloggedBlock implements E
 
 	@Override
 	public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
-		HoveringHourglassBlockEntity hourglass = (HoveringHourglassBlockEntity) world.getBlockEntity(pos);
+		if (!(world.getBlockEntity(pos) instanceof HoveringHourglassBlockEntity hourglass)) {
+			return InteractionResult.FAIL;
+		}
 		ItemStack hgStack = hourglass.getItemHandler().getItem(0);
 		ItemStack stack = player.getItemInHand(hand);
 		if (!stack.isEmpty() && stack.getItem() instanceof WandOfTheForestItem) {
@@ -111,8 +113,7 @@ public class HoveringHourglassBlock extends BotaniaWaterloggedBlock implements E
 	@Override
 	public void onRemove(@NotNull BlockState state, @NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState newState, boolean isMoving) {
 		if (!state.is(newState.getBlock())) {
-			BlockEntity be = world.getBlockEntity(pos);
-			if (be instanceof SimpleInventoryBlockEntity inventory) {
+			if (world.getBlockEntity(pos) instanceof SimpleInventoryBlockEntity inventory) {
 				Containers.dropContents(world, pos, inventory.getItemHandler());
 			}
 			super.onRemove(state, world, pos, newState, isMoving);

--- a/Xplat/src/main/java/vazkii/botania/common/block/IncensePlateBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/IncensePlateBlock.java
@@ -64,7 +64,9 @@ public class IncensePlateBlock extends BotaniaWaterloggedBlock implements Entity
 
 	@Override
 	public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
-		IncensePlateBlockEntity plate = (IncensePlateBlockEntity) world.getBlockEntity(pos);
+		if (!(world.getBlockEntity(pos) instanceof IncensePlateBlockEntity plate)) {
+			return InteractionResult.FAIL;
+		}
 		ItemStack plateStack = plate.getItemHandler().getItem(0);
 		ItemStack stack = player.getItemInHand(hand);
 		boolean did = false;
@@ -128,17 +130,13 @@ public class IncensePlateBlock extends BotaniaWaterloggedBlock implements Entity
 
 	@Override
 	public int getAnalogOutputSignal(BlockState state, Level world, BlockPos pos) {
-		return ((IncensePlateBlockEntity) world.getBlockEntity(pos)).comparatorOutput;
+		return world.getBlockEntity(pos) instanceof IncensePlateBlockEntity plate ? plate.comparatorOutput : 0;
 	}
 
 	@NotNull
 	@Override
 	public VoxelShape getShape(BlockState state, BlockGetter world, BlockPos pos, CollisionContext ctx) {
-		if (state.getValue(BlockStateProperties.HORIZONTAL_FACING).getAxis() == Direction.Axis.X) {
-			return X_SHAPE;
-		} else {
-			return Z_SHAPE;
-		}
+		return state.getValue(BlockStateProperties.HORIZONTAL_FACING).getAxis() == Direction.Axis.X ? X_SHAPE : Z_SHAPE;
 	}
 
 	@NotNull
@@ -155,11 +153,9 @@ public class IncensePlateBlock extends BotaniaWaterloggedBlock implements Entity
 
 	@Override
 	public void onRemove(@NotNull BlockState state, @NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState newState, boolean isMoving) {
-		if (!state.is(newState.getBlock())) {
-			BlockEntity block = world.getBlockEntity(pos);
-			if (block instanceof IncensePlateBlockEntity plate && !plate.burning) {
-				Containers.dropContents(world, pos, plate.getItemHandler());
-			}
+		if (!state.is(newState.getBlock())
+				&& world.getBlockEntity(pos) instanceof IncensePlateBlockEntity plate && !plate.burning) {
+			Containers.dropContents(world, pos, plate.getItemHandler());
 		}
 		super.onRemove(state, world, pos, newState, isMoving);
 	}
@@ -167,8 +163,7 @@ public class IncensePlateBlock extends BotaniaWaterloggedBlock implements Entity
 	@Override
 	public void onProjectileHit(@NotNull Level level, @NotNull BlockState blockState,
 			@NotNull BlockHitResult hit, @NotNull Projectile projectile) {
-		if (!level.isClientSide && projectile.mayInteract(level, hit.getBlockPos())
-				&& projectile.isOnFire()) {
+		if (!level.isClientSide && projectile.mayInteract(level, hit.getBlockPos()) && projectile.isOnFire()) {
 			if (level.getBlockEntity(hit.getBlockPos()) instanceof IncensePlateBlockEntity plate) {
 				plate.ignite();
 				VanillaPacketDispatcher.dispatchTEToNearbyPlayers(plate);

--- a/Xplat/src/main/java/vazkii/botania/common/block/LuminizerBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/LuminizerBlock.java
@@ -66,12 +66,10 @@ public class LuminizerBlock extends BotaniaWaterloggedBlock implements EntityBlo
 	@Override
 	public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
 		ItemStack stack = player.getItemInHand(hand);
-		BlockEntity te = world.getBlockEntity(pos);
-		if (te instanceof LuminizerBlockEntity relay) {
-			if (!stack.is(Items.ENDER_PEARL) && !(stack.getItem() instanceof PhantomInkItem)) {
-				relay.mountEntity(player);
-				return InteractionResult.sidedSuccess(world.isClientSide());
-			}
+		if (world.getBlockEntity(pos) instanceof LuminizerBlockEntity relay
+				&& !stack.is(Items.ENDER_PEARL) && !(stack.getItem() instanceof PhantomInkItem)) {
+			relay.mountEntity(player);
+			return InteractionResult.sidedSuccess(world.isClientSide());
 		}
 
 		return InteractionResult.PASS;

--- a/Xplat/src/main/java/vazkii/botania/common/block/LuminizerLauncherBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/LuminizerLauncherBlock.java
@@ -18,7 +18,6 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -70,11 +69,9 @@ public class LuminizerLauncherBlock extends BotaniaWaterloggedBlock {
 	private void pickUpEntities(Level world, BlockPos pos) {
 		List<LuminizerBlockEntity> relays = new ArrayList<>();
 		for (Direction dir : Direction.values()) {
-			BlockEntity tile = world.getBlockEntity(pos.relative(dir));
-			if (tile instanceof LuminizerBlockEntity relay) {
-				if (relay.getNextDestination() != null) {
-					relays.add(relay);
-				}
+			if (world.getBlockEntity(pos.relative(dir)) instanceof LuminizerBlockEntity relay
+					&& relay.getNextDestination() != null) {
+				relays.add(relay);
 			}
 		}
 

--- a/Xplat/src/main/java/vazkii/botania/common/block/OpenCrateBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/OpenCrateBlock.java
@@ -36,8 +36,7 @@ public class OpenCrateBlock extends BotaniaBlock implements EntityBlock {
 	@Override
 	public void onRemove(@NotNull BlockState state, @NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState newState, boolean isMoving) {
 		if (!newState.is(state.getBlock())) {
-			BlockEntity be = world.getBlockEntity(pos);
-			if (be instanceof SimpleInventoryBlockEntity inventory) {
+			if (world.getBlockEntity(pos) instanceof SimpleInventoryBlockEntity inventory) {
 				Containers.dropContents(world, pos, inventory.getItemHandler());
 			}
 			super.onRemove(state, world, pos, newState, isMoving);

--- a/Xplat/src/main/java/vazkii/botania/common/block/PetalApothecaryBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/PetalApothecaryBlock.java
@@ -107,11 +107,10 @@ public class PetalApothecaryBlock extends BotaniaBlock implements EntityBlock {
 
 	@Override
 	public void entityInside(BlockState state, Level world, BlockPos pos, Entity entity) {
-		if (!world.isClientSide && entity instanceof ItemEntity itemEntity) {
-			PetalApothecaryBlockEntity tile = (PetalApothecaryBlockEntity) world.getBlockEntity(pos);
-			if (tile.collideEntityItem(itemEntity)) {
-				VanillaPacketDispatcher.dispatchTEToNearbyPlayers(tile);
-			}
+		if (!world.isClientSide && entity instanceof ItemEntity itemEntity
+				&& world.getBlockEntity(pos) instanceof PetalApothecaryBlockEntity apothecary
+				&& apothecary.collideEntityItem(itemEntity)) {
+			VanillaPacketDispatcher.dispatchTEToNearbyPlayers(apothecary);
 		}
 	}
 
@@ -213,8 +212,7 @@ public class PetalApothecaryBlock extends BotaniaBlock implements EntityBlock {
 	public void onRemove(@NotNull BlockState state, @NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState newState, boolean isMoving) {
 		boolean blockChanged = !state.is(newState.getBlock());
 		if (blockChanged || newState.getValue(FLUID) != State.WATER) {
-			BlockEntity be = world.getBlockEntity(pos);
-			if (be instanceof SimpleInventoryBlockEntity inventory) {
+			if (world.getBlockEntity(pos) instanceof SimpleInventoryBlockEntity inventory) {
 				Containers.dropContents(world, pos, inventory.getItemHandler());
 			}
 			if (blockChanged) {

--- a/Xplat/src/main/java/vazkii/botania/common/block/PlatformBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/PlatformBlock.java
@@ -79,8 +79,7 @@ public class PlatformBlock extends BotaniaBlock implements ManaCollisionGhost, E
 	@NotNull
 	@Override
 	public VoxelShape getShape(@NotNull BlockState state, @NotNull BlockGetter world, @NotNull BlockPos pos, @NotNull CollisionContext context) {
-		BlockEntity te = world.getBlockEntity(pos);
-		if (te instanceof PlatformBlockEntity platform && platform.getCamoState() != null) {
+		if (world.getBlockEntity(pos) instanceof PlatformBlockEntity platform && platform.getCamoState() != null) {
 			return platform.getCamoState().getShape(world, pos);
 		} else {
 			return super.getShape(state, world, pos, context);
@@ -132,7 +131,6 @@ public class PlatformBlock extends BotaniaBlock implements ManaCollisionGhost, E
 	@NotNull
 	@Override
 	public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
-		BlockEntity tile = world.getBlockEntity(pos);
 		ItemStack currentStack = player.getItemInHand(hand);
 
 		if (variant.indestructible && !player.isCreative()) {
@@ -140,7 +138,7 @@ public class PlatformBlock extends BotaniaBlock implements ManaCollisionGhost, E
 		}
 		if (!currentStack.isEmpty()
 				&& Block.byItem(currentStack.getItem()) != Blocks.AIR
-				&& tile instanceof PlatformBlockEntity camo) {
+				&& world.getBlockEntity(pos) instanceof PlatformBlockEntity camo) {
 			BlockPlaceContext ctx = new BlockPlaceContext(player, hand, currentStack, hit);
 			BlockState changeState = Block.byItem(currentStack.getItem()).getStateForPlacement(ctx);
 

--- a/Xplat/src/main/java/vazkii/botania/common/block/SparkTinkererBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/SparkTinkererBlock.java
@@ -59,7 +59,9 @@ public class SparkTinkererBlock extends BotaniaWaterloggedBlock implements Entit
 		boolean powered = state.getValue(BlockStateProperties.POWERED);
 
 		if (power && !powered) {
-			((SparkTinkererBlockEntity) world.getBlockEntity(pos)).doSwap();
+			if (world.getBlockEntity(pos) instanceof SparkTinkererBlockEntity tinkerer) {
+				tinkerer.doSwap();
+			}
 			world.setBlock(pos, state.setValue(BlockStateProperties.POWERED, true), Block.UPDATE_INVISIBLE);
 		} else if (!power && powered) {
 			world.setBlock(pos, state.setValue(BlockStateProperties.POWERED, false), Block.UPDATE_INVISIBLE);
@@ -68,7 +70,9 @@ public class SparkTinkererBlock extends BotaniaWaterloggedBlock implements Entit
 
 	@Override
 	public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
-		SparkTinkererBlockEntity changer = (SparkTinkererBlockEntity) world.getBlockEntity(pos);
+		if (!(world.getBlockEntity(pos) instanceof SparkTinkererBlockEntity changer)) {
+			return InteractionResult.FAIL;
+		}
 		ItemStack pstack = player.getItemInHand(hand);
 		ItemStack cstack = changer.getItemHandler().getItem(0);
 		if (!cstack.isEmpty()) {
@@ -88,8 +92,7 @@ public class SparkTinkererBlock extends BotaniaWaterloggedBlock implements Entit
 	@Override
 	public void onRemove(@NotNull BlockState state, @NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState newState, boolean isMoving) {
 		if (!state.is(newState.getBlock())) {
-			BlockEntity be = world.getBlockEntity(pos);
-			if (be instanceof SimpleInventoryBlockEntity inventory) {
+			if (world.getBlockEntity(pos) instanceof SimpleInventoryBlockEntity inventory) {
 				Containers.dropContents(world, pos, inventory.getItemHandler());
 			}
 			super.onRemove(state, world, pos, newState, isMoving);
@@ -103,10 +106,11 @@ public class SparkTinkererBlock extends BotaniaWaterloggedBlock implements Entit
 
 	@Override
 	public int getAnalogOutputSignal(BlockState state, Level world, BlockPos pos) {
-		SparkTinkererBlockEntity changer = (SparkTinkererBlockEntity) world.getBlockEntity(pos);
-		ItemStack stack = changer.getItemHandler().getItem(0);
-		if (!stack.isEmpty() && stack.getItem() instanceof SparkAugmentItem upgrade) {
-			return upgrade.type.ordinal() + 1;
+		if (world.getBlockEntity(pos) instanceof SparkTinkererBlockEntity changer) {
+			ItemStack stack = changer.getItemHandler().getItem(0);
+			if (!stack.isEmpty() && stack.getItem() instanceof SparkAugmentItem upgrade) {
+				return upgrade.type.ordinal() + 1;
+			}
 		}
 		return 0;
 	}

--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/LuminizerBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/LuminizerBlockEntity.java
@@ -177,7 +177,7 @@ public class LuminizerBlockEntity extends BotaniaBlockEntity implements WandBind
 			}
 
 			BlockEntity tile = level.getBlockEntity(coords);
-			if (tile != null && tile instanceof LuminizerBlockEntity tileRelay) {
+			if (tile instanceof LuminizerBlockEntity tileRelay) {
 				relay = tileRelay;
 			} else {
 				return lastCoords;
@@ -228,8 +228,7 @@ public class LuminizerBlockEntity extends BotaniaBlockEntity implements WandBind
 				}
 			}
 
-			if (torchPos != null) {
-				AnimatedTorchBlockEntity torch = (AnimatedTorchBlockEntity) level.getBlockEntity(torchPos);
+			if (torchPos != null && level.getBlockEntity(torchPos) instanceof AnimatedTorchBlockEntity torch) {
 				Direction side = AnimatedTorchBlockEntity.SIDES[torch.side].getOpposite();
 				for (int i = 1; i < MAX_DIST; i++) {
 					BlockPos testPos = worldPosition.relative(side, i);

--- a/Xplat/src/main/java/vazkii/botania/common/block/corporea/CorporeaCrystalCubeBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/corporea/CorporeaCrystalCubeBlock.java
@@ -45,8 +45,7 @@ public class CorporeaCrystalCubeBlock extends BotaniaWaterloggedBlock implements
 
 	@Override
 	public void attack(BlockState state, Level world, BlockPos pos, Player player) {
-		if (!world.isClientSide) {
-			CorporeaCrystalCubeBlockEntity cube = (CorporeaCrystalCubeBlockEntity) world.getBlockEntity(pos);
+		if (!world.isClientSide && world.getBlockEntity(pos) instanceof CorporeaCrystalCubeBlockEntity cube) {
 			cube.doRequest(player);
 		}
 	}
@@ -64,7 +63,9 @@ public class CorporeaCrystalCubeBlock extends BotaniaWaterloggedBlock implements
 			if (stack.getItem() instanceof WandOfTheForestItem && player.isSecondaryUseActive()) {
 				return InteractionResult.PASS;
 			}
-			CorporeaCrystalCubeBlockEntity cube = (CorporeaCrystalCubeBlockEntity) world.getBlockEntity(pos);
+			if (!(world.getBlockEntity(pos) instanceof CorporeaCrystalCubeBlockEntity cube)) {
+				return InteractionResult.FAIL;
+			}
 			if (cube.locked) {
 				if (!world.isClientSide) {
 					player.displayClientMessage(Component.translatable("botaniamisc.crystalCubeLocked"), false);
@@ -99,6 +100,8 @@ public class CorporeaCrystalCubeBlock extends BotaniaWaterloggedBlock implements
 
 	@Override
 	public int getAnalogOutputSignal(BlockState state, Level world, BlockPos pos) {
-		return ((CorporeaCrystalCubeBlockEntity) world.getBlockEntity(pos)).getComparatorValue();
+		return world.getBlockEntity(pos) instanceof CorporeaCrystalCubeBlockEntity cube
+				? cube.getComparatorValue()
+				: 0;
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/block/corporea/CorporeaFunnelBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/corporea/CorporeaFunnelBlock.java
@@ -41,7 +41,9 @@ public class CorporeaFunnelBlock extends BotaniaBlock implements EntityBlock {
 
 		if (power && !powered) {
 			world.setBlock(pos, state.setValue(BlockStateProperties.POWERED, true), Block.UPDATE_INVISIBLE);
-			((CorporeaFunnelBlockEntity) world.getBlockEntity(pos)).doRequest();
+			if (world.getBlockEntity(pos) instanceof CorporeaFunnelBlockEntity funnel) {
+				funnel.doRequest();
+			}
 		} else if (!power && powered) {
 			world.setBlock(pos, state.setValue(BlockStateProperties.POWERED, false), Block.UPDATE_INVISIBLE);
 		}

--- a/Xplat/src/main/java/vazkii/botania/common/block/corporea/CorporeaRetainerBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/corporea/CorporeaRetainerBlock.java
@@ -53,7 +53,9 @@ public class CorporeaRetainerBlock extends BotaniaBlock implements EntityBlock {
 		boolean powered = state.getValue(BlockStateProperties.POWERED);
 
 		if (power && !powered) {
-			((CorporeaRetainerBlockEntity) world.getBlockEntity(pos)).fulfilRequest();
+			if (world.getBlockEntity(pos) instanceof CorporeaRetainerBlockEntity retainer) {
+				retainer.fulfilRequest();
+			}
 			world.setBlockAndUpdate(pos, state.setValue(BlockStateProperties.POWERED, true));
 		} else if (!power && powered) {
 			world.setBlockAndUpdate(pos, state.setValue(BlockStateProperties.POWERED, false));
@@ -67,7 +69,9 @@ public class CorporeaRetainerBlock extends BotaniaBlock implements EntityBlock {
 
 	@Override
 	public int getAnalogOutputSignal(BlockState state, Level world, BlockPos pos) {
-		return ((CorporeaRetainerBlockEntity) world.getBlockEntity(pos)).getComparatorValue();
+		return world.getBlockEntity(pos) instanceof CorporeaRetainerBlockEntity retainer
+				? retainer.getComparatorValue()
+				: 0;
 	}
 
 	@NotNull

--- a/Xplat/src/main/java/vazkii/botania/common/block/decor/TinyPotatoBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/decor/TinyPotatoBlock.java
@@ -65,11 +65,9 @@ public class TinyPotatoBlock extends BotaniaWaterloggedBlock implements EntityBl
 
 	@Override
 	public int getAnalogOutputSignal(BlockState state, Level level, BlockPos pos) {
-		if (level.getBlockEntity(pos) instanceof TinyPotatoBlockEntity tater) {
-			return AbstractContainerMenu.getRedstoneSignalFromContainer(tater);
-		} else {
-			return 0;
-		}
+		return level.getBlockEntity(pos) instanceof TinyPotatoBlockEntity tater
+				? AbstractContainerMenu.getRedstoneSignalFromContainer(tater)
+				: 0;
 	}
 
 	@Override

--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/BubbellBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/functional/BubbellBlockEntity.java
@@ -13,7 +13,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -63,8 +62,9 @@ public class BubbellBlockEntity extends FunctionalFlowerBlockEntity {
 					BlockState state = getLevel().getBlockState(pos);
 					if (state.is(Blocks.WATER)) {
 						getLevel().setBlock(pos, BotaniaBlocks.fakeAir.defaultBlockState(), Block.UPDATE_CLIENTS);
-						FakeAirBlockEntity air = (FakeAirBlockEntity) getLevel().getBlockEntity(pos);
-						air.setFlower(this);
+						if (getLevel().getBlockEntity(pos) instanceof FakeAirBlockEntity air) {
+							air.setFlower(this);
+						}
 					}
 				}
 			}
@@ -72,8 +72,7 @@ public class BubbellBlockEntity extends FunctionalFlowerBlockEntity {
 	}
 
 	public static boolean isValidBubbell(Level world, BlockPos pos) {
-		BlockEntity tile = world.getBlockEntity(pos);
-		if (tile instanceof BubbellBlockEntity bubbell) {
+		if (world.getBlockEntity(pos) instanceof BubbellBlockEntity bubbell) {
 			return bubbell.getMana() > COST_PER_TICK;
 		}
 

--- a/Xplat/src/main/java/vazkii/botania/common/block/flower/generating/DandelifeonBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/flower/generating/DandelifeonBlockEntity.java
@@ -67,9 +67,8 @@ public class DandelifeonBlockEntity extends GeneratingFlowerBlockEntity {
 				for (int i = 0; i <= diameter; i++) {
 					for (int j = 0; j <= diameter; j++) {
 						BlockPos pos = getEffectivePos().offset(-radius + i, 0, -radius + j);
-						BlockEntity tile = getLevel().getBlockEntity(pos);
-						if (tile instanceof CellularBlockEntity) {
-							((CellularBlockEntity) (tile)).claim(this);
+						if (getLevel().getBlockEntity(pos) instanceof CellularBlockEntity cell) {
+							cell.claim(this);
 						}
 					}
 				}
@@ -140,7 +139,6 @@ public class DandelifeonBlockEntity extends GeneratingFlowerBlockEntity {
 	void setBlockForGeneration(BlockPos pos, int cell, int prevCell) {
 		Level world = getLevel();
 		BlockState stateAt = world.getBlockState(pos);
-		BlockEntity tile = world.getBlockEntity(pos);
 		if (cell == Cell.CONSUME) {
 			if (stateAt.isAir()) {
 				int val = prevCell * MANA_PER_GEN;
@@ -148,13 +146,14 @@ public class DandelifeonBlockEntity extends GeneratingFlowerBlockEntity {
 				addMana(val);
 				sync();
 			}
-		} else if (tile instanceof CellularBlockEntity cellBlock) {
+		} else if (world.getBlockEntity(pos) instanceof CellularBlockEntity cellBlock) {
 			cellBlock.setNextGeneration(this, cell);
 		} else if (Cell.isLive(cell) && stateAt.isAir()) {
 			world.setBlockAndUpdate(pos, BotaniaBlocks.cellBlock.defaultBlockState());
-			tile = world.getBlockEntity(pos);
-			((CellularBlockEntity) tile).setNextGeneration(this, cell);
-			((CellularBlockEntity) tile).setGeneration(Cell.DEAD); // so that other flowers know this is 'dead' this tick
+			if (world.getBlockEntity(pos) instanceof CellularBlockEntity cellBlock) {
+				cellBlock.setNextGeneration(this, cell);
+				cellBlock.setGeneration(Cell.DEAD); // so that other flowers know this is 'dead' this tick
+			}
 		}
 	}
 

--- a/Xplat/src/main/java/vazkii/botania/common/block/mana/BellowsBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/mana/BellowsBlock.java
@@ -76,8 +76,8 @@ public class BellowsBlock extends BotaniaBlock implements EntityBlock {
 
 	@Override
 	public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
-		if (PlayerHelper.isTruePlayer(player)) {
-			((BellowsBlockEntity) world.getBlockEntity(pos)).interact();
+		if (PlayerHelper.isTruePlayer(player) && world.getBlockEntity(pos) instanceof BellowsBlockEntity bellows) {
+			bellows.interact();
 			return InteractionResult.sidedSuccess(world.isClientSide());
 		}
 		return InteractionResult.PASS;

--- a/Xplat/src/main/java/vazkii/botania/common/block/mana/BotanicalBreweryBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/mana/BotanicalBreweryBlock.java
@@ -80,8 +80,7 @@ public class BotanicalBreweryBlock extends BotaniaWaterloggedBlock implements En
 	@Override
 	public void onRemove(@NotNull BlockState state, @NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState newState, boolean isMoving) {
 		if (!state.is(newState.getBlock())) {
-			BlockEntity be = world.getBlockEntity(pos);
-			if (be instanceof SimpleInventoryBlockEntity inventory) {
+			if (world.getBlockEntity(pos) instanceof SimpleInventoryBlockEntity inventory) {
 				Containers.dropContents(world, pos, inventory.getItemHandler());
 			}
 			super.onRemove(state, world, pos, newState, isMoving);
@@ -95,8 +94,7 @@ public class BotanicalBreweryBlock extends BotaniaWaterloggedBlock implements En
 
 	@Override
 	public int getAnalogOutputSignal(BlockState state, Level world, BlockPos pos) {
-		BreweryBlockEntity brew = (BreweryBlockEntity) world.getBlockEntity(pos);
-		return brew.signal;
+		return world.getBlockEntity(pos) instanceof BreweryBlockEntity brew ? brew.signal : 0;
 	}
 
 	@NotNull

--- a/Xplat/src/main/java/vazkii/botania/common/block/mana/ManaEnchanterBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/mana/ManaEnchanterBlock.java
@@ -61,9 +61,8 @@ public class ManaEnchanterBlock extends BotaniaBlock implements EntityBlock {
 
 	@Override
 	public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
-		ManaEnchanterBlockEntity enchanter = (ManaEnchanterBlockEntity) world.getBlockEntity(pos);
 		ItemStack stack = player.getItemInHand(hand);
-		if (!stack.isEmpty() && stack.getItem() instanceof WandOfTheForestItem) {
+		if (!(world.getBlockEntity(pos) instanceof ManaEnchanterBlockEntity enchanter) || !stack.isEmpty() && stack.getItem() instanceof WandOfTheForestItem) {
 			return InteractionResult.PASS;
 		}
 
@@ -92,13 +91,10 @@ public class ManaEnchanterBlock extends BotaniaBlock implements EntityBlock {
 	@Override
 	public void onRemove(@NotNull BlockState state, @NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState newState, boolean isMoving) {
 		if (!state.is(newState.getBlock())) {
-			BlockEntity tile = world.getBlockEntity(pos);
 
-			if (tile instanceof ManaEnchanterBlockEntity enchanter) {
-
-				if (!enchanter.itemToEnchant.isEmpty()) {
-					Containers.dropItemStack(world, pos.getX(), pos.getY(), pos.getZ(), enchanter.itemToEnchant);
-				}
+			if (world.getBlockEntity(pos) instanceof ManaEnchanterBlockEntity enchanter
+					&& !enchanter.itemToEnchant.isEmpty()) {
+				Containers.dropItemStack(world, pos.getX(), pos.getY(), pos.getZ(), enchanter.itemToEnchant);
 			}
 
 			super.onRemove(state, world, pos, newState, isMoving);

--- a/Xplat/src/main/java/vazkii/botania/common/block/mana/ManaPoolBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/mana/ManaPoolBlock.java
@@ -181,9 +181,8 @@ public class ManaPoolBlock extends BotaniaWaterloggedBlock implements EntityBloc
 
 	@Override
 	public void entityInside(BlockState state, Level world, BlockPos pos, Entity entity) {
-		if (entity instanceof ItemEntity item) {
-			ManaPoolBlockEntity tile = (ManaPoolBlockEntity) world.getBlockEntity(pos);
-			tile.collideEntityItem(item);
+		if (entity instanceof ItemEntity item && world.getBlockEntity(pos) instanceof ManaPoolBlockEntity pool) {
+			pool.collideEntityItem(item);
 		}
 	}
 
@@ -204,7 +203,8 @@ public class ManaPoolBlock extends BotaniaWaterloggedBlock implements EntityBloc
 
 	@Override
 	public int getAnalogOutputSignal(BlockState state, Level world, BlockPos pos) {
-		ManaPoolBlockEntity pool = (ManaPoolBlockEntity) world.getBlockEntity(pos);
-		return ManaPoolBlockEntity.calculateComparatorLevel(pool.getCurrentMana(), pool.getMaxMana());
+		return world.getBlockEntity(pos) instanceof ManaPoolBlockEntity pool
+				? ManaPoolBlockEntity.calculateComparatorLevel(pool.getCurrentMana(), pool.getMaxMana())
+				: 0;
 	}
 }

--- a/Xplat/src/main/java/vazkii/botania/common/block/mana/ManaPrismBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/mana/ManaPrismBlock.java
@@ -98,8 +98,7 @@ public class ManaPrismBlock extends BotaniaWaterloggedBlock implements EntityBlo
 
 	@Override
 	public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
-		BlockEntity tile = world.getBlockEntity(pos);
-		if (!(tile instanceof ManaPrismBlockEntity prism)) {
+		if (!(world.getBlockEntity(pos) instanceof ManaPrismBlockEntity prism)) {
 			return InteractionResult.PASS;
 		}
 
@@ -157,8 +156,7 @@ public class ManaPrismBlock extends BotaniaWaterloggedBlock implements EntityBlo
 	@Override
 	public void onRemove(@NotNull BlockState state, @NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState newState, boolean isMoving) {
 		if (!state.is(newState.getBlock())) {
-			BlockEntity be = world.getBlockEntity(pos);
-			if (be instanceof SimpleInventoryBlockEntity inventory) {
+			if (world.getBlockEntity(pos) instanceof SimpleInventoryBlockEntity inventory) {
 				Containers.dropContents(world, pos, inventory.getItemHandler());
 			}
 			super.onRemove(state, world, pos, newState, isMoving);

--- a/Xplat/src/main/java/vazkii/botania/common/block/mana/ManaPumpBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/mana/ManaPumpBlock.java
@@ -85,7 +85,7 @@ public class ManaPumpBlock extends BotaniaWaterloggedBlock implements EntityBloc
 
 	@Override
 	public int getAnalogOutputSignal(BlockState state, Level world, BlockPos pos) {
-		return ((ManaPumpBlockEntity) world.getBlockEntity(pos)).comparator;
+		return world.getBlockEntity(pos) instanceof ManaPumpBlockEntity pump ? pump.comparator : 0;
 	}
 
 	@NotNull

--- a/Xplat/src/main/java/vazkii/botania/common/block/mana/ManaSpreaderBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/mana/ManaSpreaderBlock.java
@@ -95,8 +95,8 @@ public class ManaSpreaderBlock extends BotaniaWaterloggedBlock implements Entity
 		if (blockState.getValue(BotaniaStateProperties.HAS_SCAFFOLDING)) {
 			return SHAPE_SCAFFOLDING;
 		}
-		BlockEntity be = blockGetter.getBlockEntity(blockPos);
-		return be instanceof ManaSpreaderBlockEntity spreader && spreader.paddingColor != null ? SHAPE_PADDING : SHAPE;
+		return blockGetter.getBlockEntity(blockPos) instanceof ManaSpreaderBlockEntity spreader
+				&& spreader.paddingColor != null ? SHAPE_PADDING : SHAPE;
 	}
 
 	@NotNull
@@ -113,8 +113,9 @@ public class ManaSpreaderBlock extends BotaniaWaterloggedBlock implements Entity
 	@Override
 	public void setPlacedBy(Level world, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack stack) {
 		Direction orientation = placer == null ? Direction.WEST : Direction.orderedByNearest(placer)[0].getOpposite();
-		ManaSpreaderBlockEntity spreader = (ManaSpreaderBlockEntity) world.getBlockEntity(pos);
-
+		if (!(world.getBlockEntity(pos) instanceof ManaSpreaderBlockEntity spreader)) {
+			return;
+		}
 		switch (orientation) {
 			case DOWN:
 				spreader.rotationY = -90F;
@@ -144,8 +145,7 @@ public class ManaSpreaderBlock extends BotaniaWaterloggedBlock implements Entity
 
 	@Override
 	public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hit) {
-		BlockEntity tile = world.getBlockEntity(pos);
-		if (!(tile instanceof ManaSpreaderBlockEntity spreader)) {
+		if (!(world.getBlockEntity(pos) instanceof ManaSpreaderBlockEntity spreader)) {
 			return InteractionResult.PASS;
 		}
 
@@ -239,8 +239,7 @@ public class ManaSpreaderBlock extends BotaniaWaterloggedBlock implements Entity
 	@Override
 	public void onRemove(@NotNull BlockState state, @NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState newState, boolean isMoving) {
 		if (!state.is(newState.getBlock())) {
-			BlockEntity tile = world.getBlockEntity(pos);
-			if (!(tile instanceof ManaSpreaderBlockEntity spreader)) {
+			if (!(world.getBlockEntity(pos) instanceof ManaSpreaderBlockEntity spreader)) {
 				return;
 			}
 

--- a/Xplat/src/main/java/vazkii/botania/common/block/mana/RunicAltarBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/mana/RunicAltarBlock.java
@@ -82,8 +82,7 @@ public class RunicAltarBlock extends BotaniaWaterloggedBlock implements EntityBl
 	@Override
 	public void onRemove(@NotNull BlockState state, @NotNull Level world, @NotNull BlockPos pos, @NotNull BlockState newState, boolean isMoving) {
 		if (!state.is(newState.getBlock())) {
-			BlockEntity be = world.getBlockEntity(pos);
-			if (be instanceof SimpleInventoryBlockEntity inventory) {
+			if (world.getBlockEntity(pos) instanceof SimpleInventoryBlockEntity inventory) {
 				Containers.dropContents(world, pos, inventory.getItemHandler());
 			}
 			super.onRemove(state, world, pos, newState, isMoving);
@@ -113,8 +112,7 @@ public class RunicAltarBlock extends BotaniaWaterloggedBlock implements EntityBl
 
 	@Override
 	public int getAnalogOutputSignal(BlockState state, Level world, BlockPos pos) {
-		RunicAltarBlockEntity altar = (RunicAltarBlockEntity) world.getBlockEntity(pos);
-		return altar.signal;
+		return world.getBlockEntity(pos) instanceof RunicAltarBlockEntity altar ? altar.signal : 0;
 	}
 
 }

--- a/Xplat/src/main/java/vazkii/botania/common/block/mana/TerrestrialAgglomerationPlateBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/mana/TerrestrialAgglomerationPlateBlock.java
@@ -108,8 +108,9 @@ public class TerrestrialAgglomerationPlateBlock extends BotaniaWaterloggedBlock 
 
 	@Override
 	public int getAnalogOutputSignal(BlockState state, Level world, BlockPos pos) {
-		TerrestrialAgglomerationPlateBlockEntity plate = (TerrestrialAgglomerationPlateBlockEntity) world.getBlockEntity(pos);
-		return plate.getComparatorLevel();
+		return world.getBlockEntity(pos) instanceof TerrestrialAgglomerationPlateBlockEntity plate
+				? plate.getComparatorLevel()
+				: 0;
 	}
 
 }

--- a/Xplat/src/main/java/vazkii/botania/common/block/red_string/RedStringComparatorBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/red_string/RedStringComparatorBlock.java
@@ -39,7 +39,7 @@ public class RedStringComparatorBlock extends RedStringBlock {
 
 	@Override
 	public int getAnalogOutputSignal(BlockState state, Level world, BlockPos pos) {
-		return ((RedStringComparatorBlockEntity) world.getBlockEntity(pos)).getComparatorValue();
+		return world.getBlockEntity(pos) instanceof RedStringComparatorBlockEntity be ? be.getComparatorValue() : 0;
 	}
 
 	@NotNull

--- a/Xplat/src/main/java/vazkii/botania/common/block/red_string/RedStringDispenserBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/red_string/RedStringDispenserBlock.java
@@ -46,7 +46,9 @@ public class RedStringDispenserBlock extends RedStringBlock {
 		boolean powered = state.getValue(BlockStateProperties.POWERED);
 
 		if (power && !powered) {
-			((RedStringDispenserBlockEntity) world.getBlockEntity(pos)).tickDispenser();
+			if (world.getBlockEntity(pos) instanceof RedStringDispenserBlockEntity be) {
+				be.tickDispenser();
+			}
 			world.setBlock(pos, state.setValue(BlockStateProperties.POWERED, true), Block.UPDATE_INVISIBLE);
 		} else if (!power && powered) {
 			world.setBlock(pos, state.setValue(BlockStateProperties.POWERED, false), Block.UPDATE_INVISIBLE);

--- a/Xplat/src/main/java/vazkii/botania/common/block/red_string/RedStringNutrifierBlock.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/red_string/RedStringNutrifierBlock.java
@@ -38,17 +38,19 @@ public class RedStringNutrifierBlock extends RedStringBlock implements Bonemeala
 
 	@Override
 	public boolean isValidBonemealTarget(@NotNull LevelReader world, @NotNull BlockPos pos, @NotNull BlockState state, boolean isClient) {
-		return ((RedStringNutrifierBlockEntity) world.getBlockEntity(pos)).canGrow(world, isClient);
+		return world.getBlockEntity(pos) instanceof RedStringNutrifierBlockEntity be && be.canGrow(world, isClient);
 	}
 
 	@Override
 	public boolean isBonemealSuccess(@NotNull Level world, @NotNull RandomSource rand, @NotNull BlockPos pos, @NotNull BlockState state) {
-		return ((RedStringNutrifierBlockEntity) world.getBlockEntity(pos)).canUseBonemeal(world, rand);
+		return world.getBlockEntity(pos) instanceof RedStringNutrifierBlockEntity be && be.canUseBonemeal(world, rand);
 	}
 
 	@Override
 	public void performBonemeal(@NotNull ServerLevel world, @NotNull RandomSource rand, @NotNull BlockPos pos, @NotNull BlockState state) {
-		((RedStringNutrifierBlockEntity) world.getBlockEntity(pos)).grow(world, rand);
+		if (world.getBlockEntity(pos) instanceof RedStringNutrifierBlockEntity be) {
+			be.grow(world, rand);
+		}
 	}
 
 	@NotNull

--- a/Xplat/src/main/java/vazkii/botania/common/entity/ManaPoolMinecartEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/entity/ManaPoolMinecartEntity.java
@@ -115,8 +115,8 @@ public class ManaPoolMinecartEntity extends AbstractMinecart {
 		for (Direction dir : Direction.Plane.HORIZONTAL) {
 			BlockPos pumpPos = pos.relative(dir);
 			BlockState pumpState = level().getBlockState(pumpPos);
-			if (pumpState.is(BotaniaBlocks.pump)) {
-				ManaPumpBlockEntity pump = (ManaPumpBlockEntity) level().getBlockEntity(pumpPos);
+			if (pumpState.is(BotaniaBlocks.pump)
+					&& level().getBlockEntity(pumpPos) instanceof ManaPumpBlockEntity pump) {
 				BlockPos poolPos = pumpPos.relative(dir);
 				var receiver = XplatAbstractions.INSTANCE.findManaReceiver(level(), poolPos, dir.getOpposite());
 

--- a/Xplat/src/main/java/vazkii/botania/common/helper/EthicalTntHelper.java
+++ b/Xplat/src/main/java/vazkii/botania/common/helper/EthicalTntHelper.java
@@ -115,16 +115,14 @@ public class EthicalTntHelper {
 			}
 
 			final var blockState = entity.level().getBlockState(blockPos);
-			if (blockState.is(Blocks.MOVING_PISTON)) {
-				final var blockEntity = entity.level().getBlockEntity(blockPos);
-				if (blockEntity instanceof PistonMovingBlockEntity movingBlockEntity
-						&& movingBlockEntity.getMovementDirection() == dir
-						&& (movingBlockEntity.getMovedState().getBlock() instanceof TntBlock
-								|| movingBlockEntity.getMovedState().is(BotaniaTags.Blocks.UNETHICAL_TNT_CHECK))) {
-					// found a moving block that marks the destination of a TNT block moving away from the TNT entity
-					XplatAbstractions.INSTANCE.ethicalComponent(entity).markUnethical();
-					break;
-				}
+			if (blockState.is(Blocks.MOVING_PISTON)
+					&& entity.level().getBlockEntity(blockPos) instanceof PistonMovingBlockEntity movingBlockEntity
+					&& movingBlockEntity.getMovementDirection() == dir
+					&& (movingBlockEntity.getMovedState().getBlock() instanceof TntBlock
+							|| movingBlockEntity.getMovedState().is(BotaniaTags.Blocks.UNETHICAL_TNT_CHECK))) {
+				// found a moving block that marks the destination of a TNT block moving away from the TNT entity
+				XplatAbstractions.INSTANCE.ethicalComponent(entity).markUnethical();
+				break;
 			}
 		}
 	}

--- a/Xplat/src/main/java/vazkii/botania/common/impl/corporea/CorporeaHelperImpl.java
+++ b/Xplat/src/main/java/vazkii/botania/common/impl/corporea/CorporeaHelperImpl.java
@@ -22,7 +22,6 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.AABB;
 
 import org.jetbrains.annotations.Nullable;
@@ -88,8 +87,7 @@ public class CorporeaHelperImpl implements CorporeaHelper {
 		for (CorporeaNode node : nodes) {
 			CorporeaSpark invSpark = node.getSpark();
 
-			BlockEntity te = node.getWorld().getBlockEntity(node.getPos());
-			if (te instanceof CorporeaInterceptor interceptor) {
+			if (node.getWorld().getBlockEntity(node.getPos()) instanceof CorporeaInterceptor interceptor) {
 				interceptor.interceptRequest(matcher, itemCount, invSpark, spark, stacks, nodes, doit);
 				interceptors.put(interceptor, invSpark);
 			}

--- a/Xplat/src/main/java/vazkii/botania/common/integration/corporea/VanillaNodeDetector.java
+++ b/Xplat/src/main/java/vazkii/botania/common/integration/corporea/VanillaNodeDetector.java
@@ -16,7 +16,6 @@ import net.minecraft.world.WorldlyContainerHolder;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.ChestBlock;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.ChestBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -39,13 +38,10 @@ public class VanillaNodeDetector implements CorporeaNodeDetector {
 		Block block = blockState.getBlock();
 		if (block instanceof WorldlyContainerHolder worldlyContainer) {
 			container = worldlyContainer.getContainer(blockState, level, blockPos);
-		} else if (blockState.hasBlockEntity()) {
-			BlockEntity blockEntity = level.getBlockEntity(blockPos);
-			if (blockEntity instanceof Container beContainer) {
-				container = beContainer;
-				if (container instanceof ChestBlockEntity && block instanceof ChestBlock chest) {
-					container = ChestBlock.getContainer(chest, blockState, level, blockPos, true);
-				}
+		} else if (blockState.hasBlockEntity() && level.getBlockEntity(blockPos) instanceof Container beContainer) {
+			container = beContainer;
+			if (container instanceof ChestBlockEntity && block instanceof ChestBlock chest) {
+				container = ChestBlock.getContainer(chest, blockState, level, blockPos, true);
 			}
 		}
 

--- a/Xplat/src/main/java/vazkii/botania/common/item/BlackHoleTalismanItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/BlackHoleTalismanItem.java
@@ -32,7 +32,6 @@ import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.HopperBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -88,8 +87,7 @@ public class BlackHoleTalismanItem extends Item {
 				return InteractionResult.PASS;
 			}
 
-			BlockEntity tile = world.getBlockEntity(pos);
-			if (tile instanceof Container container) {
+			if (world.getBlockEntity(pos) instanceof Container container) {
 				if (!world.isClientSide) {
 					ItemStack toAdd = new ItemStack(bBlock);
 					int maxSize = toAdd.getMaxStackSize();

--- a/Xplat/src/main/java/vazkii/botania/common/item/CacophoniumItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/CacophoniumItem.java
@@ -93,7 +93,9 @@ public class CacophoniumItem extends Item {
 			if (block instanceof NoteBlock) {
 				if (!world.isClientSide()) {
 					world.setBlockAndUpdate(pos, BotaniaBlocks.cacophonium.defaultBlockState());
-					((CacophoniumBlockEntity) world.getBlockEntity(pos)).stack = stack.copy();
+					if (world.getBlockEntity(pos) instanceof CacophoniumBlockEntity cacophonium) {
+						cacophonium.stack = stack.copy();
+					}
 					stack.shrink(1);
 				}
 				return InteractionResult.sidedSuccess(world.isClientSide());

--- a/Xplat/src/main/java/vazkii/botania/common/item/FloralObedienceStickItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/FloralObedienceStickItem.java
@@ -13,7 +13,6 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.entity.BlockEntity;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -51,8 +50,8 @@ public class FloralObedienceStickItem extends Item {
 					continue;
 				}
 
-				BlockEntity tile = world.getBlockEntity(iterPos);
-				if (tile instanceof BindableSpecialFlowerBlockEntity<?>bindable && bindable.wouldBeValidBinding(pos)) {
+				if (world.getBlockEntity(iterPos) instanceof BindableSpecialFlowerBlockEntity<?>bindable
+						&& bindable.wouldBeValidBinding(pos)) {
 					bindable.setBindingPos(pos);
 					WandOfTheForestItem.doParticleBeamWithOffset(world, iterPos, pos);
 				}
@@ -60,8 +59,7 @@ public class FloralObedienceStickItem extends Item {
 
 			return true;
 		}
-		BlockEntity tile = world.getBlockEntity(pos);
-		if (tile instanceof BindableSpecialFlowerBlockEntity<?>bindableFlower) {
+		if (world.getBlockEntity(pos) instanceof BindableSpecialFlowerBlockEntity<?>bindableFlower) {
 			bindableFlower.setBindingPos(null);
 			return true;
 		}

--- a/Xplat/src/main/java/vazkii/botania/common/item/LifeAggregatorItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/LifeAggregatorItem.java
@@ -130,16 +130,19 @@ public class LifeAggregatorItem extends Item {
 
 		if (world.getBlockState(pos).is(Blocks.SPAWNER)) {
 			if (!world.isClientSide) {
-				BlockEntity te = world.getBlockEntity(pos);
-				stack.getOrCreateTag().put(TAG_SPAWNER, te.saveWithFullMetadata());
-				world.destroyBlock(pos, false);
-				if (player != null) {
-					player.getCooldowns().addCooldown(this, 20);
-					if (player instanceof ServerPlayer serverPlayer) {
-						UseItemSuccessTrigger.INSTANCE.trigger(serverPlayer, stack, serverPlayer.serverLevel(),
-								pos.getX(), pos.getY(), pos.getZ());
+				if (world.getBlockEntity(pos) instanceof SpawnerBlockEntity te) {
+					stack.getOrCreateTag().put(TAG_SPAWNER, te.saveWithFullMetadata());
+					world.destroyBlock(pos, false);
+					if (player != null) {
+						player.getCooldowns().addCooldown(this, 20);
+						if (player instanceof ServerPlayer serverPlayer) {
+							UseItemSuccessTrigger.INSTANCE.trigger(
+									serverPlayer, stack, serverPlayer.serverLevel(),
+									pos.getX(), pos.getY(), pos.getZ()
+							);
+						}
+						player.broadcastBreakEvent(ctx.getHand());
 					}
-					player.broadcastBreakEvent(ctx.getHand());
 				}
 			} else {
 				for (int i = 0; i < 50; i++) {

--- a/Xplat/src/main/java/vazkii/botania/common/item/WandOfTheForestItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/WandOfTheForestItem.java
@@ -545,11 +545,9 @@ public class WandOfTheForestItem extends Item implements CustomCreativeTabConten
 			}
 
 			var pos = ClientProxy.INSTANCE.getClientHit();
-			if (pos instanceof BlockHitResult bHit && pos.getType() == HitResult.Type.BLOCK) {
-				BlockEntity tile = world.getBlockEntity(bHit.getBlockPos());
-				if (tile instanceof Bound boundTile) {
-					return boundTile.getBinding();
-				}
+			if (pos instanceof BlockHitResult bHit && pos.getType() == HitResult.Type.BLOCK
+					&& world.getBlockEntity(bHit.getBlockPos()) instanceof Bound boundTile) {
+				return boundTile.getBinding();
 			}
 
 			return null;

--- a/Xplat/src/main/java/vazkii/botania/common/item/rod/BifrostRodItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/rod/BifrostRodItem.java
@@ -127,9 +127,8 @@ public class BifrostRodItem extends SelfReturningItem {
 				if (world.isEmptyBlock(placePos) || world.getBlockState(placePos) == bifrost) {
 					world.setBlock(placePos, bifrost, Block.UPDATE_CLIENTS);
 
-					BifrostBlockEntity tile = (BifrostBlockEntity) world.getBlockEntity(placePos);
-					if (tile != null) {
-						tile.ticks = time;
+					if (world.getBlockEntity(placePos) instanceof BifrostBlockEntity bifrostBlockEntity) {
+						bifrostBlockEntity.ticks = time;
 						placed = true;
 					}
 				}
@@ -184,16 +183,16 @@ public class BifrostRodItem extends SelfReturningItem {
 						BlockState state = world.getBlockState(pos);
 						if (state.isAir()) {
 							if (world.setBlockAndUpdate(pos, BotaniaBlocks.bifrost.defaultBlockState())) {
-								BifrostBlockEntity bifrostBlockEntity = (BifrostBlockEntity) world.getBlockEntity(pos);
-								bifrostBlockEntity.ticks = 10;
+								if (world.getBlockEntity(pos) instanceof BifrostBlockEntity bifrostBlockEntity) {
+									bifrostBlockEntity.ticks = 10;
+								}
 								receiver.receiveMana(-MANA_COST_AVATAR);
 							}
-						} else if (state.is(BotaniaBlocks.bifrost)) {
-							BifrostBlockEntity bifrostBlockEntity = (BifrostBlockEntity) world.getBlockEntity(pos);
-							if (bifrostBlockEntity.ticks < 2) {
-								bifrostBlockEntity.ticks += 10;
-								receiver.receiveMana(-MANA_COST_AVATAR);
-							}
+						} else if (state.is(BotaniaBlocks.bifrost)
+								&& world.getBlockEntity(pos) instanceof BifrostBlockEntity bifrostBlockEntity
+								&& bifrostBlockEntity.ticks < 2) {
+							bifrostBlockEntity.ticks += 10;
+							receiver.receiveMana(-MANA_COST_AVATAR);
 						}
 					}
 				}

--- a/Xplat/src/main/java/vazkii/botania/common/item/rod/ShiftingCrustRodItem.java
+++ b/Xplat/src/main/java/vazkii/botania/common/item/rod/ShiftingCrustRodItem.java
@@ -39,7 +39,6 @@ import net.minecraft.world.level.block.AbstractGlassBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.IronBarsBlock;
 import net.minecraft.world.level.block.RenderShape;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.redstone.NeighborUpdater;
 import net.minecraft.world.phys.BlockHitResult;
@@ -95,8 +94,7 @@ public class ShiftingCrustRodItem extends Item implements WireframeCoordinateLis
 		Block block = wstate.getBlock();
 
 		if (player != null && player.isSecondaryUseActive()) {
-			BlockEntity tile = world.getBlockEntity(pos);
-			if (tile == null && block.asItem() != Items.AIR
+			if (world.getBlockEntity(pos) == null && block.asItem() != Items.AIR
 					&& (wstate.isSolidRender(world, pos) || wstate.getRenderShape() == RenderShape.MODEL)
 					&& (wstate.canOcclude() || block instanceof AbstractGlassBlock || block instanceof IronBarsBlock)
 					&& block.asItem() instanceof BlockItem) {
@@ -246,8 +244,7 @@ public class ShiftingCrustRodItem extends Item implements WireframeCoordinateLis
 	}
 
 	public int exchange(Level world, Player player, BlockPos pos, ItemStack rod, Item replacement) {
-		BlockEntity tile = world.getBlockEntity(pos);
-		if (tile != null) {
+		if (world.getBlockEntity(pos) != null) {
 			return 0;
 		}
 

--- a/Xplat/src/main/java/vazkii/botania/common/world/SkyblockWorldEvents.java
+++ b/Xplat/src/main/java/vazkii/botania/common/world/SkyblockWorldEvents.java
@@ -145,6 +145,7 @@ public final class SkyblockWorldEvents {
 		structureBlockInfos.removeIf(info -> info.nbt() == null);
 
 		BlockPos offset;
+		//noinspection DataFlowIssue (null NBT was already filtered above)
 		var infoOptional = structureBlockInfos.stream()
 				.filter(info -> "spawn_point".equals(info.nbt().getString("metadata")))
 				.findFirst();
@@ -164,14 +165,16 @@ public final class SkyblockWorldEvents {
 				level.random,
 				Block.UPDATE_ALL);
 		for (var info : structureBlockInfos) {
+			//noinspection DataFlowIssue (null NBT was already filtered above)
 			if ("light".equals(info.nbt().getString("metadata"))) {
 				BlockPos lightPos = startPoint.offset(info.pos());
-				if (level.setBlockAndUpdate(lightPos, BotaniaBlocks.manaFlame.defaultBlockState())) {
+				if (level.setBlockAndUpdate(lightPos, BotaniaBlocks.manaFlame.defaultBlockState())
+						&& level.getBlockEntity(lightPos) instanceof ManaFlameBlockEntity flame) {
 					int r = 70 + level.random.nextInt(185);
 					int g = 70 + level.random.nextInt(185);
 					int b = 70 + level.random.nextInt(185);
 					int color = r << 16 | g << 8 | b;
-					((ManaFlameBlockEntity) level.getBlockEntity(lightPos)).setColor(color);
+					flame.setColor(color);
 				}
 			}
 		}

--- a/web/changelog.md
+++ b/web/changelog.md
@@ -28,6 +28,7 @@ In the meantime, Botania for Minecraft 1.20.1 may still receive updates for bug 
 * Fix: Floating special flowers now show the type and reference lines, like their non-floating versions do
 * Fix: Diagonal Windows iron bars now also work for summoning fel blazes
 * Fix: Loonium could cause a crash when spawning a spider jockey
+* Fix: Potential crashes related to failed block entity access due to other mods using Botania blocks in weird ways
 
 ---
 


### PR DESCRIPTION
(prevents crashes when other mods do weird stuff, like in #4931; also fixes #5010)