### PR TITLE
Fix Solegnolia never disabling item magnetization due to inverted red…

### DIFF
--- a/Xplat/src/main/java/vazkii/botania/common/block/block_entity/flower/misc/SolegnoliaBlockEntity.java
+++ b/Xplat/src/main/java/vazkii/botania/common/block/block_entity/flower/misc/SolegnoliaBlockEntity.java
@@ -53,7 +53,7 @@ public class SolegnoliaBlockEntity extends SpecialFlowerBlockEntity {
 
 	public static boolean hasSolegnoliaAround(Entity e) {
 		for (var flower : existingFlowers) {
-			if (flower.isPowered() && flower.getLevel() == e.level()
+			if (!flower.isPowered() && flower.getLevel() == e.level()
 					&& flower.getEffectivePos().distToCenterSqr(e.getX(), e.getY(), e.getZ())
 							<= flower.getRange() * flower.getRange()) {
 				return true;


### PR DESCRIPTION
SolegnoliaBlockEntity.hasSolegnoliaAround currently requires flower.isPowered() to be true, meaning the flower only suppresses magnetization while it is receiving a redstone signal. Since redstone is meant to disable flowers, this is backwards: with no redstone (the normal case) the check is always false, so the Solegnolia has no effect and nearby items are still pulled by the Ring of Magnetization.

This is a regression from e59ee189f ("Refactor special flower redstone signal check"), which replaced the original redstoneSignal == 0 condition with isPowered() but dropped the negation.