### PR TITLE
Remove Light0 and Light1 direction parameters

### DIFF
--- a/Xplat/src/main/resources/assets/botania/shaders/core/pylon.json
+++ b/Xplat/src/main/resources/assets/botania/shaders/core/pylon.json
@@ -25,8 +25,6 @@
     { "name": "ProjMat", "type": "matrix4x4", "count": 16, "values": [ 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0 ] },
     { "name": "IViewRotMat", "type": "matrix3x3", "count": 9, "values": [ 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0 ] },
     { "name": "ColorModulator", "type": "float", "count": 4, "values": [ 1.0, 1.0, 1.0, 1.0 ] },
-    { "name": "Light0_Direction", "type": "float", "count": 3, "values": [0.0, 0.0, 0.0] },
-    { "name": "Light1_Direction", "type": "float", "count": 3, "values": [0.0, 0.0, 0.0] },
     { "name": "FogStart", "type": "float", "count": 1, "values": [ 0.0 ] },
     { "name": "FogEnd", "type": "float", "count": 1, "values": [ 1.0 ] },
     { "name": "FogColor", "type": "float", "count": 4, "values": [ 0.0, 0.0, 0.0, 0.0 ] },


### PR DESCRIPTION
This change fixes the copy error that caused the pylon to crash. This is because all necessary elements are now included in the `pylon.fsh` file. No console output is generated anymore, and the crystals continue to glow.

The reason the fragment shader (`.fsh`) is already complete is that the actual custom graphics code (`pylon.fsh`) does not use sun vectors. Instead, the pylon's characteristic pulsating brightness is calculated mathematically based on the game time (`GameTime`):

float time = GameTime * 24000;
float brightness = sin(time / 20.0) * 0.5 + 0.15;

Consequently, defining `Light0_Direction` and `Light1_Direction` in the `pylon.json` file is no longer necessary. The visual brightness and animation are entirely self-contained and ready to use, as the time of day determines the sun's position anyway.

Furthermore, this should prevent future issues with mods that affect the time of day.