### PR TITLE
Fix sampler definition in film_grain_particle.json

### DIFF
--- a/Xplat/src/main/resources/assets/botania/shaders/core/film_grain_particle.json
+++ b/Xplat/src/main/resources/assets/botania/shaders/core/film_grain_particle.json
@@ -14,8 +14,7 @@
     "UV2"
   ],
   "samplers": [
-    { "name": "Sampler0" },
-    { "name": "Sampler2" }
+    { "name": "Sampler0" }
   ],
   "uniforms": [
     { "name": "ModelViewMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },


### PR DESCRIPTION
Deleting this line is fixing the following issue.

Shader botania:film_grain_particle could not find sampler named Sampler2 in the specified shader program.

Including Sampler2 in this particle shader causes rendering errors and log spam (e.g., “Could not find sampler named Sampler2”), especially when users run performance mods or shaderpacks like Iris, Oculus, or Complementary.